### PR TITLE
Les url de redirection sont maintenant au format URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,12 @@
 ## Unreleased
 
 ### Breaking changes
-- Require URL instead of String for the redirect URLs
+- Changed type of redirect URL fields to URL instead of String 
+- SdkConfig:
+  - As above, changed type of redirect URL fields to URL instead of String
+  - Removed `scheme` field alias for `redirectUri`
+  - Renamed `baseScheme` field to `customScheme`
+  - The initializer now throws an error in case the scheme is not correct (either due to the `customScheme` parameter or indirectly because of the `clientId` parameter being ill-formatted)
 
 ## v10.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
   - As above, changed type of redirect URL fields to URL instead of String
   - Removed `scheme` field alias for `redirectUri`
   - Renamed `baseScheme` field to `customScheme`
-  - The initializer now throws an error in case the scheme is not correct (either due to the `customScheme` parameter or indirectly because of the `clientId` parameter being ill-formatted)
+  - The initializer now stops the program with a `preconditionFailure` when the scheme is not a valid URL scheme (either because of the `customScheme` parameter, or indirectly because the default scheme is derived from an ill-formatted `clientId`, e.g. one containing `_`). In that case, pass an explicit valid `customScheme` and declare it in your Info.plist and your ReachFive console.
 
 - ProviderCreator : the factory receives the ``ReachFive`` instance instead of sub-components, so that the creator can
   reuse high-level helpers such as `buildAuthorizeURL`,`authWithCode` or `webviewLogin`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Breaking changes
+- Require URL instead of String for the redirect URLs
+
 ## v10.0.1
 
 - Fix compilation issue in XCode 26

--- a/Package.swift
+++ b/Package.swift
@@ -14,6 +14,11 @@ let package = Package(
             name: "Reach5",
             path: "Sources/Core",
             resources: [.copy("PrivacyInfo.xcprivacy")]
+        ),
+        .testTarget(
+            name: "Reach5Tests",
+            dependencies: ["Reach5"],
+            path: "Tests/Reach5Tests"
         )
     ]
 )

--- a/Sandbox/Sandbox/Application/AppDelegate.swift
+++ b/Sandbox/Sandbox/Application/AppDelegate.swift
@@ -41,12 +41,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     /// A complete example of a redirect URI utilizing a private-use URI scheme is:
     ///
     ///     com.example.app:/oauth2redirect/example-provider
