### PR TITLE
Generalize links and correct path

### DIFF
--- a/docs/modules/ROOT/pages/addAccountRecoveryCallback.adoc
+++ b/docs/modules/ROOT/pages/addAccountRecoveryCallback.adoc
@@ -7,7 +7,7 @@ AppDelegate.reachfive().addAccountRecoveryCallback(<<recoveryCallback>>)
 ----
 
 == Setup ==
-Before using this method, you need to setup deep link interception by using xref:applicationOpenUrl.adoc[].
+Before using this method, you need to setup deep link interception by using xref:application/applicationOpenUrl.adoc[].
 
 == About this command
 

--- a/docs/modules/ROOT/pages/addPasswordlessCallback.adoc
+++ b/docs/modules/ROOT/pages/addPasswordlessCallback.adoc
@@ -7,7 +7,7 @@ AppDelegate.reachfive().addPasswordlessCallback(<<passwordlessCallback>>)
 ----
 
 == Setup ==
-Before using this method, you need to setup deep link interception by using xref:applicationOpenUrl.adoc[].
+Before using this method, you need to setup deep link interception by using xref:application/applicationOpenUrl.adoc[].
 
 == About this command
 

--- a/docs/modules/ROOT/pages/application/applicationContinueUserActivity.adoc
+++ b/docs/modules/ROOT/pages/application/applicationContinueUserActivity.adoc
@@ -13,7 +13,7 @@ Currently, this method is only used by xref:index.adoc#wechat-connect[WeChat].
 
 Call this to enable the SDK to process activities passed to the app, such as restoring state from another device.
 
-Call this method in response to the equivalent UIKit method link:https://developer.apple.com/documentation/uikit/uiapplicationdelegate/application(_:continue:restorationhandler:)[`application(_:continue:restorationHandler:)`^].
+Call this method in response to the equivalent UIKit method link:https://developer.apple.com/documentation/uikit/uiapplicationdelegate/[`application(_:continue:restorationHandler:)`^].
 
 == Examples
 

--- a/docs/modules/ROOT/pages/application/applicationDidBecomeActive.adoc
+++ b/docs/modules/ROOT/pages/application/applicationDidBecomeActive.adoc
@@ -11,7 +11,7 @@ AppDelegate.reachfive().applicationDidBecomeActive(<<application, application>>)
 This method finalises SDK activation after launch or when resuming from the background. 
 It ensures the SDK is ready for user interaction.
 
-Call this method in response to the equivalent UIKit method link:https://developer.apple.com/documentation/uikit/uiapplicationdelegate/applicationdidbecomeactive(_:)[`applicationDidBecomeActive(_:)`].
+Call this method in response to the equivalent UIKit method link:https://developer.apple.com/documentation/uikit/uiapplicationdelegate/[`applicationDidBecomeActive(_:)`^].
 
 Used by xref:index.adoc#facebook-native-provider[Facebook].
 

--- a/docs/modules/ROOT/pages/application/applicationDidFinishLaunchingWithOptions.adoc
+++ b/docs/modules/ROOT/pages/application/applicationDidFinishLaunchingWithOptions.adoc
@@ -10,7 +10,7 @@ AppDelegate.reachfive().application(<<application, application>>, didFinishLaunc
 
 Allows {company} to initialize the iOS SDK, by fetching information from the server about the client (e.g., default scopes, enabled features) and initializing any configured providers.
 
-Call this method in response to the equivalent UIKit method link:https://developer.apple.com/documentation/uikit/uiapplicationdelegate/application(_:didfinishlaunchingwithoptions:)[`application(_:didFinishLaunchingWithOptions:)`^].
+Call this method in response to the equivalent UIKit method link:https://developer.apple.com/documentation/uikit/uiapplicationdelegate/[`application(_:didFinishLaunchingWithOptions:)`^].
 
 == Examples
 

--- a/docs/modules/ROOT/pages/application/applicationOpenUrl.adoc
+++ b/docs/modules/ROOT/pages/application/applicationOpenUrl.adoc
@@ -14,7 +14,7 @@ Allows {company} to handle URLs in the following format:
 
 Additionally, the method allows configured providers to handle their own native links.
 
-Call this method in response to the equivalent UIKit method link:https://developer.apple.com/documentation/uikit/uiapplicationdelegate/application(_:open:options:)[`application(_:open:options)`^].
+Call this method in response to the equivalent UIKit method link:https://developer.apple.com/documentation/uikit/uiapplicationdelegate/[`application(_:open:options)`^].
 
 == Examples
 


### PR DESCRIPTION
Generalize links and correct paths for internal cross references. The links were being processed oddly so kept it to the general application page link: for Apple Dev docs.