### PR TITLE
URL.authorizationCode() remplace les trois extractions manuelles du code

### DIFF
--- a/Sources/Core/Classes/LoginWKWebview.swift
+++ b/Sources/Core/Classes/LoginWKWebview.swift
@@ -40,13 +40,8 @@ extension LoginWKWebview: WKNavigationDelegate {
             return .allow
         }
 
-        let params = URLComponents(url: url, resolvingAgainstBaseURL: true)?.queryItems
-        if let params, let code = params.first(where: { $0.name == "code" })?.value {
-            continuation.resume {
-                try await reachfive.authWithCode(code: code, pkce: pkce)
-            }
-        } else {
-            continuation.resume(throwing: ReachFiveError.TechnicalError(reason: "No authorization code", apiError: ApiError(fromQueryParams: params)))
+        continuation.resume {
+            try await reachfive.authWithCode(code: url.authorizationCode(), pkce: pkce)
         }
         self.continuation = nil
         return .cancel

--- a/Sources/Core/Classes/ReachFiveApi.swift
+++ b/Sources/Core/Classes/ReachFiveApi.swift
@@ -138,11 +138,7 @@ public class ReachFiveApi {
 
     public func authorize(params: [String: String?]?) async throws -> String {
         let url = try await networkClient.request(createUrl(path: "/oauth/authorize", params: params)).redirect()
-        let params = URLComponents(string: url.absoluteString)?.queryItems
-        guard let code = params?.first(where: { $0.name == "code" })?.value else {
-            throw ReachFiveError.TechnicalError(reason: "No authorization code", apiError: ApiError(fromQueryParams: params))
-        }
-        return code
+        return try url.authorizationCode()
     }
 
     public func authWithCode(authCodeRequest: AuthCodeRequest) async throws -> AccessTokenResponse {

--- a/Sources/Core/Classes/ReachFiveWebviewLogin.swift
+++ b/Sources/Core/Classes/ReachFiveWebviewLogin.swift
@@ -16,12 +16,8 @@ public extension ReachFive {
             callbackURLScheme: reachFiveApi.sdkConfig.customScheme,
             presentationContextProvider: request.presentationContextProvider,
             prefersEphemeralWebBrowserSession: request.prefersEphemeralWebBrowserSession)
-        
-        let params = URLComponents(url: callbackURL, resolvingAgainstBaseURL: true)?.queryItems
-        guard let params, let code = params.first(where: { $0.name == "code" })?.value else {
-            throw ReachFiveError.TechnicalError(reason: "No authorization code", apiError: ApiError(fromQueryParams: params))
-        }
 
+        let code = try callbackURL.authorizationCode()
         return try await self.authWithCode(code: code, pkce: pkce)
     }
 }

--- a/Sources/Core/Classes/webauth/URL+WebAuth.swift
+++ b/Sources/Core/Classes/webauth/URL+WebAuth.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+extension URL {
+    /// Value of the `name` query parameter, or `nil` if absent.
+    func queryValue(_ name: String) -> String? {
+        URLComponents(url: self, resolvingAgainstBaseURL: true)?
+            .queryItems?
+            .first(where: { $0.name == name })?
+            .value
+    }
+
+    /// The authorization `code` of this OAuth callback, or a `TechnicalError` carrying the `ApiError`
+    /// described by the callback's parameters (`error`, `error_description`…).
+    func authorizationCode() throws -> String {
+        let params = URLComponents(url: self, resolvingAgainstBaseURL: true)?.queryItems
+        guard let code = params?.first(where: { $0.name == "code" })?.value else {
+            throw ReachFiveError.TechnicalError(reason: "No authorization code", apiError: ApiError(fromQueryParams: params))
+        }
+        return code
+    }
+}

--- a/Tests/Reach5Tests/WebAuth/URLWebAuthTests.swift
+++ b/Tests/Reach5Tests/WebAuth/URLWebAuthTests.swift
@@ -1,0 +1,43 @@
+import XCTest
+@testable import Reach5
+
+final class URLWebAuthTests: XCTestCase {
+
+    func testQueryValuePresent() {
+        XCTAssertEqual(URL(string: "https://h/p?code=abc&state=xyz")!.queryValue("state"), "xyz")
+    }
+
+    func testQueryValueAbsent() {
+        XCTAssertNil(URL(string: "https://h/p?code=abc")!.queryValue("state"))
+    }
+
+    func testQueryValueNoQuery() {
+        XCTAssertNil(URL(string: "https://h/p")!.queryValue("state"))
+    }
+
+    func testQueryValueEmptyValue() {
+        XCTAssertEqual(URL(string: "https://h/p?state=")!.queryValue("state"), "")
+    }
+
+    func testQueryValuePercentDecoded() {
+        XCTAssertEqual(URL(string: "https://h/p?state=a%20b")!.queryValue("state"), "a b")
+    }
+
+    func testQueryValueFirstOfDuplicates() {
+        XCTAssertEqual(URL(string: "https://h/p?state=first&state=second")!.queryValue("state"), "first")
+    }
+
+    func testAuthorizationCodePresent() throws {
+        XCTAssertEqual(try URL(string: "https://h/p?code=abc&state=x")!.authorizationCode(), "abc")
+    }
+
+    func testAuthorizationCodeMissingThrowsWithApiError() {
+        XCTAssertThrowsError(try URL(string: "https://h/p?error=access_denied&error_description=denied")!.authorizationCode()) { error in
+            guard case let ReachFiveError.TechnicalError(reason, apiError) = error else {
+                return XCTFail("attendu : TechnicalError, obtenu \(error)")
+            }
+            XCTAssertEqual(reason, "No authorization code")
+            XCTAssertEqual(apiError?.error, "access_denied")
+        }
+    }
+}


### PR DESCRIPTION
Découpage préparatoire de la PR B.connect (CA-6191). Refactor pur, valable indépendamment de la feature :

- Nouvelle extension `URL.authorizationCode()` (et `queryValue(_:)`) dans `webauth/URL+WebAuth.swift` : extraction du `code` OAuth d'une URL de callback, ou `TechnicalError` portant l'`ApiError` décrit par les paramètres (`error`, `error_description`…).

La PR feature B.connect se rebasera sur celle-ci (sa version finale de `webviewLogin` appelle `authorizationCode()`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)