-    static let sdkLocal = SdkConfig(
+    static let sdkLocal = try! SdkConfig(
         domain: "local-sandbox.og4.me",
         clientId: "9DKRdQyDLpaJqQQQAR9K"
     )
 
-    static let sdkRemote = SdkConfig(
+    static let sdkRemote = try! SdkConfig(
         domain: "integ-qa-fonctionnelle.reach5.net",
         clientId: "9DKRdQyDLpaJqQQQAR9K"
     )

--- a/Sandbox/Sandbox/Application/AppDelegate.swift
+++ b/Sandbox/Sandbox/Application/AppDelegate.swift
@@ -41,12 +41,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     /// A complete example of a redirect URI utilizing a private-use URI scheme is:
     ///
     ///     com.example.app:/oauth2redirect/example-provider
-    static let sdkLocal = try! SdkConfig(
+    static let sdkLocal = SdkConfig(
         domain: "local-sandbox.og4.me",
         clientId: "9DKRdQyDLpaJqQQQAR9K"
     )
 
-    static let sdkRemote = try! SdkConfig(
+    static let sdkRemote = SdkConfig(
         domain: "integ-qa-fonctionnelle.reach5.net",
         clientId: "9DKRdQyDLpaJqQQQAR9K"
     )

--- a/Sandbox/Sandbox/Controllers/Passwordless/PasswordlessController.swift
+++ b/Sandbox/Sandbox/Controllers/Passwordless/PasswordlessController.swift
@@ -31,7 +31,7 @@ class PasswordlessController: UIViewController {
                     .startPasswordless(
                         .Email(
                             email: emailInput.text ?? "",
-                            redirectUri: redirectUriInput.text != "" ? redirectUriInput.text : nil,
+                            redirectUri: URL(string: redirectUriInput.text ?? ""),
                             origin: "PasswordlessController.loginWithEmail"
                         )
                     )
@@ -49,7 +49,7 @@ class PasswordlessController: UIViewController {
                     .startPasswordless(
                         .PhoneNumber(
                             phoneNumber: phoneNumberInput.text ?? "",
-                            redirectUri: redirectUriInput.text != "" ? redirectUriInput.text : nil,
+                            redirectUri: URL(string: redirectUriInput.text ?? ""),
                             origin: "PasswordlessController.loginWithPhoneNumber"
                         )
                     )

--- a/Sandbox/Sandbox/Controllers/Web/LoginCustomWebviewController.swift
+++ b/Sandbox/Sandbox/Controllers/Web/LoginCustomWebviewController.swift
@@ -22,7 +22,7 @@ extension LoginCustomWebviewController: WKNavigationDelegate {
         let app: UIApplication = UIApplication.shared
         // not sure why the callback has a scheme in lowercase
         let reachfive = AppDelegate.reachfive()
-        guard let url = navigationAction.request.url, url.scheme == reachfive.sdkConfig.baseScheme.lowercased(), app.canOpenURL(url) else {
+        guard let url = navigationAction.request.url, url.scheme == reachfive.sdkConfig.customScheme.lowercased(), app.canOpenURL(url) else {
             return .allow
         }
 

--- a/Sources/Core/Classes/CredentialManager.swift
+++ b/Sources/Core/Classes/CredentialManager.swift
@@ -382,7 +382,7 @@ extension CredentialManager: ASAuthorizationControllerDelegate {
                         "client_id": reachFiveApi.sdkConfig.clientId,
                         "id_token": idToken,
                         "response_type": "code",
-                        "redirect_uri": reachFiveApi.sdkConfig.scheme,
+                        "redirect_uri": reachFiveApi.sdkConfig.redirectUri.absoluteString,
                         "scope": scope,
                         "code_challenge": pkce.codeChallenge,
                         "code_challenge_method": pkce.codeChallengeMethod,
@@ -517,7 +517,7 @@ extension CredentialManager {
         let authCodeRequest = AuthCodeRequest(
             clientId: reachFiveApi.sdkConfig.clientId,
             code: code,
-            redirectUri: reachFiveApi.sdkConfig.scheme,
+            redirectUri: reachFiveApi.sdkConfig.redirectUri,
             pkce: pkce
         )
         let token = try await reachFiveApi.authWithCode(authCodeRequest: authCodeRequest)

--- a/Sources/Core/Classes/LoginWKWebview.swift
+++ b/Sources/Core/Classes/LoginWKWebview.swift
@@ -35,7 +35,7 @@ extension LoginWKWebview: WKNavigationDelegate {
               let pkce,
               let continuation,
               let url = navigationAction.request.url,
-              url.scheme == reachfive.sdkConfig.baseScheme.lowercased()
+              url.scheme == reachfive.sdkConfig.customScheme.lowercased()
         else {
             return .allow
         }

--- a/Sources/Core/Classes/ReachFive.swift
+++ b/Sources/Core/Classes/ReachFive.swift
@@ -57,10 +57,10 @@ public class ReachFive: NSObject {
     public func interceptUrl(_ url: URL) -> () {
         let receivedUrl = URLComponents(url: url, resolvingAgainstBaseURL: true)
 
-        let recovery = URLComponents(string: sdkConfig.accountRecoveryUri)
-        let mfa = URLComponents(string: sdkConfig.mfaUri)
-        let passwordless = URLComponents(string: sdkConfig.redirectUri)
-        let emailVerification = URLComponents(string: sdkConfig.emailVerificationUri)
+        let recovery = URLComponents(url: sdkConfig.accountRecoveryUri, resolvingAgainstBaseURL: true)
+        let mfa = URLComponents(url: sdkConfig.mfaUri, resolvingAgainstBaseURL: true)
+        let passwordless = URLComponents(url: sdkConfig.redirectUri, resolvingAgainstBaseURL: true)
+        let emailVerification = URLComponents(url: sdkConfig.emailVerificationUri, resolvingAgainstBaseURL: true)
 
         switch (receivedUrl?.host, receivedUrl?.path) {
 

--- a/Sources/Core/Classes/ReachFiveLogin.swift
+++ b/Sources/Core/Classes/ReachFiveLogin.swift
@@ -17,7 +17,7 @@ public extension ReachFive {
 
             let _ = try? await webAuthenticationSession(
                 url: reachFiveApi.buildLogoutURL(queryParams: options),
-                callbackURLScheme: sdkConfig.baseScheme,
+                callbackURLScheme: sdkConfig.customScheme,
                 presentationContextProvider: request.presentationContextProvider,
                 prefersEphemeralWebBrowserSession: false)
         }

--- a/Sources/Core/Classes/ReachFiveLogin.swift
+++ b/Sources/Core/Classes/ReachFiveLogin.swift
@@ -4,14 +4,14 @@ public extension ReachFive {
 
     func logout(webSessionLogout request: WebSessionLogoutRequest? = nil, revoke token: AuthToken? = nil) async throws {
         // Don't stop for errors along the way
-        
+
         for provider in providers {
             try? await provider.logout()
         }
 
         if let request {
             let options = [
-                "post_logout_redirect_uri": sdkConfig.redirectUri,
+                "post_logout_redirect_uri": sdkConfig.redirectUri.absoluteString,
                 "origin": request.origin,
             ]
 
@@ -21,11 +21,11 @@ public extension ReachFive {
                 presentationContextProvider: request.presentationContextProvider,
                 prefersEphemeralWebBrowserSession: false)
         }
-        
+
         if let token {
             try? await revokeToken(authToken: token)
         }
-        
+
         try await self.reachFiveApi.logout()
     }
 
@@ -42,7 +42,7 @@ public extension ReachFive {
         let options = [
             "provider": provider,
             "client_id": sdkConfig.clientId,
-            "redirect_uri": sdkConfig.redirectUri,
+            "redirect_uri": sdkConfig.redirectUri.absoluteString,
             "response_type": "code",
             "scope": scope,
             "code_challenge": pkce.codeChallenge,
@@ -59,7 +59,7 @@ public extension ReachFive {
         let authCodeRequest = AuthCodeRequest(
             clientId: sdkConfig.clientId,
             code: code,
-            redirectUri: sdkConfig.scheme,
+            redirectUri: sdkConfig.redirectUri,
             pkce: pkce)
         let token = try await reachFiveApi.authWithCode(authCodeRequest: authCodeRequest)
         return try AuthToken.fromOpenIdTokenResponse(token)

--- a/Sources/Core/Classes/ReachFiveMfa.swift
+++ b/Sources/Core/Classes/ReachFiveMfa.swift
@@ -6,7 +6,7 @@ public enum CredentialType {
 }
 
 public enum Credential {
-    case Email(redirectUrl: String? = nil)
+    case Email(redirectUrl: URL? = nil)
     case PhoneNumber(_ phoneNumber: String)
 
     public var credentialType: CredentialType {
@@ -18,8 +18,8 @@ public enum Credential {
 }
 
 public enum StartStepUp {
-    case AuthTokenFlow(authType: MfaCredentialItemType, authToken: AuthToken, redirectUri: String? = nil, scope: [String]? = nil, origin: String? = nil, action: String? = nil)
-    case LoginFlow(authType: MfaCredentialItemType, stepUpToken: String, redirectUri: String? = nil, origin: String? = nil)
+    case AuthTokenFlow(authType: MfaCredentialItemType, authToken: AuthToken, redirectUri: URL? = nil, scope: [String]? = nil, origin: String? = nil, action: String? = nil)
+    case LoginFlow(authType: MfaCredentialItemType, stepUpToken: String, redirectUri: URL? = nil, origin: String? = nil)
     public var authType: MfaCredentialItemType {
         switch self {
         case let .AuthTokenFlow(authType, _, _, _, _, _): return authType
@@ -59,7 +59,7 @@ public class ContinueRegistration {
     private let reachfive: ReachFive
     private let authToken: AuthToken
     private let trustDevice: Bool
-    
+
     fileprivate init(credentialType: CredentialType, reachfive: ReachFive, authToken: AuthToken, trustDevice: Bool = false) {
         self.credentialType = credentialType
         self.authToken = authToken
@@ -116,7 +116,8 @@ public extension ReachFive {
         switch request {
 
         case let .LoginFlow(authType, stepUpToken, redirectUri, origin):
-            let response = try await reachFiveApi.startPasswordless(mfa: StartMfaPasswordlessRequest(redirectUri: redirectUri ?? sdkConfig.redirectUri, clientId: sdkConfig.clientId, stepUp: stepUpToken, authType: authType, origin: origin))
+            let req = StartMfaPasswordlessRequest(redirectUri: redirectUri ?? sdkConfig.redirectUri, clientId: sdkConfig.clientId, stepUp: stepUpToken, authType: authType, origin: origin)
+            let response = try await reachFiveApi.startPasswordless(mfa: req)
             return ContinueStepUp(challengeId: response.challengeId, reachFive: self)
 
         case let .AuthTokenFlow(authType, authToken, redirectUri, overwrittenScope, origin, action):
@@ -124,7 +125,8 @@ public extension ReachFive {
             storage.save(key: pkceKey, value: pkce)
             let stepUp = StartMfaStepUpRequest(clientId: sdkConfig.clientId, redirectUri: redirectUri ?? sdkConfig.redirectUri, pkce: pkce, scope: (overwrittenScope ?? scope).joined(separator: " "), action: action)
             let result = try await reachFiveApi.startMfaStepUp(stepUp, authToken: authToken)
-            let response = try await self.reachFiveApi.startPasswordless(mfa: StartMfaPasswordlessRequest(redirectUri: redirectUri ?? self.sdkConfig.redirectUri, clientId: self.sdkConfig.clientId, stepUp: result.token, authType: authType, origin: origin))
+            let req = StartMfaPasswordlessRequest(redirectUri: redirectUri ?? sdkConfig.redirectUri, clientId: sdkConfig.clientId, stepUp: result.token, authType: authType, origin: origin)
+            let response = try await self.reachFiveApi.startPasswordless(mfa: req)
             return ContinueStepUp(challengeId: response.challengeId, reachFive: self)
         }
     }

--- a/Sources/Core/Classes/ReachFivePassword.swift
+++ b/Sources/Core/Classes/ReachFivePassword.swift
@@ -11,7 +11,7 @@ public enum SignupFlow {
 }
 
 public extension ReachFive {
-    func signup(profile: ProfileSignupRequest, redirectUrl: String? = nil, scope: [String]? = nil, origin: String? = nil) async throws -> SignupFlow {
+    func signup(profile: ProfileSignupRequest, redirectUrl: URL? = nil, scope: [String]? = nil, origin: String? = nil) async throws -> SignupFlow {
         let signupRequest = SignupRequest(
             clientId: sdkConfig.clientId,
             data: profile,

--- a/Sources/Core/Classes/ReachFivePasswordLess.swift
+++ b/Sources/Core/Classes/ReachFivePasswordLess.swift
@@ -1,8 +1,8 @@
 import Foundation
 
 public enum PasswordLessRequest {
-    case Email(email: String, redirectUri: String?, origin: String? = nil)
-    case PhoneNumber(phoneNumber: String, redirectUri: String?, origin: String? = nil)
+    case Email(email: String, redirectUri: URL?, origin: String? = nil)
+    case PhoneNumber(phoneNumber: String, redirectUri: URL?, origin: String? = nil)
 }
 
 public extension ReachFive {
@@ -20,7 +20,7 @@ public extension ReachFive {
                 clientId: sdkConfig.clientId,
                 email: email,
                 authType: .MagicLink,
-                redirectUri: redirectUri ?? sdkConfig.scheme,
+                redirectUri: redirectUri ?? sdkConfig.redirectUri,
                 codeChallenge: pkce.codeChallenge,
                 codeChallengeMethod: pkce.codeChallengeMethod,
                 origin: origin
@@ -30,7 +30,7 @@ public extension ReachFive {
                 clientId: sdkConfig.clientId,
                 phoneNumber: phoneNumber,
                 authType: .SMS,
-                redirectUri: redirectUri ?? sdkConfig.scheme,
+                redirectUri: redirectUri ?? sdkConfig.redirectUri,
                 codeChallenge: pkce.codeChallenge,
                 codeChallengeMethod: pkce.codeChallengeMethod,
                 origin: origin

--- a/Sources/Core/Classes/ReachFiveProfile.swift
+++ b/Sources/Core/Classes/ReachFiveProfile.swift
@@ -26,7 +26,7 @@ public extension ReachFive {
         try await reachFiveApi.getProfile(authToken: authToken)
     }
 
-    func sendEmailVerification(authToken: AuthToken, redirectUrl: String? = nil) async throws -> EmailVerificationResponse {
+    func sendEmailVerification(authToken: AuthToken, redirectUrl: URL? = nil) async throws -> EmailVerificationResponse {
         let sendEmailVerificationRequest = SendEmailVerificationRequest(redirectUrl: redirectUrl ?? sdkConfig.emailVerificationUri)
 
         let resp = try await reachFiveApi.sendEmailVerification(authToken: authToken, sendEmailVerificationRequest: sendEmailVerificationRequest)
@@ -58,7 +58,7 @@ public extension ReachFive {
     func updateEmail(
         authToken: AuthToken,
         email: String,
-        redirectUrl: String? = nil
+        redirectUrl: URL? = nil
     ) async throws -> Profile {
         let updateEmailRequest = UpdateEmailRequest(email: email, redirectUrl: redirectUrl)
         return try await reachFiveApi.updateEmail(
@@ -106,7 +106,7 @@ public extension ReachFive {
     func requestPasswordReset(
         email: String? = nil,
         phoneNumber: String? = nil,
-        redirectUrl: String? = nil,
+        redirectUrl: URL? = nil,
         origin: String? = nil
     ) async throws {
         let requestPasswordResetRequest = RequestPasswordResetRequest(
@@ -124,7 +124,7 @@ public extension ReachFive {
     func requestAccountRecovery(
         email: String? = nil,
         phoneNumber: String? = nil,
-        redirectUrl: String? = nil,
+        redirectUrl: URL? = nil,
         origin: String? = nil
     ) async throws {
         let requestAccountRecoveryRequest = RequestAccountRecoveryRequest(

--- a/Sources/Core/Classes/ReachFiveToken.swift
+++ b/Sources/Core/Classes/ReachFiveToken.swift
@@ -5,7 +5,7 @@ public extension ReachFive {
         let refreshRequest = RefreshRequest(
             clientId: sdkConfig.clientId,
             refreshToken: authToken.refreshToken,
-            redirectUri: sdkConfig.scheme
+            redirectUri: sdkConfig.redirectUri
         )
         let token = try await reachFiveApi.refreshAccessToken(refreshRequest)
         return try AuthToken.fromOpenIdTokenResponse(token)
@@ -21,7 +21,7 @@ public extension ReachFive {
             clientId: sdkConfig.clientId
         )
         try await reachFiveApi.revokeToken(revokeTokenRequest: revokeAccessToken)
-        
+
         if let refreshToken = authToken.refreshToken {
             let revokeRefreshToken = RevokeTokenRequest(
                 token: refreshToken,

--- a/Sources/Core/Classes/ReachFiveWebviewLogin.swift
+++ b/Sources/Core/Classes/ReachFiveWebviewLogin.swift
@@ -13,7 +13,7 @@ public extension ReachFive {
 
         let callbackURL = try await webAuthenticationSession(
             url: authURL,
-            callbackURLScheme: reachFiveApi.sdkConfig.baseScheme,
+            callbackURLScheme: reachFiveApi.sdkConfig.customScheme,
             presentationContextProvider: request.presentationContextProvider,
             prefersEphemeralWebBrowserSession: request.prefersEphemeralWebBrowserSession)
         

--- a/Sources/Core/Classes/models/SdkConfig.swift
+++ b/Sources/Core/Classes/models/SdkConfig.swift
@@ -3,29 +3,46 @@ import Foundation
 public class SdkConfig {
     public let domain: String
     public let clientId: String
-    
-    /// Alias for the `redirectUri`
-    public let scheme: String
-    
+
     ///The scheme. Defaults to `reachfive-clientId`
     public let baseScheme: String
     /// The redirect URI for passwordless. Defaults to `reachfive-clientId://callback`
-    public let redirectUri: String
+    public let redirectUri: URL
     /// The redirect URI for MFA. Defaults to `reachfive-clientId://mfa`
-    public let mfaUri: String
+    public let mfaUri: URL
     /// The redirect URI for Account Recovery. Defaults to `reachfive-clientId://account-recovery`
-    public let accountRecoveryUri: String
+    public let accountRecoveryUri: URL
     /// The redirect URI for email verification. Defaults to `reachfive-clientId://email-verification`
-    public let emailVerificationUri: String
-    
-    public init(domain: String, clientId: String, scheme: String? = nil, baseScheme: String? = nil, mfaUri: String? = nil, accountRecoveryUri: String? = nil, emailVerificationUri: String? = nil) {
+    public let emailVerificationUri: URL
+
+    public init(
+        domain: String,
+        clientId: String,
+        baseScheme: String? = nil,
+        redirectUri: URL? = nil,
+        mfaUri: URL? = nil,
+        accountRecoveryUri: URL? = nil,
+        emailVerificationUri: URL? = nil
+    ) throws {
         self.domain = domain
         self.clientId = clientId
-        self.baseScheme = baseScheme ?? "reachfive-\(clientId)"
-        self.scheme = scheme ?? "\(self.baseScheme)://callback"
-        self.redirectUri = self.scheme
-        self.mfaUri = mfaUri ?? "\(self.baseScheme)://mfa"
-        self.emailVerificationUri = emailVerificationUri ?? "\(self.baseScheme)://email-verification"
-        self.accountRecoveryUri = accountRecoveryUri ?? "\(self.baseScheme)://account-recovery"
+
+        let resolvedBaseScheme = baseScheme ?? "reachfive-\(clientId)"
+        self.baseScheme = resolvedBaseScheme
+
+        func parseUrl(_ url: URL?, defaultString: String) throws -> URL {
+            if let url {
+                return url
+            }
+            guard let parsedUrl = URL(string: defaultString) else {
+                throw ReachFiveError.TechnicalError(reason: "Unable to construct SdkConfig default URL for value: \(defaultString)")
+            }
+            return parsedUrl
+        }
+
+        self.redirectUri = try parseUrl(redirectUri, defaultString: "\(resolvedBaseScheme)://callback")
+        self.mfaUri = try parseUrl(mfaUri, defaultString: "\(resolvedBaseScheme)://mfa")
+        self.emailVerificationUri = try parseUrl(emailVerificationUri, defaultString: "\(resolvedBaseScheme)://email-verification")
+        self.accountRecoveryUri = try parseUrl(accountRecoveryUri, defaultString: "\(resolvedBaseScheme)://account-recovery")
     }
 }

--- a/Sources/Core/Classes/models/SdkConfig.swift
+++ b/Sources/Core/Classes/models/SdkConfig.swift
@@ -40,8 +40,21 @@ public class SdkConfig {
 
     /// Validation by construction: `URL(string:)` applies Foundation's RFC 3986 parsing,
     /// the same rules the rest of the system will enforce on every redirect.
+    /// Checking the parsed scheme is required because a malformed input can still parse,
+    /// just not as intended: with "my:app", "my" becomes the scheme and "app://callback" the path;
+    /// with "my/app" the whole string parses as a scheme-less relative reference.
+    internal static func makeUri(scheme: String, path: String) -> URL? {
+        guard !scheme.isEmpty, // "://callback" parses, with an empty scheme
+              let url = URL(string: "\(scheme)://\(path)"),
+              url.scheme?.lowercased() == scheme.lowercased()
+        else {
+            return nil
+        }
+        return url
+    }
+
     private static func defaultUri(scheme: String, path: String) -> URL {
-        guard let url = URL(string: "\(scheme)://\(path)") else {
+        guard let url = makeUri(scheme: scheme, path: path) else {
             preconditionFailure("""
                 '\(scheme)' is not a valid URL scheme: it must start with a letter and contain only letters, digits, '+', '-' or '.'. \
                 If no customScheme is passed, the scheme is derived from the clientId as 'reachfive-<clientId>'. \

--- a/Sources/Core/Classes/models/SdkConfig.swift
+++ b/Sources/Core/Classes/models/SdkConfig.swift
@@ -5,7 +5,7 @@ public class SdkConfig {
     public let clientId: String
 
     ///The scheme. Defaults to `reachfive-clientId`
-    public let baseScheme: String
+    public let customScheme: String
     /// The redirect URI for passwordless. Defaults to `reachfive-clientId://callback`
     public let redirectUri: URL
     /// The redirect URI for MFA. Defaults to `reachfive-clientId://mfa`
@@ -18,7 +18,7 @@ public class SdkConfig {
     public init(
         domain: String,
         clientId: String,
-        baseScheme: String? = nil,
+        customScheme: String? = nil,
         redirectUri: URL? = nil,
         mfaUri: URL? = nil,
         accountRecoveryUri: URL? = nil,
@@ -27,22 +27,21 @@ public class SdkConfig {
         self.domain = domain
         self.clientId = clientId
 
-        let resolvedBaseScheme = baseScheme ?? "reachfive-\(clientId)"
-        self.baseScheme = resolvedBaseScheme
+        let resolvedScheme = customScheme ?? "reachfive-\(clientId)"
 
-        func parseUrl(_ url: URL?, defaultString: String) throws -> URL {
-            if let url {
-                return url
-            }
-            guard let parsedUrl = URL(string: defaultString) else {
-                throw ReachFiveError.TechnicalError(reason: "Unable to construct SdkConfig default URL for value: \(defaultString)")
-            }
-            return parsedUrl
+        // Broad scheme validation based on RFC 3986 generic parser rules:
+        // Must start with a letter and contain any character except `:`, `/`, `?`, `#`, or whitespace.
+        let schemeRegex = "^[a-zA-Z][^:/?#\\s]*$"
+        guard resolvedScheme.range(of: schemeRegex, options: .regularExpression) != nil else {
+            throw ReachFiveError.TechnicalError(reason: "Invalid scheme format: '\(resolvedScheme)'. A URL scheme must start with a letter and must not contain colons, slashes, question marks, hash symbols, or whitespace.")
         }
 
-        self.redirectUri = try parseUrl(redirectUri, defaultString: "\(resolvedBaseScheme)://callback")
-        self.mfaUri = try parseUrl(mfaUri, defaultString: "\(resolvedBaseScheme)://mfa")
-        self.emailVerificationUri = try parseUrl(emailVerificationUri, defaultString: "\(resolvedBaseScheme)://email-verification")
-        self.accountRecoveryUri = try parseUrl(accountRecoveryUri, defaultString: "\(resolvedBaseScheme)://account-recovery")
+        self.customScheme = resolvedScheme
+
+        // Since resolvedBaseScheme is validated under generic URI parsing rules, the following URL constructions are guaranteed to succeed
+        self.redirectUri = redirectUri ?? URL(string: "\(resolvedScheme)://callback")!
+        self.mfaUri = mfaUri ?? URL(string: "\(resolvedScheme)://mfa")!
+        self.emailVerificationUri = emailVerificationUri ?? URL(string: "\(resolvedScheme)://email-verification")!
+        self.accountRecoveryUri = accountRecoveryUri ?? URL(string: "\(resolvedScheme)://account-recovery")!
     }
 }

--- a/Sources/Core/Classes/models/SdkConfig.swift
+++ b/Sources/Core/Classes/models/SdkConfig.swift
@@ -23,25 +23,31 @@ public class SdkConfig {
         mfaUri: URL? = nil,
         accountRecoveryUri: URL? = nil,
         emailVerificationUri: URL? = nil
-    ) throws {
+    ) {
         self.domain = domain
         self.clientId = clientId
 
-        let resolvedScheme = customScheme ?? "reachfive-\(clientId)"
+        let scheme = customScheme ?? "reachfive-\(clientId)"
+        self.customScheme = scheme
 
-        // Broad scheme validation based on RFC 3986 generic parser rules:
-        // Must start with a letter and contain any character except `:`, `/`, `?`, `#`, or whitespace.
-        let schemeRegex = "^[a-zA-Z][^:/?#\\s]*$"
-        guard resolvedScheme.range(of: schemeRegex, options: .regularExpression) != nil else {
-            throw ReachFiveError.TechnicalError(reason: "Invalid scheme format: '\(resolvedScheme)'. A URL scheme must start with a letter and must not contain colons, slashes, question marks, hash symbols, or whitespace.")
+        // Built unconditionally so that an invalid scheme is caught at init even when every URI is provided explicitly
+        let defaultRedirectUri = Self.defaultUri(scheme: scheme, path: "callback")
+        self.redirectUri = redirectUri ?? defaultRedirectUri
+        self.mfaUri = mfaUri ?? Self.defaultUri(scheme: scheme, path: "mfa")
+        self.emailVerificationUri = emailVerificationUri ?? Self.defaultUri(scheme: scheme, path: "email-verification")
+        self.accountRecoveryUri = accountRecoveryUri ?? Self.defaultUri(scheme: scheme, path: "account-recovery")
+    }
+
+    /// Validation by construction: `URL(string:)` applies Foundation's RFC 3986 parsing,
+    /// the same rules the rest of the system will enforce on every redirect.
+    private static func defaultUri(scheme: String, path: String) -> URL {
+        guard let url = URL(string: "\(scheme)://\(path)") else {
+            preconditionFailure("""
+                '\(scheme)' is not a valid URL scheme: it must start with a letter and contain only letters, digits, '+', '-' or '.'. \
+                If no customScheme is passed, the scheme is derived from the clientId as 'reachfive-<clientId>'. \
+                Pass an explicit valid customScheme, and declare it in your app's Info.plist (CFBundleURLSchemes) and in your ReachFive console.
+                """)
         }
-
-        self.customScheme = resolvedScheme
-
-        // Since resolvedBaseScheme is validated under generic URI parsing rules, the following URL constructions are guaranteed to succeed
-        self.redirectUri = redirectUri ?? URL(string: "\(resolvedScheme)://callback")!
-        self.mfaUri = mfaUri ?? URL(string: "\(resolvedScheme)://mfa")!
-        self.emailVerificationUri = emailVerificationUri ?? URL(string: "\(resolvedScheme)://email-verification")!
-        self.accountRecoveryUri = accountRecoveryUri ?? URL(string: "\(resolvedScheme)://account-recovery")!
+        return url
     }
 }

--- a/Sources/Core/Classes/models/requests/AuthCodeRequest.swift
+++ b/Sources/Core/Classes/models/requests/AuthCodeRequest.swift
@@ -4,13 +4,13 @@ public class AuthCodeRequest: Codable, DictionaryEncodable {
     public let clientId: String
     public let code: String
     public let grantType: String
-    public let redirectUri: String
+    public let redirectUri: URL
     public let codeVerifier: String?
 
     public convenience init(
         clientId: String,
         code: String,
-        redirectUri: String,
+        redirectUri: URL,
         pkce: Pkce? = nil
     ) {
         self.init(
@@ -26,7 +26,7 @@ public class AuthCodeRequest: Codable, DictionaryEncodable {
         clientId: String,
         code: String,
         grantType: String,
-        redirectUri: String,
+        redirectUri: URL,
         codeVerifier: String?
     ) {
         self.clientId = clientId

--- a/Sources/Core/Classes/models/requests/LoginCallback.swift
+++ b/Sources/Core/Classes/models/requests/LoginCallback.swift
@@ -3,16 +3,16 @@ import Foundation
 public class LoginCallback: Codable, DictionaryEncodable {
     public let clientId: String
     public let responseType: String
-    public let redirectUri: String
+    public let redirectUri: URL
     public let scope: String
     public let codeChallenge: String
     public let codeChallengeMethod: String
     public let tkn: String?
     public let origin: String?
-    
+
     public init(sdkConfig: SdkConfig, scope: String, pkce: Pkce, tkn: String? = nil, origin: String? = nil) {
         clientId = sdkConfig.clientId
-        redirectUri = sdkConfig.scheme
+        redirectUri = sdkConfig.redirectUri
         codeChallenge = pkce.codeChallenge
         codeChallengeMethod = pkce.codeChallengeMethod
         responseType = "code"

--- a/Sources/Core/Classes/models/requests/MfaCredentialsRequest.swift
+++ b/Sources/Core/Classes/models/requests/MfaCredentialsRequest.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 public class MfaStartEmailRegistrationRequest: Codable, DictionaryEncodable {
-    public let redirectUrl: String?
+    public let redirectUrl: URL?
     public let action: String?
     public let trustDevice: Bool
-    
-    public init(redirectUrl: String? = nil, action: String? = nil, trustDevice: Bool = false) {
+
+    public init(redirectUrl: URL? = nil, action: String? = nil, trustDevice: Bool = false) {
         self.redirectUrl = redirectUrl
         self.action = action
         self.trustDevice = trustDevice
@@ -16,7 +16,7 @@ public class MfaStartPhoneRegistrationRequest: Codable, DictionaryEncodable {
     public let phoneNumber: String
     public let action: String?
     public let trustDevice: Bool
-    
+
     public init(phoneNumber: String, action: String? = nil, trustDevice: Bool = false) {
         self.phoneNumber = phoneNumber
         self.action = action
@@ -27,7 +27,7 @@ public class MfaStartPhoneRegistrationRequest: Codable, DictionaryEncodable {
 public class MfaVerifyEmailRegistrationPostRequest: Codable, DictionaryEncodable {
     public let verificationCode: String
     public let trustDevice: Bool
-    
+
     public init(_ verificationCode: String, trustDevice: Bool = false) {
         self.verificationCode = verificationCode
         self.trustDevice = trustDevice
@@ -47,7 +47,7 @@ public class MfaVerifyEmailRegistrationGetRequest: Codable, DictionaryEncodable 
 public class MfaVerifyPhoneRegistrationRequest: Codable, DictionaryEncodable {
     public let verificationCode: String
     public let trustDevice: Bool
-    
+
     public init(_ verificationCode: String, trustDevice: Bool = false) {
         self.verificationCode = verificationCode
         self.trustDevice = trustDevice

--- a/Sources/Core/Classes/models/requests/MfaStepUpRequest.swift
+++ b/Sources/Core/Classes/models/requests/MfaStepUpRequest.swift
@@ -3,14 +3,14 @@ import Foundation
 public class StartMfaStepUpRequest: Codable, DictionaryEncodable {
     public let responseType: String
     public let clientId: String
-    public let redirectUri: String
+    public let redirectUri: URL
     public let codeChallenge: String
     public let codeChallengeMethod: String
     public let scope: String?
     public let tkn: String?
     public let action: String?
 
-    public init(clientId: String, redirectUri: String, pkce: Pkce, scope: String? = nil, tkn: String? = nil, action: String? = nil) {
+    public init(clientId: String, redirectUri: URL, pkce: Pkce, scope: String? = nil, tkn: String? = nil, action: String? = nil) {
         self.clientId = clientId
         self.responseType = "code"
         self.redirectUri = redirectUri
@@ -34,13 +34,13 @@ public class StartMfaStepUpResponse: Codable, DictionaryEncodable {
 
 public class StartMfaPasswordlessRequest: Codable, DictionaryEncodable {
     public let responseType: String
-    public let redirectUri: String
+    public let redirectUri: URL
     public let clientId: String
     public let stepUp: String
     public let authType: MfaCredentialItemType
     public let origin: String?
 
-    public init(redirectUri: String, clientId: String, stepUp: String, authType: MfaCredentialItemType, origin: String?) {
+    public init(redirectUri: URL, clientId: String, stepUp: String, authType: MfaCredentialItemType, origin: String?) {
         self.redirectUri = redirectUri
         self.responseType = "code"
         self.clientId = clientId

--- a/Sources/Core/Classes/models/requests/RefreshRequest.swift
+++ b/Sources/Core/Classes/models/requests/RefreshRequest.swift
@@ -3,13 +3,13 @@ import Foundation
 public class RefreshRequest: Codable, DictionaryEncodable {
     public let clientId: String
     public let refreshToken: String?
-    public let redirectUri: String
+    public let redirectUri: URL
     public let grantType: String
-    
+
     public init(
         clientId: String,
         refreshToken: String?,
-        redirectUri: String
+        redirectUri: URL
     ) {
         self.clientId = clientId
         self.refreshToken = refreshToken

--- a/Sources/Core/Classes/models/requests/RequestAccountRecoveryRequest.swift
+++ b/Sources/Core/Classes/models/requests/RequestAccountRecoveryRequest.swift
@@ -4,10 +4,10 @@ public class RequestAccountRecoveryRequest: Codable, DictionaryEncodable {
     public let clientId: String
     public let email: String?
     public let phoneNumber: String?
-    public let redirectUrl: String?
+    public let redirectUrl: URL?
     public let origin: String?
-    
-    public init(clientId: String, email: String? = nil, phoneNumber: String? = nil, redirectUrl: String? = nil, origin: String? = nil) {
+
+    public init(clientId: String, email: String? = nil, phoneNumber: String? = nil, redirectUrl: URL? = nil, origin: String? = nil) {
         self.clientId = clientId
         self.email = email
         self.phoneNumber = phoneNumber

--- a/Sources/Core/Classes/models/requests/RequestPasswordResetRequest.swift
+++ b/Sources/Core/Classes/models/requests/RequestPasswordResetRequest.swift
@@ -4,10 +4,10 @@ public class RequestPasswordResetRequest: Codable, DictionaryEncodable {
     public let clientId: String
     public let email: String?
     public let phoneNumber: String?
-    public let redirectUrl: String?
+    public let redirectUrl: URL?
     public let origin: String?
-    
-    public init(clientId: String, email: String?, phoneNumber: String?, redirectUrl: String?, origin: String? = nil) {
+
+    public init(clientId: String, email: String?, phoneNumber: String?, redirectUrl: URL?, origin: String? = nil) {
         self.clientId = clientId
         self.email = email
         self.phoneNumber = phoneNumber

--- a/Sources/Core/Classes/models/requests/SignupRequest.swift
+++ b/Sources/Core/Classes/models/requests/SignupRequest.swift
@@ -4,10 +4,10 @@ public class SignupRequest: Codable, DictionaryEncodable {
     public let clientId: String
     public let data: ProfileSignupRequest
     public let scope: String
-    public let redirectUrl: String?
+    public let redirectUrl: URL?
     public let origin: String?
-    
-    public init(clientId: String, data: ProfileSignupRequest, scope: String, redirectUrl: String?, origin: String? = nil) {
+
+    public init(clientId: String, data: ProfileSignupRequest, scope: String, redirectUrl: URL?, origin: String? = nil) {
         self.clientId = clientId
         self.data = data
         self.scope = scope

--- a/Sources/Core/Classes/models/requests/StartPasswordlessRequest.swift
+++ b/Sources/Core/Classes/models/requests/StartPasswordlessRequest.swift
@@ -11,7 +11,7 @@ public class StartPasswordlessRequest: Codable, DictionaryEncodable {
     public let phoneNumber: String?
     public let responseType: String
     public let authType: String
-    public let redirectUri: String
+    public let redirectUri: URL
     public let state: String?
     public let codeChallenge: String
     public let codeChallengeMethod: String
@@ -22,7 +22,7 @@ public class StartPasswordlessRequest: Codable, DictionaryEncodable {
         email: String? = nil,
         phoneNumber: String? = nil,
         authType: PasswordLessAuthType,
-        redirectUri: String,
+        redirectUri: URL,
         codeChallenge: String,
         codeChallengeMethod: String,
         origin: String? = nil
@@ -47,7 +47,7 @@ public class StartPasswordlessRequest: Codable, DictionaryEncodable {
         phoneNumber: String?,
         responseType: String,
         authType: PasswordLessAuthType,
-        redirectUri: String,
+        redirectUri: URL,
         state: String? = nil,
         codeChallenge: String,
         codeChallengeMethod: String,

--- a/Sources/Core/Classes/models/requests/UpdateEmailRequest.swift
+++ b/Sources/Core/Classes/models/requests/UpdateEmailRequest.swift
@@ -2,9 +2,9 @@ import Foundation
 
 public class UpdateEmailRequest: Codable, DictionaryEncodable {
     public let email: String
-    public let redirectUrl: String?
-    
-    public init(email: String, redirectUrl: String?) {
+    public let redirectUrl: URL?
+
+    public init(email: String, redirectUrl: URL?) {
         self.email = email
         self.redirectUrl = redirectUrl
     }

--- a/Sources/Core/Classes/models/requests/VerifyAuthCodeRequest.swift
+++ b/Sources/Core/Classes/models/requests/VerifyAuthCodeRequest.swift
@@ -6,7 +6,7 @@ public class VerifyAuthCodeRequest: Codable, DictionaryEncodable {
     let email: String?
     let verificationCode: String
     let origin: String?
-    
+
     public init(
         authType: PasswordLessAuthType? = nil,
         phoneNumber: String? = nil,
@@ -27,17 +27,17 @@ public class VerifyPasswordlessRequest: Codable, DictionaryEncodable {
     let phoneNumber: String?
     let verificationCode: String
     let state: String?
-    let redirectUri: String?
+    let redirectUri: URL?
     let clientId: String?
     let responseType: String?
     let origin: String?
-    
+
     public init(
         email: String? = nil,
         phoneNumber: String? = nil,
         verificationCode: String,
         state: String? = nil,
-        redirectUri: String? = nil,
+        redirectUri: URL? = nil,
         clientId: String? = nil,
         responseType: String? = nil,
         origin: String? = nil
@@ -56,7 +56,7 @@ public class VerifyPasswordlessRequest: Codable, DictionaryEncodable {
 public class PasswordlessVerifyResponse: Codable {
     let code: String?
     let state: String?
-    
+
     public init(
         code: String?,
         state: String?

--- a/Sources/Core/Classes/models/requests/VerifyEmailRequest.swift
+++ b/Sources/Core/Classes/models/requests/VerifyEmailRequest.swift
@@ -1,9 +1,9 @@
 import Foundation
 
 public class SendEmailVerificationRequest: Codable, DictionaryEncodable {
-    public let redirectUrl: String?
-    
-    public init(redirectUrl: String? = nil) {
+    public let redirectUrl: URL?
+
+    public init(redirectUrl: URL? = nil) {
         self.redirectUrl = redirectUrl
     }
 }
@@ -11,10 +11,10 @@ public class SendEmailVerificationRequest: Codable, DictionaryEncodable {
 public class VerifyEmailRequest: Codable, DictionaryEncodable {
     public let email: String
     public let verificationCode: String
-    
+
     public init(email: String, verificationCode: String) {
         self.email = email
         self.verificationCode = verificationCode
     }
-    
+
 }

--- a/Tests/Reach5Tests/Models/SdkConfigTests.swift
+++ b/Tests/Reach5Tests/Models/SdkConfigTests.swift
@@ -1,0 +1,116 @@
+import XCTest
+@testable import Reach5
+
+/// Documents what is acceptable as a clientId/customScheme when initializing SdkConfig.
+///
+/// The default scheme is derived from the clientId as `reachfive-<clientId>`, so the clientId
+/// obeys the same rules as a scheme: it must contain only letters, digits, `+`, `-` or `.`.
+/// An invalid scheme stops the program with a `preconditionFailure` at init, which cannot be
+/// asserted directly in XCTest: the invalid cases below go through `SdkConfig.makeUri`,
+/// the single construction point on which the init's precondition relies.
+final class SdkConfigTests: XCTestCase {
+
+    // MARK: - Acceptable clientIds
+
+    func testDefaultUrisAreDerivedFromClientId() {
+        let config = SdkConfig(domain: "example.reach5.net", clientId: "9DKRdQyDLpaJqQQQAR9K")
+
+        XCTAssertEqual(config.customScheme, "reachfive-9DKRdQyDLpaJqQQQAR9K")
+        XCTAssertEqual(config.redirectUri.absoluteString, "reachfive-9DKRdQyDLpaJqQQQAR9K://callback")
+        XCTAssertEqual(config.mfaUri.absoluteString, "reachfive-9DKRdQyDLpaJqQQQAR9K://mfa")
+        XCTAssertEqual(config.emailVerificationUri.absoluteString, "reachfive-9DKRdQyDLpaJqQQQAR9K://email-verification")
+        XCTAssertEqual(config.accountRecoveryUri.absoluteString, "reachfive-9DKRdQyDLpaJqQQQAR9K://account-recovery")
+    }
+
+    func testAcceptableClientIds() {
+        let acceptable = [
+            "9DKRdQyDLpaJqQQQAR9K", // alphanumeric
+            "abc",                  // letters only
+            "123abc",               // may start with a digit: the derived scheme starts with 'reachfive-'
+            "my-client",            // hyphen
+            "my.client",            // dot
+            "my+client",            // plus
+        ]
+        for clientId in acceptable {
+            XCTAssertNotNil(
+                SdkConfig.makeUri(scheme: "reachfive-\(clientId)", path: "callback"),
+                "clientId '\(clientId)' should be acceptable")
+        }
+    }
+
+    func testUnacceptableClientIds() {
+        let unacceptable = [
+            "my_client",  // underscore is not allowed in a URL scheme
+            "my client",  // whitespace
+            "my/client",  // slash
+            "my:client",  // colon
+            "my%client",  // percent
+            "cliént",     // non-ASCII letter
+        ]
+        for clientId in unacceptable {
+            XCTAssertNil(
+                SdkConfig.makeUri(scheme: "reachfive-\(clientId)", path: "callback"),
+                "clientId '\(clientId)' should be rejected")
+        }
+    }
+
+    // MARK: - Acceptable customSchemes
+
+    func testCustomSchemeOverridesTheDerivedScheme() {
+        let config = SdkConfig(domain: "example.reach5.net", clientId: "my_client", customScheme: "com.example.app")
+
+        XCTAssertEqual(config.customScheme, "com.example.app")
+        XCTAssertEqual(config.redirectUri.absoluteString, "com.example.app://callback")
+    }
+
+    func testAcceptableCustomSchemes() {
+        let acceptable = [
+            "com.example.app", // reverse-DNS, the recommended form
+            "a",               // single letter
+            "myapp2",          // digits after the first letter
+            "my-app+x.y",      // '+', '-' and '.' are allowed
+        ]
+        for scheme in acceptable {
+            XCTAssertNotNil(
+                SdkConfig.makeUri(scheme: scheme, path: "callback"),
+                "customScheme '\(scheme)' should be acceptable")
+        }
+    }
+
+    func testUnacceptableCustomSchemes() {
+        let unacceptable = [
+            "reachfive-my_client", // underscore
+            "1app",                // must start with a letter
+            "-app",                // must start with a letter
+            "my app",              // whitespace
+            "my:app",              // colon
+            "my/app",              // slash
+            "my?app",              // question mark
+            "my#app",              // hash
+            "",                    // empty
+        ]
+        for scheme in unacceptable {
+            XCTAssertNil(
+                SdkConfig.makeUri(scheme: scheme, path: "callback"),
+                "customScheme '\(scheme)' should be rejected")
+        }
+    }
+
+    // MARK: - Explicit URIs
+
+    func testExplicitUrisAreKeptAsIs() {
+        let redirectUri = URL(string: "https://example.com/callback")!
+        let mfaUri = URL(string: "com.example.app://mfa")!
+        let config = SdkConfig(
+            domain: "example.reach5.net",
+            clientId: "abc",
+            redirectUri: redirectUri,
+            mfaUri: mfaUri)
+
+        XCTAssertEqual(config.redirectUri, redirectUri)
+        XCTAssertEqual(config.mfaUri, mfaUri)
+        // The other URIs still get their defaults
+        XCTAssertEqual(config.accountRecoveryUri.absoluteString, "reachfive-abc://account-recovery")
+        XCTAssertEqual(config.emailVerificationUri.absoluteString, "reachfive-abc://email-verification")
+    }
+}


### PR DESCRIPTION
Conséquence : l'initialisation du SdkConfig peut maintenant échouer.
Aussi, suppression du champ `scheme`, renomage de `baseScheme` en `customScheme`.