### PR TITLE
Stratégie de branche pour la documentation

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -38,6 +38,6 @@
 
 9. Finally, draft a new release in the [Github releases tab](https://github.com/ReachFive/reachfive-ios/releases) (copy & paste the changelog in the release's description).
 
-10. If the new version needs a fork of the documentation, the a `x.x.x` should exist in perpetuity for the purpose of this documentation.<br>
+10. If the new version needs a fork of the documentation, the tag `x.x.x` should exist in perpetuity for the purpose of this documentation.<br>
     If, at step 6., the `x.x.x` branch was merged (not squashed) into master, then keep the branch open.<br>
     If the branch was squashed, then delete the branch and recreate a new branch still named `x.x.x`.


### PR DESCRIPTION
Vu que la documentation a été intégrée dans le repo, et que la documentation est maintenant versionnée (comme l'est celle pour Android depuis longtemps), je détaille ici le processus à suivre pour gérer ces versions de documentation.