### PR TITLE
Correctifs providers : cycle de rétention et créateurs de même nom

### DIFF
--- a/Sources/Core/Classes/DefaultProvider.swift
+++ b/Sources/Core/Classes/DefaultProvider.swift
@@ -4,7 +4,10 @@ import AuthenticationServices
 class DefaultProvider: NSObject, Provider {
     let name: String
 
-    let reachfive: ReachFive
+    // `weak` : ReachFive retient ses providers, une référence forte ici créerait un cycle
+    // ReachFive ↔ DefaultProvider et le graphe SDK ne serait jamais désalloué (même pattern que
+    // LoginWKWebview).
+    private weak var reachfive: ReachFive?
     let providerConfig: ProviderConfig
 
     public init(reachfive: ReachFive, providerConfig: ProviderConfig) {
@@ -21,6 +24,10 @@ class DefaultProvider: NSObject, Provider {
 
         guard let presentationContextProvider = viewController as? ASWebAuthenticationPresentationContextProviding else {
             throw ReachFiveError.TechnicalError(reason: "No presenting viewController")
+        }
+
+        guard let reachfive else {
+            throw ReachFiveError.TechnicalError(reason: "ReachFive instance was deallocated")
         }
 
         return try await reachfive.webviewLogin(WebviewLoginRequest(scope: scope, presentationContextProvider: presentationContextProvider, origin: origin, provider: providerConfig.provider))

--- a/Sources/Core/Classes/Provider.swift
+++ b/Sources/Core/Classes/Provider.swift
@@ -8,6 +8,9 @@ public protocol ProviderCreator {
     /// Factory called by the SDK. Receives the ``ReachFive`` instance, so the creator can reuse
     /// `reachFive.sdkConfig`, `reachFive.reachFiveApi` or high-level helpers such as `buildAuthorizeURL`,
     /// `authWithCode` or `webviewLogin`.
+    ///
+    /// Do not store `reachFive` strongly in the returned ``Provider``: ReachFive retains its providers,
+    /// so a strong back-reference creates a retain cycle. Hold it weakly, or copy the values you need.
     func create(reachFive: ReachFive, providerConfig: ProviderConfig, clientConfigResponse: ClientConfigResponse) -> Provider
 }
 

--- a/Sources/Core/Classes/ReachFiveProviders.swift
+++ b/Sources/Core/Classes/ReachFiveProviders.swift
@@ -15,7 +15,13 @@ public extension ReachFive {
         self.clientConfig = clientConfig
         self.scope = clientConfig.scope.components(separatedBy: " ")
 
-        let variants = Dictionary(uniqueKeysWithValues: self.providersCreators.map { ($0.name, $0.variant) })
+        // Tolère deux créateurs de même nom (ex. un provider natif + un `WebProvider` du même nom) sans
+        // crasher : on garde le premier, comme `createProviders` qui résout par `first(where:)`.
+        let creators = self.providersCreators
+        let variants = Dictionary(creators.map { ($0.name, $0.variant) }, uniquingKeysWith: { first, _ in first })
+        if variants.count != creators.count {
+            Logger.shared.log("Several ProviderCreators share the same name; only the first of each is used (its variant is sent to the backend). Register at most one creator per provider name.")
+        }
         let providersConfigs = try await self.reachFiveApi.providersConfigs(variants: variants)
         let providers = self.createProviders(providersConfigsResult: providersConfigs, clientConfigResponse: clientConfig)
 


### PR DESCRIPTION
Découpage préparatoire de la PR B.connect (CA-6191). Deux correctifs indépendants de la feature :

- `DefaultProvider` ne retient plus `ReachFive` fortement : `ReachFive` retient ses providers, la référence forte créait un cycle et le graphe SDK n'était jamais désalloué (même pattern que `LoginWKWebview`). Doc ajoutée sur `ProviderCreator` pour prévenir le même piège dans les créateurs custom.
- `reinitialize()` ne crashe plus quand deux `ProviderCreators` portent le même nom (`Dictionary(uniqueKeysWithValues:)` → `uniquingKeysWith`) : on garde le premier, comme le fait déjà la résolution par `first(where:)` de `createProviders`, et on logge un avertissement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)