### PR TITLE
[CA-6191] Session web d'authentification : support de la validation par app externe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,15 +3,21 @@
 ## Unreleased
 
 ### Breaking changes
-- Changed type of redirect URL fields to URL instead of String 
+- Changed type of redirect URL fields to URL instead of String
 - SdkConfig:
   - As above, changed type of redirect URL fields to URL instead of String
   - Removed `scheme` field alias for `redirectUri`
   - Renamed `baseScheme` field to `customScheme`
   - The initializer now stops the program with a `preconditionFailure` when the scheme is not a valid URL scheme (either because of the `customScheme` parameter, or indirectly because the default scheme is derived from an ill-formatted `clientId`, e.g. one containing `_`). In that case, pass an explicit valid `customScheme` and declare it in your Info.plist and your ReachFive console.
 
+- `application(_:continue:restorationHandler:)` now returns `false` when neither ReachFive's web-auth session nor any registered provider consumed the activity, instead of always returning `true`. If your app also routes universal links itself, only do so when this call returns `false`.
+
 - ProviderCreator : the factory receives the ``ReachFive`` instance instead of sub-components, so that the creator can
   reuse high-level helpers such as `buildAuthorizeURL`,`authWithCode` or `webviewLogin`.
+
+### New features
+- Support for universal-link providers: register a `WebProvider` (e.g. `WebProvider(name: .bconnect, mode: .externalApp)`) to pick how the login session is delivered back to the app. See xref:providerCreator.adoc[] and xref:guides/custom-provider.adoc[].
+- `webviewLogin` accepts a new `webSessionMode` parameter (`.sdkScheme`, `.universalLink`, `.externalApp`) to control the return channel of the underlying `ASWebAuthenticationSession`.
 
 ## v10.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
   reuse high-level helpers such as `buildAuthorizeURL`,`authWithCode` or `webviewLogin`.
 
 ### New features
-- Support for universal-link providers: register a `WebProvider` (e.g. `WebProvider(name: .bconnect, mode: .externalApp)`) to pick how the login session is delivered back to the app. See xref:providerCreator.adoc[] and xref:guides/custom-provider.adoc[].
+- Support for universal-link providers: register a `WebProvider` (e.g. `WebProvider(name: .bconnect, mode: .externalApp)`) to pick how the login session is delivered back to the app. See the [ProviderCreator](https://developer.reachfive.com/sdk-ios/providerCreator.html) and [custom provider guide](https://developer.reachfive.com/sdk-ios/guides/custom-provider.html) documentation.
 - `WebProvider` also supports choosing a variant: `WebProvider(name: .bconnect, variant: "natif")`
 - `webviewLogin` accepts a new `webSessionMode` parameter (`.sdkScheme`, `.universalLink`, `.externalApp`) to control the return channel of the underlying `ASWebAuthenticationSession`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,8 @@
   reuse high-level helpers such as `buildAuthorizeURL`,`authWithCode` or `webviewLogin`.
 
 ### New features
-- Support for universal-link and external-app providers: register a `WebProvider` (e.g. `WebProvider(name: .bconnect, mode: .externalAppUniversalLink)`) to pick how the login session is delivered back to the app. See the [ProviderCreator](https://developer.reachfive.com/sdk-ios/providerCreator.html) and [custom provider guide](https://developer.reachfive.com/sdk-ios/guides/custom-provider.html) documentation.
-- `WebProvider` also supports choosing a variant: `WebProvider(name: .bconnect, variant: "natif")`
-- `webviewLogin` accepts a new `webSessionMode` parameter to control the return channel of the underlying `ASWebAuthenticationSession`. It is a combination of two orthogonal axes — the callback shape (custom scheme vs HTTPS universal link) and the channel (in-band, intercepted in the sheet, vs out-of-band, handed off to an external app) — exposed as four factories: `.sdkScheme`, `.externalAppScheme`, `.externalAppUniversalLink(_:)`, and `.inSheetUniversalLink(_:)` (iOS 17.4+). `WebProviderMode` offers the same four choices.
+- New `WebProvider` to register a web provider (e.g. B.connect) with a `variant` and a completion `mode`. See the [ProviderCreator](https://developer.reachfive.com/sdk-ios/providerCreator.html) and [custom provider guide](https://developer.reachfive.com/sdk-ios/guides/custom-provider.html) documentation.
+- `webviewLogin` accepts a `webSessionMode` parameter picking how the `ASWebAuthenticationSession` returns: `.sdkScheme`, `.externalAppScheme`, `.externalAppUniversalLink(_:)` or `.inSheetUniversalLink(_:)` (iOS 17.4+). `WebProvider` takes the same choices.
 
 ## v10.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,9 @@
   reuse high-level helpers such as `buildAuthorizeURL`,`authWithCode` or `webviewLogin`.
 
 ### New features
-- Support for universal-link providers: register a `WebProvider` (e.g. `WebProvider(name: .bconnect, mode: .externalApp)`) to pick how the login session is delivered back to the app. See the [ProviderCreator](https://developer.reachfive.com/sdk-ios/providerCreator.html) and [custom provider guide](https://developer.reachfive.com/sdk-ios/guides/custom-provider.html) documentation.
+- Support for universal-link and external-app providers: register a `WebProvider` (e.g. `WebProvider(name: .bconnect, mode: .externalAppUniversalLink)`) to pick how the login session is delivered back to the app. See the [ProviderCreator](https://developer.reachfive.com/sdk-ios/providerCreator.html) and [custom provider guide](https://developer.reachfive.com/sdk-ios/guides/custom-provider.html) documentation.
 - `WebProvider` also supports choosing a variant: `WebProvider(name: .bconnect, variant: "natif")`
-- `webviewLogin` accepts a new `webSessionMode` parameter (`.sdkScheme`, `.universalLink`, `.externalApp`) to control the return channel of the underlying `ASWebAuthenticationSession`.
+- `webviewLogin` accepts a new `webSessionMode` parameter to control the return channel of the underlying `ASWebAuthenticationSession`. It is a combination of two orthogonal axes — the callback shape (custom scheme vs HTTPS universal link) and the channel (in-band, intercepted in the sheet, vs out-of-band, handed off to an external app) — exposed as four factories: `.sdkScheme`, `.externalAppScheme`, `.externalAppUniversalLink(_:)`, and `.inSheetUniversalLink(_:)` (iOS 17.4+). `WebProviderMode` offers the same four choices.
 
 ## v10.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### New features
 - Support for universal-link providers: register a `WebProvider` (e.g. `WebProvider(name: .bconnect, mode: .externalApp)`) to pick how the login session is delivered back to the app. See xref:providerCreator.adoc[] and xref:guides/custom-provider.adoc[].
+- `WebProvider` also supports choosing a variant: `WebProvider(name: .bconnect, variant: "natif")`
 - `webviewLogin` accepts a new `webSessionMode` parameter (`.sdkScheme`, `.universalLink`, `.externalApp`) to control the return channel of the underlying `ASWebAuthenticationSession`.
 
 ## v10.0.1

--- a/Sandbox/Sandbox/Application/AppDelegate.swift
+++ b/Sandbox/Sandbox/Application/AppDelegate.swift
@@ -55,7 +55,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         GoogleProvider(variant: "one_tap"),
         FacebookProvider(),
         AppleProvider(variant: "natif"),
-        WebProvider(name: .bconnect, variant: "natif", mode: .externalApp)
+        WebProvider(name: .bconnect, variant: "natif", mode: .externalAppUniversalLink)
     ]
     #if targetEnvironment(macCatalyst)
     static let macLocal: ReachFive = ReachFive(sdkConfig: sdkLocal, providersCreators: providers, storage: storage, sdkInternalConfig: SdkInternalConfig(loggingEnabled: true))

--- a/Sandbox/Sandbox/Application/AppDelegate.swift
+++ b/Sandbox/Sandbox/Application/AppDelegate.swift
@@ -55,7 +55,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         GoogleProvider(variant: "one_tap"),
         FacebookProvider(),
         AppleProvider(variant: "natif"),
-        WebProvider(name: .bconnect, variant: "natif", mode: .externalApp)
+        WebProvider(name: .Bconnect, variant: "natif", mode: .externalApp)
     ]
     #if targetEnvironment(macCatalyst)
     static let macLocal: ReachFive = ReachFive(sdkConfig: sdkLocal, providersCreators: providers, storage: storage, sdkInternalConfig: SdkInternalConfig(loggingEnabled: true))

--- a/Sandbox/Sandbox/Application/AppDelegate.swift
+++ b/Sandbox/Sandbox/Application/AppDelegate.swift
@@ -55,7 +55,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         GoogleProvider(variant: "one_tap"),
         FacebookProvider(),
         AppleProvider(variant: "natif"),
-        WebProvider(name: .Bconnect, variant: "natif", mode: .externalApp)
+        WebProvider(name: .bconnect, variant: "natif", mode: .externalApp)
     ]
     #if targetEnvironment(macCatalyst)
     static let macLocal: ReachFive = ReachFive(sdkConfig: sdkLocal, providersCreators: providers, storage: storage, sdkInternalConfig: SdkInternalConfig(loggingEnabled: true))

--- a/Sandbox/Sandbox/Application/AppDelegate.swift
+++ b/Sandbox/Sandbox/Application/AppDelegate.swift
@@ -51,7 +51,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         clientId: "9DKRdQyDLpaJqQQQAR9K"
     )
 
-    static let providers: [ProviderCreator] = [GoogleProvider(variant: "one_tap"), FacebookProvider(), AppleProvider(variant: "natif")]
+    static let providers: [ProviderCreator] = [
+        GoogleProvider(variant: "one_tap"),
+        FacebookProvider(),
+        AppleProvider(variant: "natif"),
+        WebProvider(name: .bconnect, variant: "natif", mode: .externalApp)
+    ]
     #if targetEnvironment(macCatalyst)
     static let macLocal: ReachFive = ReachFive(sdkConfig: sdkLocal, providersCreators: providers, storage: storage, sdkInternalConfig: SdkInternalConfig(loggingEnabled: true))
     static let macRemote: ReachFive = ReachFive(sdkConfig: sdkRemote, providersCreators: providers, storage: storage, sdkInternalConfig: SdkInternalConfig(loggingEnabled: true))

--- a/Sandbox/Sandbox/Application/Base.lproj/Main.storyboard
+++ b/Sandbox/Sandbox/Application/Base.lproj/Main.storyboard
@@ -1292,6 +1292,23 @@
                                             </subviews>
                                         </tableViewCellContentView>
                                     </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="webviewLoginExternalAppScheme" textLabel="Es1-ch-l03" style="IBUITableViewCellStyleDefault" id="Es1-ch-c03">
+                                        <rect key="frame" x="0.0" y="851.66668319702148" width="402" height="43.666667938232422"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Es1-ch-c03" id="Es1-ch-cv3">
+                                            <rect key="frame" x="0.0" y="0.0" width="402" height="43.666667938232422"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Login using secure webview (external app, scheme)" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Es1-ch-l03">
+                                                    <rect key="frame" x="8" y="0.0" width="386" height="43.666667938232422"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="WKWebview" textLabel="gXe-Fl-eAZ" style="IBUITableViewCellStyleDefault" id="gtf-cP-u7l" userLabel="WKWebview">
                                         <rect key="frame" x="0.0" y="764.33334732055664" width="402" height="43.666667938232422"/>
                                         <autoresizingMask key="autoresizingMask"/>

--- a/Sandbox/Sandbox/Application/Base.lproj/Main.storyboard
+++ b/Sandbox/Sandbox/Application/Base.lproj/Main.storyboard
@@ -1258,6 +1258,40 @@
                                             </subviews>
                                         </tableViewCellContentView>
                                     </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="webviewLoginHttps" textLabel="Ht1-ps-l01" style="IBUITableViewCellStyleDefault" id="Ht1-ps-c01">
+                                        <rect key="frame" x="0.0" y="764.33334732055664" width="402" height="43.666667938232422"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Ht1-ps-c01" id="Ht1-ps-cv1">
+                                            <rect key="frame" x="0.0" y="0.0" width="402" height="43.666667938232422"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Login using secure webview (HTTPS)" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Ht1-ps-l01">
+                                                    <rect key="frame" x="8" y="0.0" width="386" height="43.666667938232422"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="webviewLoginExternalApp" textLabel="Ea1-pp-l02" style="IBUITableViewCellStyleDefault" id="Ea1-pp-c02">
+                                        <rect key="frame" x="0.0" y="808.00001525878906" width="402" height="43.666667938232422"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Ea1-pp-c02" id="Ea1-pp-cv2">
+                                            <rect key="frame" x="0.0" y="0.0" width="402" height="43.666667938232422"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Login using secure webview (external app)" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Ea1-pp-l02">
+                                                    <rect key="frame" x="8" y="0.0" width="386" height="43.666667938232422"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="WKWebview" textLabel="gXe-Fl-eAZ" style="IBUITableViewCellStyleDefault" id="gtf-cP-u7l" userLabel="WKWebview">
                                         <rect key="frame" x="0.0" y="764.33334732055664" width="402" height="43.666667938232422"/>
                                         <autoresizingMask key="autoresizingMask"/>

--- a/Sandbox/Sandbox/Application/Sandbox.entitlements
+++ b/Sandbox/Sandbox/Application/Sandbox.entitlements
@@ -9,7 +9,7 @@
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>webcredentials:local-sandbox.og4.me?mode=developer</string>
-		<string>applinks:local-sandbox.og4.me</string>
+		<string>applinks:local-sandbox.og4.me?mode=developer</string>
 		<string>webcredentials:integ-qa-fonctionnelle.reach5.net</string>
 		<string>applinks:integ-qa-fonctionnelle.reach5.net</string>
 	</array>

--- a/Sandbox/Sandbox/Tabs/ActionController.swift
+++ b/Sandbox/Sandbox/Tabs/ActionController.swift
@@ -62,6 +62,22 @@ class ActionController: UITableViewController {
                         try await AppDelegate.reachfive().webviewLogin(WebviewLoginRequest(presentationContextProvider: self, origin: "ActionController.webviewLogin"))
                     }
                 }
+
+                // secure webview completing IN-BAND via an https universal link (intercepted in the sheet, iOS 17.4+)
+                if indexPath.row == 1 {
+                    let inSheetCallback = URL(string: "https://local-sandbox.og4.me/universal_link_internal")!
+                    await handleAuthToken {
+                        try await AppDelegate.reachfive().webviewLogin(WebviewLoginRequest(presentationContextProvider: self, origin: "ActionController.webviewLogin.https", webSessionMode: .universalLink(inSheetCallback)))
+                    }
+                }
+
+                // secure webview handing off to an external app and returning OUT-OF-BAND via an https universal link
+                if indexPath.row == 2 {
+                    let externalAppCallback = URL(string: "https://local-sandbox.og4.me/_dev/mobile/callback")!
+                    await handleAuthToken {
+                        try await AppDelegate.reachfive().webviewLogin(WebviewLoginRequest(presentationContextProvider: self, origin: "ActionController.webviewLogin.externalApp", webSessionMode: .externalApp(externalAppCallback)))
+                    }
+                }
             }
 
             // Section Others

--- a/Sandbox/Sandbox/Tabs/ActionController.swift
+++ b/Sandbox/Sandbox/Tabs/ActionController.swift
@@ -65,9 +65,10 @@ class ActionController: UITableViewController {
 
                 // secure webview completing IN-BAND via an https universal link (intercepted in the sheet, iOS 17.4+)
                 if indexPath.row == 1 {
+                    guard #available(iOS 17.4, *) else { return }
                     let inSheetCallback = URL(string: "https://local-sandbox.og4.me/universal_link_internal")!
                     await handleAuthToken {
-                        try await AppDelegate.reachfive().webviewLogin(WebviewLoginRequest(presentationContextProvider: self, origin: "ActionController.webviewLogin.https", webSessionMode: .universalLink(inSheetCallback)))
+                        try await AppDelegate.reachfive().webviewLogin(WebviewLoginRequest(presentationContextProvider: self, origin: "ActionController.webviewLogin.https", webSessionMode: .inSheetUniversalLink(inSheetCallback)))
                     }
                 }
 
@@ -75,7 +76,14 @@ class ActionController: UITableViewController {
                 if indexPath.row == 2 {
                     let externalAppCallback = URL(string: "https://local-sandbox.og4.me/_dev/mobile/callback")!
                     await handleAuthToken {
-                        try await AppDelegate.reachfive().webviewLogin(WebviewLoginRequest(presentationContextProvider: self, origin: "ActionController.webviewLogin.externalApp", webSessionMode: .externalApp(externalAppCallback)))
+                        try await AppDelegate.reachfive().webviewLogin(WebviewLoginRequest(presentationContextProvider: self, origin: "ActionController.webviewLogin.externalApp", webSessionMode: .externalAppUniversalLink(externalAppCallback)))
+                    }
+                }
+
+                // secure webview handing off to an external app and returning OUT-OF-BAND via the custom scheme
+                if indexPath.row == 3 {
+                    await handleAuthToken {
+                        try await AppDelegate.reachfive().webviewLogin(WebviewLoginRequest(presentationContextProvider: self, origin: "ActionController.webviewLogin.externalAppScheme", webSessionMode: .externalAppScheme))
                     }
                 }
             }

--- a/Sources/Core/Classes/DefaultProvider.swift
+++ b/Sources/Core/Classes/DefaultProvider.swift
@@ -4,7 +4,7 @@ import AuthenticationServices
 /// Registers a **web** provider (one without a native SDK component, served by `DefaultProvider`) so the app
 /// can pick its **variant** and its **completion mode**
 ///
-/// Example: `WebProvider(name: .bconnect, variant: "natif", mode: .externalApp)`.
+/// Example: `WebProvider(name: .bconnect, variant: "natif", mode: .externalAppUniversalLink)`.
 public final class WebProvider: ProviderCreator {
     /// The SLO providers supported by the backend. `rawValue` is the backend name.
     public enum Name: String {
@@ -18,21 +18,36 @@ public final class WebProvider: ProviderCreator {
         case line
     }
 
-    /// Selects how the `ASWebAuthenticationSession` should complete for this provider; resolved into the
-    /// corresponding ``WebSessionMode`` (with its URL) by `DefaultProvider.init`.
-    public enum WebProviderMode {
-        /// Custom scheme intercepted by the session (works on all iOS versions). E.g. `reachfive-<clientId>`.
-        case sdkScheme
+    /// Selects how the `ASWebAuthenticationSession` should complete for this provider, on the same two
+    /// orthogonal axes as ``WebSessionMode`` — the callback shape (custom scheme vs universal link) and the
+    /// channel (in-band vs out-of-band) — but without any URL: for a universal-link callback the SDK reads
+    /// the provider's `universalLink` from its backend config. `DefaultProvider.init` resolves this into the
+    /// corresponding ``WebSessionMode``. Exposed as named factories (private init); the in-sheet universal
+    /// link is annotated `@available(iOS 17.4, *)`.
+    public struct WebProviderMode {
+        enum Callback { case customScheme, universalLink }
+        let callback: Callback
+        let channel: WebSessionMode.Channel
 
-        /// out-of-band completion: the flow ends in an external app that reopens the host app via a
-        /// universal link. Requires the `applinks:<host>` Associated Domain on the host app side.
-        case externalApp
+        private init(callback: Callback, channel: WebSessionMode.Channel) {
+            self.callback = callback
+            self.channel = channel
+        }
 
-        /// Universal link intercepted _inside_ the webview (iOS 17.4+ via `callback: .https`). Requires
-        /// the `webcredentials:<host>` Associated Domain. Reserve for flows that end
-        /// entirely within the sheet (no jump to an external app).
+        /// Custom scheme intercepted _inside_ the sheet — the default, on every iOS version.
+        public static let sdkScheme = WebProviderMode(callback: .customScheme, channel: .inBand)
+
+        /// out-of-band: an external app reopens the host app via the custom scheme (`application(_:open:)`).
+        public static let externalAppScheme = WebProviderMode(callback: .customScheme, channel: .outOfBand)
+
+        /// out-of-band: an external app reopens the host app via a universal link (`application(_:continue:)`).
+        /// Requires the `applinks:<host>` Associated Domain on the host app side.
+        public static let externalAppUniversalLink = WebProviderMode(callback: .universalLink, channel: .outOfBand)
+
+        /// Universal link intercepted _inside_ the webview (iOS 17.4+ via `callback: .https`). Requires the
+        /// `webcredentials:<host>` Associated Domain. Reserve for flows that stay within the sheet.
         @available(iOS 17.4, *)
-        case universalLink
+        public static let inSheetUniversalLink = WebProviderMode(callback: .universalLink, channel: .inBand)
     }
 
     private let providerName: Name
@@ -70,18 +85,27 @@ class DefaultProvider: NSObject, Provider {
         self.providerConfig = providerConfig
         self.name = providerConfig.provider
 
-        if mode == .sdkScheme {
-            webSessionMode = .sdkScheme
-        } else {
+        switch mode.callback {
+        case .customScheme:
+            // Le custom scheme n'a pas besoin de l'`universalLink` du backend : la redirect_uri est celle
+            // du SdkConfig, in-band comme hors-bande.
+            webSessionMode = mode.channel == .inBand ? .sdkScheme : .externalAppScheme
+
+        case .universalLink:
             guard let link = providerConfig.universalLink else {
-                Logger.shared.log("No universal link configured for provider '\(providerConfig.provider)' in \(mode) mode; login() will fail with a TechnicalError.")
+                Logger.shared.log("No universal link configured for provider '\(providerConfig.provider)' in universal-link mode; login() will fail with a TechnicalError.")
                 webSessionMode = nil
                 return
             }
-            if mode == .externalApp {
-                webSessionMode = WebSessionMode.externalApp(link)
+            if mode.channel == .inBand {
+                guard #available(iOS 17.4, *) else {
+                    Logger.shared.log("In-sheet universal link requires iOS 17.4+; login() for provider '\(providerConfig.provider)' will fail with a TechnicalError.")
+                    webSessionMode = nil
+                    return
+                }
+                webSessionMode = .inSheetUniversalLink(link)
             } else {
-                webSessionMode = WebSessionMode.universalLink(link)
+                webSessionMode = .externalAppUniversalLink(link)
             }
         }
     }

--- a/Sources/Core/Classes/DefaultProvider.swift
+++ b/Sources/Core/Classes/DefaultProvider.swift
@@ -18,12 +18,8 @@ public final class WebProvider: ProviderCreator {
         case line
     }
 
-    /// Selects how the `ASWebAuthenticationSession` should complete for this provider, on the same two
-    /// orthogonal axes as ``WebSessionMode`` — the callback shape (custom scheme vs universal link) and the
-    /// channel (in-band vs out-of-band) — but without any URL: for a universal-link callback the SDK reads
-    /// the provider's `universalLink` from its backend config. `DefaultProvider.init` resolves this into the
-    /// corresponding ``WebSessionMode``. Exposed as named factories (private init); the in-sheet universal
-    /// link is annotated `@available(iOS 17.4, *)`.
+    /// How this provider's login session completes. Same choices as ``WebSessionMode``, resolved into it by
+    /// `DefaultProvider.init` (a universal-link mode uses the provider's `universalLink` from its backend config).
     public struct WebProviderMode {
         enum Callback { case customScheme, universalLink }
         let callback: Callback
@@ -34,18 +30,16 @@ public final class WebProvider: ProviderCreator {
             self.channel = channel
         }
 
-        /// Custom scheme intercepted _inside_ the sheet — the default, on every iOS version.
+        /// Custom scheme intercepted in the sheet — the default, on every iOS version.
         public static let sdkScheme = WebProviderMode(callback: .customScheme, channel: .inBand)
 
-        /// out-of-band: an external app reopens the host app via the custom scheme (`application(_:open:)`).
+        /// An external app reopens the host app via the custom scheme.
         public static let externalAppScheme = WebProviderMode(callback: .customScheme, channel: .outOfBand)
 
-        /// out-of-band: an external app reopens the host app via a universal link (`application(_:continue:)`).
-        /// Requires the `applinks:<host>` Associated Domain on the host app side.
+        /// An external app reopens the host app via a universal link.
         public static let externalAppUniversalLink = WebProviderMode(callback: .universalLink, channel: .outOfBand)
 
-        /// Universal link intercepted _inside_ the webview (iOS 17.4+ via `callback: .https`). Requires the
-        /// `webcredentials:<host>` Associated Domain. Reserve for flows that stay within the sheet.
+        /// Universal link intercepted in the sheet (via `callback: .https`).
         @available(iOS 17.4, *)
         public static let inSheetUniversalLink = WebProviderMode(callback: .universalLink, channel: .inBand)
     }

--- a/Sources/Core/Classes/DefaultProvider.swift
+++ b/Sources/Core/Classes/DefaultProvider.swift
@@ -6,14 +6,19 @@ import AuthenticationServices
 ///
 /// Example: `WebProvider(name: .bconnect, variant: "natif", mode: .externalApp)`.
 public final class WebProvider: ProviderCreator {
-    /// The variant-aware SLO providers the backend exposes a variant for. `rawValue` is the backend name.
+    /// The SLO providers supported by the backend. `rawValue` is the backend name.
     public enum Name: String {
-        case facebook
-        case google
-        case line
-        case bconnect
+        case Facebook = "facebook"
+        case Google = "google"
+        case PayPal = "paypal"
+        case Twitter = "twitter"
+        case FranceConnect = "franceconnect"
+        case Oney = "oney"
+        case Bconnect = "bconnect"
+        case Line = "line"
     }
 
+    //TODO: doc à reprendre depuis WebSessionMode
     public enum WebProviderMode {
         case sdkScheme
         case externalApp

--- a/Sources/Core/Classes/DefaultProvider.swift
+++ b/Sources/Core/Classes/DefaultProvider.swift
@@ -1,6 +1,44 @@
 import Foundation
 import AuthenticationServices
 
+/// Registers a **web** provider (one without a native SDK component, served by `DefaultProvider`) so the app
+/// can pick its **variant** — exactly like native creators carry a `variant`. The chosen variant flows through
+/// the existing mechanism: `ReachFive.reinitialize()` sends `providersCreators.map { ($0.name, $0.variant) }`
+/// to `/api/v1/providers`, and the returned per-variant config (incl. `universalLink`) drives `DefaultProvider`.
+///
+/// Example: `WebProvider(name: .bconnect, variant: "natif")`.
+public final class WebProvider: ProviderCreator {
+    /// The variant-aware SLO providers the backend exposes a variant for. `rawValue` is the backend name.
+    public enum Name: String {
+        case facebook
+        case google
+        case line
+        case bconnect
+    }
+
+    public enum WebProviderMode {
+        case sdkScheme
+        case externalApp
+        @available(iOS 17.4, *)
+        case universalLink
+    }
+
+    private let providerName: Name
+    public var name: String { providerName.rawValue }
+    public let variant: String?
+    public let mode: WebProviderMode
+
+    public init(name: Name, variant: String? = nil, mode: WebProviderMode = .sdkScheme) {
+        self.providerName = name
+        self.variant = variant
+        self.mode = mode
+    }
+
+    public func create(reachFive: ReachFive, providerConfig: ProviderConfig, clientConfigResponse: ClientConfigResponse) -> Provider {
+        DefaultProvider(reachfive: reachFive, providerConfig: providerConfig, mode: mode)
+    }
+}
+
 class DefaultProvider: NSObject, Provider {
     let name: String
 
@@ -9,11 +47,31 @@ class DefaultProvider: NSObject, Provider {
     // LoginWKWebview).
     private weak var reachfive: ReachFive?
     let providerConfig: ProviderConfig
+    public let webSessionMode: WebSessionMode?
 
-    public init(reachfive: ReachFive, providerConfig: ProviderConfig) {
+    public init(
+        reachfive: ReachFive,
+        providerConfig: ProviderConfig,
+        mode: WebProvider.WebProviderMode = .sdkScheme
+    ) {
         self.reachfive = reachfive
         self.providerConfig = providerConfig
         self.name = providerConfig.provider
+
+        if mode == .sdkScheme {
+            webSessionMode = .sdkScheme
+        } else {
+            guard let link = providerConfig.universalLink else {
+                Logger.shared.log("No universal link configured for provider '\(providerConfig.provider)' in \(mode) mode; login() will fail with a TechnicalError.")
+                webSessionMode = nil
+                return
+            }
+            if mode == .externalApp {
+                webSessionMode = WebSessionMode.externalApp(link)
+            } else {
+                webSessionMode = WebSessionMode.universalLink(link)
+            }
+        }
     }
 
     public func login(
@@ -26,32 +84,26 @@ class DefaultProvider: NSObject, Provider {
             throw ReachFiveError.TechnicalError(reason: "No presenting viewController")
         }
 
+        guard let webSessionMode else {
+            throw ReachFiveError.TechnicalError(reason: "No universal link configured for provider \(name)")
+        }
+
         guard let reachfive else {
             throw ReachFiveError.TechnicalError(reason: "ReachFive instance was deallocated")
         }
 
-        return try await reachfive.webviewLogin(WebviewLoginRequest(scope: scope, presentationContextProvider: presentationContextProvider, origin: origin, provider: providerConfig.provider))
+        return try await reachfive.webviewLogin(
+            WebviewLoginRequest(
+                scope: scope,
+                presentationContextProvider: presentationContextProvider,
+                origin: origin,
+                provider: providerConfig.providerWithVariant,
+                webSessionMode: webSessionMode)
+        )
     }
 
     override var description: String {
         "Provider: \(providerConfig.provider)"
-    }
-}
-
-extension DefaultProvider {
-    public func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any]) -> Bool {
-        true
-    }
-
-    public func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        true
-    }
-
-    func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
-        true
-    }
-
-    public func applicationDidBecomeActive(_ application: UIApplication) {
     }
 
     public func logout() {

--- a/Sources/Core/Classes/DefaultProvider.swift
+++ b/Sources/Core/Classes/DefaultProvider.swift
@@ -18,10 +18,19 @@ public final class WebProvider: ProviderCreator {
         case Line = "line"
     }
 
-    //TODO: doc à reprendre depuis WebSessionMode
+    /// Selects how the `ASWebAuthenticationSession` should complete for this provider; resolved into the
+    /// corresponding ``WebSessionMode`` (with its URL) by `DefaultProvider.init`.
     public enum WebProviderMode {
+        /// Custom scheme intercepted by the session (works on all iOS versions). E.g. `reachfive-<clientId>`.
         case sdkScheme
+
+        /// out-of-band completion: the flow ends in an external app that reopens the host app via a
+        /// universal link. Requires the `applinks:<host>` Associated Domain on the host app side.
         case externalApp
+
+        /// Universal link intercepted _inside_ the webview (iOS 17.4+ via `callback: .https`). Requires
+        /// the `webcredentials:<host>` Associated Domain. Reserve for flows that end
+        /// entirely within the sheet (no jump to an external app).
         @available(iOS 17.4, *)
         case universalLink
     }

--- a/Sources/Core/Classes/DefaultProvider.swift
+++ b/Sources/Core/Classes/DefaultProvider.swift
@@ -8,14 +8,14 @@ import AuthenticationServices
 public final class WebProvider: ProviderCreator {
     /// The SLO providers supported by the backend. `rawValue` is the backend name.
     public enum Name: String {
-        case Facebook = "facebook"
-        case Google = "google"
-        case PayPal = "paypal"
-        case Twitter = "twitter"
-        case FranceConnect = "franceconnect"
-        case Oney = "oney"
-        case Bconnect = "bconnect"
-        case Line = "line"
+        case facebook
+        case google
+        case payPal = "paypal"
+        case twitter
+        case franceConnect = "franceconnect"
+        case oney
+        case bconnect
+        case line
     }
 
     /// Selects how the `ASWebAuthenticationSession` should complete for this provider; resolved into the

--- a/Sources/Core/Classes/DefaultProvider.swift
+++ b/Sources/Core/Classes/DefaultProvider.swift
@@ -2,11 +2,9 @@ import Foundation
 import AuthenticationServices
 
 /// Registers a **web** provider (one without a native SDK component, served by `DefaultProvider`) so the app
-/// can pick its **variant** — exactly like native creators carry a `variant`. The chosen variant flows through
-/// the existing mechanism: `ReachFive.reinitialize()` sends `providersCreators.map { ($0.name, $0.variant) }`
-/// to `/api/v1/providers`, and the returned per-variant config (incl. `universalLink`) drives `DefaultProvider`.
+/// can pick its **variant** and its **completion mode**
 ///
-/// Example: `WebProvider(name: .bconnect, variant: "natif")`.
+/// Example: `WebProvider(name: .bconnect, variant: "natif", mode: .externalApp)`.
 public final class WebProvider: ProviderCreator {
     /// The variant-aware SLO providers the backend exposes a variant for. `rawValue` is the backend name.
     public enum Name: String {

--- a/Sources/Core/Classes/LoginWKWebview.swift
+++ b/Sources/Core/Classes/LoginWKWebview.swift
@@ -11,12 +11,19 @@ public class LoginWKWebview: UIView {
         super.init(coder: coder)
     }
 
+    /// Loads the ReachFive **first-party** login form into this embedded webview and awaits the
+    /// `AuthToken`. The flow completes in-band on the SDK's custom scheme, intercepted by the webview.
+    ///
+    /// **Universal-link** providers are not supported by this path: their out-of-band callback comes
+    /// in through `application(_:continue:)` and completes the session held by `ReachFive`, not this
+    /// webview — and third-party OAuth providers generally reject embedded webviews. Use
+    /// ``ReachFive/webviewLogin(_:)`` (or a `WebProvider`) for them.
     public func loadLoginWebview(reachfive: ReachFive, state: String? = nil, nonce: String? = nil, scope: [String]? = nil, origin: String? = nil) async throws -> AuthToken {
         let pkce = Pkce.generate()
         self.reachfive = reachfive
         self.pkce = pkce
         self.reachfive?.storage.save(key: reachfive.pkceKey, value: pkce)
-        
+
         let rect = CGRect(origin: .zero, size: frame.size)
         let webView = WKWebView(frame: rect, configuration: WKWebViewConfiguration())
         self.webView = webView

--- a/Sources/Core/Classes/ReachFive.swift
+++ b/Sources/Core/Classes/ReachFive.swift
@@ -42,7 +42,7 @@ public class ReachFive: NSObject {
         self.storage = storage ?? UserDefaultsStorage()
         self.reachFiveApi = ReachFiveApi(sdkConfig: sdkConfig)
         self.credentialManager = CredentialManager(reachFiveApi: reachFiveApi, storage: self.storage)
-        self.webAuthSession = WebAuthenticationSession(baseScheme: sdkConfig.customScheme)
+        self.webAuthSession = WebAuthenticationSession(baseScheme: sdkConfig.customScheme, sdkRedirectUri: sdkConfig.redirectUri)
 
         if let sdkInternalConfig {
             Logger.shared.enabled = sdkInternalConfig.loggingEnabled

--- a/Sources/Core/Classes/ReachFiveApi.swift
+++ b/Sources/Core/Classes/ReachFiveApi.swift
@@ -5,7 +5,7 @@ public class ReachFiveApi {
 
     let sdkConfig: SdkConfig
     private let networkClient: NetworkClient
-    private let profile_fields = [
+    private let profileFields = [
         "birthdate",
         "bio",
         "middle_name",
@@ -61,7 +61,7 @@ public class ReachFiveApi {
         self.sdkConfig = sdkConfig
         let decoder = JSONDecoder()
         decoder.keyDecodingStrategy = .convertFromSnakeCase
-        self.networkClient = NetworkClient(decoder: decoder)
+        networkClient = NetworkClient(decoder: decoder)
     }
 
     // MARK: - URL Construction
@@ -160,7 +160,7 @@ public class ReachFiveApi {
     // MARK: - Profile Management
 
     public func getProfile(authToken: AuthToken) async throws -> Profile {
-        try await networkClient.request(createUrl(path: "/identity/v1/userinfo", params: ["fields": profile_fields.joined(separator: ","), "flatcf": "true"]), headers: tokenHeader(authToken))
+        try await networkClient.request(createUrl(path: "/identity/v1/userinfo", params: ["fields": profileFields.joined(separator: ","), "flatcf": "true"]), headers: tokenHeader(authToken))
             .responseJson(type: Profile.self)
     }
 
@@ -185,12 +185,13 @@ public class ReachFiveApi {
     }
 
     // MARK: - Session devices
+
     public func listSessionDevices(authToken: AuthToken) async throws -> ListSessionDevices {
         try await networkClient.request(createUrl(path: "/identity/v1/session-devices"), method: .get, headers: tokenHeader(authToken))
             .responseJson(type: ListSessionDevices.self)
     }
 
-    public func deleteSessionDevice(id: String, authToken: AuthToken) async throws -> Void {
+    public func deleteSessionDevice(id: String, authToken: AuthToken) async throws {
         try await networkClient.request(createUrl(path: "/identity/v1/session-devices/\(id)"), method: .delete, headers: tokenHeader(authToken))
             .responseJson()
     }
@@ -369,7 +370,7 @@ public class ReachFiveApi {
     // MARK: - Helpers
 
     func tokenHeader(_ authToken: AuthToken) -> [String: String] {
-       ["Authorization": "\(authToken.tokenType ?? "Bearer") \(authToken.accessToken)"]
+        ["Authorization": "\(authToken.tokenType ?? "Bearer") \(authToken.accessToken)"]
     }
 }
 

--- a/Sources/Core/Classes/ReachFiveApplication.swift
+++ b/Sources/Core/Classes/ReachFiveApplication.swift
@@ -17,6 +17,7 @@ public extension ReachFive {
                     let _ = provider.application(application, didFinishLaunchingWithOptions: launchOptions)
                 }
             } catch {
+                //TODO: faire une passe de cohérence sur l'utilisation de #if DEBUG et du Logger
                 #if DEBUG
                 print(Logger.shared.message(for: error))
                 #endif
@@ -32,10 +33,24 @@ public extension ReachFive {
         }
     }
 
+    @MainActor
     func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
-        for provider in providers {
-            let _ = provider.application(application, continue: userActivity, restorationHandler: restorationHandler)
+        // D'abord la session web-auth : son matching est exact (host + path + code/error du
+        // redirect_uri attendu), aucun risque d'avaler un lien qui ne lui est pas destiné — alors
+        // qu'un provider custom peut consommer l'activité plus largement et lui masquer son callback.
+        if userActivity.activityType == NSUserActivityTypeBrowsingWeb,
+           let url = userActivity.webpageURL,
+           webAuthSession.tryComplete(externalCallbackURL: url) {
+            return true
         }
-        return true
+
+        // …puis les providers. Ne renvoie true QUE si l'un d'eux a consommé l'activité (sinon false,
+        // pour que l'app hôte — qui nous forwarde tous ses liens — route elle-même les liens que
+        // ReachFive ne gère pas).
+        var handled = false
+        for provider in providers {
+            handled = provider.application(application, continue: userActivity, restorationHandler: restorationHandler) || handled
+        }
+        return handled
     }
 }

--- a/Sources/Core/Classes/ReachFiveApplication.swift
+++ b/Sources/Core/Classes/ReachFiveApplication.swift
@@ -2,7 +2,16 @@ import Foundation
 import UIKit
 
 public extension ReachFive {
+    @MainActor
     func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any]) -> Bool {
+        // Canal hors-bande « custom scheme » : une app externe rouvre l'app hôte par le scheme du SDK.
+        // On teste la session web-auth d'abord — son matching est exact (scheme + host + path + code/error
+        // de la redirect_uri attendue, et n'est armé que pendant un login hors-bande en cours) — sinon
+        // `interceptUrl` avalerait le lien comme un callback passwordless.
+        if webAuthSession.tryComplete(externalCallbackURL: url) {
+            return true
+        }
+
         interceptUrl(url)
         for provider in providers {
             let _ = provider.application(app, open: url, options: options)

--- a/Sources/Core/Classes/ReachFiveLogin.swift
+++ b/Sources/Core/Classes/ReachFiveLogin.swift
@@ -18,6 +18,7 @@ public extension ReachFive {
             let _ = try? await webAuthSession.start(
                 url: reachFiveApi.buildLogoutURL(queryParams: options),
                 mode: .sdkScheme,
+                redirectUri: sdkConfig.redirectUri,
                 presentationContextProvider: request.presentationContextProvider,
                 prefersEphemeralWebBrowserSession: false)
         }

--- a/Sources/Core/Classes/ReachFiveLogin.swift
+++ b/Sources/Core/Classes/ReachFiveLogin.swift
@@ -18,7 +18,6 @@ public extension ReachFive {
             let _ = try? await webAuthSession.start(
                 url: reachFiveApi.buildLogoutURL(queryParams: options),
                 mode: .sdkScheme,
-                redirectUri: sdkConfig.redirectUri,
                 presentationContextProvider: request.presentationContextProvider,
                 prefersEphemeralWebBrowserSession: false)
         }

--- a/Sources/Core/Classes/ReachFiveLogin.swift
+++ b/Sources/Core/Classes/ReachFiveLogin.swift
@@ -17,6 +17,7 @@ public extension ReachFive {
 
             let _ = try? await webAuthSession.start(
                 url: reachFiveApi.buildLogoutURL(queryParams: options),
+                mode: .sdkScheme,
                 presentationContextProvider: request.presentationContextProvider,
                 prefersEphemeralWebBrowserSession: false)
         }
@@ -36,12 +37,12 @@ public extension ReachFive {
         return try await self.authWithCode(code: code, pkce: pkce)
     }
 
-    func buildAuthorizeURL(pkce: Pkce, state: String? = nil, nonce: String? = nil, scope: [String]? = nil, origin: String? = nil, provider: String? = nil) -> URL {
+    func buildAuthorizeURL(pkce: Pkce, state: String? = nil, nonce: String? = nil, scope: [String]? = nil, origin: String? = nil, provider: String? = nil, redirectUri: URL? = nil) -> URL {
         let scope = (scope ?? self.scope).joined(separator: " ")
         let options = [
             "provider": provider,
             "client_id": sdkConfig.clientId,
-            "redirect_uri": sdkConfig.redirectUri.absoluteString,
+            "redirect_uri": (redirectUri ?? sdkConfig.redirectUri).absoluteString,
             "response_type": "code",
             "scope": scope,
             "code_challenge": pkce.codeChallenge,
@@ -54,11 +55,11 @@ public extension ReachFive {
         return reachFiveApi.buildAuthorizeURL(queryParams: options)
     }
 
-    func authWithCode(code: String, pkce: Pkce) async throws -> AuthToken {
+    func authWithCode(code: String, pkce: Pkce, redirectUri: URL? = nil) async throws -> AuthToken {
         let authCodeRequest = AuthCodeRequest(
             clientId: sdkConfig.clientId,
             code: code,
-            redirectUri: sdkConfig.redirectUri,
+            redirectUri: redirectUri ?? sdkConfig.redirectUri,
             pkce: pkce)
         let token = try await reachFiveApi.authWithCode(authCodeRequest: authCodeRequest)
         return try AuthToken.fromOpenIdTokenResponse(token)

--- a/Sources/Core/Classes/ReachFiveWebviewLogin.swift
+++ b/Sources/Core/Classes/ReachFiveWebviewLogin.swift
@@ -14,15 +14,20 @@ public extension ReachFive {
 
         let scope = (request.scope ?? scope)
         let mode = request.webSessionMode
-        let authURL = buildAuthorizeURL(pkce: pkce, state: request.state, nonce: request.nonce, scope: scope, origin: request.origin, provider: request.provider, redirectUri: mode.redirectUri)
+        // `redirect_uri` résolue une fois : celle du mode (lien universel), ou à défaut celle du SdkConfig
+        // (custom scheme). Réutilisée à l'identique pour `/authorize`, l'armement hors-bande et l'échange
+        // du code (exigence OAuth : les trois doivent coïncider).
+        let redirectUri = mode.redirectUri ?? sdkConfig.redirectUri
+        let authURL = buildAuthorizeURL(pkce: pkce, state: request.state, nonce: request.nonce, scope: scope, origin: request.origin, provider: request.provider, redirectUri: redirectUri)
 
         let callbackURL = try await webAuthSession.start(
             url: authURL,
             mode: mode,
+            redirectUri: redirectUri,
             presentationContextProvider: request.presentationContextProvider,
             prefersEphemeralWebBrowserSession: request.prefersEphemeralWebBrowserSession)
 
         let code = try callbackURL.authorizationCode()
-        return try await self.authWithCode(code: code, pkce: pkce, redirectUri: mode.redirectUri)
+        return try await self.authWithCode(code: code, pkce: pkce, redirectUri: redirectUri)
     }
 }

--- a/Sources/Core/Classes/ReachFiveWebviewLogin.swift
+++ b/Sources/Core/Classes/ReachFiveWebviewLogin.swift
@@ -14,20 +14,17 @@ public extension ReachFive {
 
         let scope = (request.scope ?? scope)
         let mode = request.webSessionMode
-        // `redirect_uri` résolue une fois : celle du mode (lien universel), ou à défaut celle du SdkConfig
-        // (custom scheme). Réutilisée à l'identique pour `/authorize`, l'armement hors-bande et l'échange
-        // du code (exigence OAuth : les trois doivent coïncider).
-        let redirectUri = mode.redirectUri ?? sdkConfig.redirectUri
-        let authURL = buildAuthorizeURL(pkce: pkce, state: request.state, nonce: request.nonce, scope: scope, origin: request.origin, provider: request.provider, redirectUri: redirectUri)
+        // La `redirect_uri` du mode (nil pour un custom scheme, où le SdkConfig s'applique) est utilisée
+        // à l'identique pour `/authorize` et l'échange du code — exigence OAuth : les deux doivent coïncider.
+        let authURL = buildAuthorizeURL(pkce: pkce, state: request.state, nonce: request.nonce, scope: scope, origin: request.origin, provider: request.provider, redirectUri: mode.redirectUri)
 
         let callbackURL = try await webAuthSession.start(
             url: authURL,
             mode: mode,
-            redirectUri: redirectUri,
             presentationContextProvider: request.presentationContextProvider,
             prefersEphemeralWebBrowserSession: request.prefersEphemeralWebBrowserSession)
 
         let code = try callbackURL.authorizationCode()
-        return try await self.authWithCode(code: code, pkce: pkce, redirectUri: redirectUri)
+        return try await self.authWithCode(code: code, pkce: pkce, redirectUri: mode.redirectUri)
     }
 }

--- a/Sources/Core/Classes/ReachFiveWebviewLogin.swift
+++ b/Sources/Core/Classes/ReachFiveWebviewLogin.swift
@@ -3,20 +3,26 @@ import AuthenticationServices
 
 public extension ReachFive {
 
+    /// Orchestrates the whole web login: PKCE, authorize URL, web session (via the centralized carrier),
+    /// then code exchange. The session is carried by `ReachFive` so that a return via universal link
+    /// (received through `application(_:continue:)`) can complete it out-of-band, even for a direct call
+    /// to this public API.
     func webviewLogin(_ request: WebviewLoginRequest) async throws -> AuthToken {
 
         let pkce = Pkce.generate()
         storage.save(key: pkceKey, value: pkce)
 
         let scope = (request.scope ?? scope)
-        let authURL = buildAuthorizeURL(pkce: pkce, state: request.state, nonce: request.nonce, scope: scope, origin: request.origin, provider: request.provider)
+        let mode = request.webSessionMode
+        let authURL = buildAuthorizeURL(pkce: pkce, state: request.state, nonce: request.nonce, scope: scope, origin: request.origin, provider: request.provider, redirectUri: mode.redirectUri)
 
         let callbackURL = try await webAuthSession.start(
             url: authURL,
+            mode: mode,
             presentationContextProvider: request.presentationContextProvider,
             prefersEphemeralWebBrowserSession: request.prefersEphemeralWebBrowserSession)
 
         let code = try callbackURL.authorizationCode()
-        return try await self.authWithCode(code: code, pkce: pkce)
+        return try await self.authWithCode(code: code, pkce: pkce, redirectUri: mode.redirectUri)
     }
 }

--- a/Sources/Core/Classes/models/ProviderConfig.swift
+++ b/Sources/Core/Classes/models/ProviderConfig.swift
@@ -4,7 +4,7 @@ public class ProviderConfig: Codable {
     public let provider: String
     public let variant: String
     public let clientId: String?
-    public let universalLink: String?
+    public let universalLink: URL?
     public let scope: [String]?
     
     public var providerWithVariant: String { provider + ":" + variant }

--- a/Sources/Core/Classes/models/requests/WebviewLoginRequest.swift
+++ b/Sources/Core/Classes/models/requests/WebviewLoginRequest.swift
@@ -9,8 +9,21 @@ public class WebviewLoginRequest {
     public let origin: String?
     public let provider: String?
     public let prefersEphemeralWebBrowserSession: Bool
+    /// The `redirect_uri` of this login and its return channel. The resolved `redirect_uri` must be one
+    /// of the client's authorized callback URLs, and is reused identically for the code exchange.
+    /// Default: ``WebSessionMode/sdkScheme``.
+    public let webSessionMode: WebSessionMode
 
-    public init(state: String? = nil, nonce: String? = nil, scope: [String]? = nil, presentationContextProvider: ASWebAuthenticationPresentationContextProviding, origin: String? = nil, provider: String? = nil, prefersEphemeralWebBrowserSession: Bool = false) {
+    public init(
+        state: String? = nil,
+        nonce: String? = nil,
+        scope: [String]? = nil,
+        presentationContextProvider: ASWebAuthenticationPresentationContextProviding,
+        origin: String? = nil,
+        provider: String? = nil,
+        prefersEphemeralWebBrowserSession: Bool = false,
+        webSessionMode: WebSessionMode = .sdkScheme
+    ) {
         self.state = state ?? "state"
         self.nonce = nonce ?? "nonce"
         self.scope = scope
@@ -18,5 +31,6 @@ public class WebviewLoginRequest {
         self.origin = origin
         self.provider = provider
         self.prefersEphemeralWebBrowserSession = prefersEphemeralWebBrowserSession
+        self.webSessionMode = webSessionMode
     }
 }

--- a/Sources/Core/Classes/webauth/WebAuthentication.swift
+++ b/Sources/Core/Classes/webauth/WebAuthentication.swift
@@ -1,6 +1,8 @@
 import AuthenticationServices
 
-/// Porte le login web en cours : démarre une `ASWebAuthenticationSession` et attend son callback.
+/// Porte le login web en cours : démarre une `ASWebAuthenticationSession`, attend son callback,
+/// et — pour les providers à lien universel — laisse un lien reçu hors-bande via `application(_:continue:)`
+/// le compléter (``tryComplete(externalCallbackURL:)``).
 ///
 /// **Un seul login à la fois.** Sur iPhone, la feuille modale d'une `ASWebAuthenticationSession` rend
 /// un second `start(...)` inatteignable par l'interaction utilisateur : tant qu'elle est présentée rien
@@ -13,14 +15,23 @@ import AuthenticationServices
 /// Les callbacks tardifs ou dupliqués sont neutralisés de deux façons : un **jeton par tentative**
 /// (`attempt`) — pour qu'un callback d'une `ASWebAuthenticationSession` périmée ne puisse jamais
 /// reprendre la continuation d'un login plus récent — et la remise à `nil` de `continuation` dans
-/// `complete(_:)` — pour que la résolution gagnante (callback ou annulation) reprenne la
+/// `complete(_:)` — pour que la résolution gagnante (in-band, hors-bande, ou annulation) reprenne la
 /// continuation exactement une fois.
+///
+/// **Limitation (hors-bande)** : l'état d'un login en vol ne vit qu'en mémoire. Si iOS tue l'app
+/// pendant l'aller-retour vers l'app externe, le callback reçu au relancement ne matche rien
+/// (`tryComplete` renvoie `false`, l'app hôte route le lien) et le `code` est perdu : l'utilisateur
+/// doit relancer le login. Une reprise après relancement demanderait de persister le login en vol
+/// (redirect_uri + PKCE, déjà en storage) et un canal pour livrer le résultat à l'app — assumé hors
+/// périmètre tant que l'usage ne le justifie pas.
 ///
 /// `@MainActor` : tout le domaine `ASWebAuthenticationSession` est déjà main-thread.
 @MainActor
 final class WebAuthenticationSession {
     private var session: ASWebAuthenticationSession?
     private var continuation: CheckedContinuation<URL, Error>?
+    /// La `redirect_uri` attendue pour cette tentative ; `nil` hors d'un login → `tryComplete` ne matche rien.
+    private var expectedCallback: URL?
     /// Identifie la tentative en cours ; un callback capturant un `attempt` périmé est ignoré.
     private var attempt = 0
     private let baseScheme: String
@@ -29,10 +40,13 @@ final class WebAuthenticationSession {
         self.baseScheme = baseScheme
     }
 
-    /// Démarre un login web sur le scheme custom du SDK et attend son callback (succès, erreur ou
-    /// annulation). Si le `Task` appelant est annulé (vue démontée, timeout…), la feuille est fermée
-    /// et l'appel se termine par `.AuthCanceled`.
+    /// Démarre un login web et attend son callback (succès, erreur ou annulation). Le ``WebSessionMode``
+    /// décrit comment la session se termine (scheme in-band, lien universel in-band, ou app externe
+    /// hors-bande) et pilote donc à la fois la construction de la session et le canal du callback.
+    /// Si le `Task` appelant est annulé (vue démontée, timeout…), la feuille est fermée et l'appel se
+    /// termine par `.AuthCanceled`.
     func start(url: URL,
+               mode: WebSessionMode,
                presentationContextProvider: ASWebAuthenticationPresentationContextProviding,
                prefersEphemeralWebBrowserSession: Bool = false) async throws -> URL {
 
@@ -49,6 +63,8 @@ final class WebAuthenticationSession {
         return try await withTaskCancellationHandler {
             try await withCheckedThrowingContinuation { continuation in
                 self.continuation = continuation
+                // Seul le mode hors-bande arme `tryComplete` ; en in-band, la session se complète elle-même.
+                self.expectedCallback = mode.outOfBandCallback
 
                 let completionHandler: ASWebAuthenticationSession.CompletionHandler = { [weak self] callbackURL, error in
                     // Tout passe sur le main thread pour éviter les situations de compétition.
@@ -57,11 +73,36 @@ final class WebAuthenticationSession {
                     }
                 }
 
-                // Scheme custom intercepté par la session (historique, tout iOS).
-                let session = ASWebAuthenticationSession(
-                    url: url,
-                    callbackURLScheme: self.baseScheme,
-                    completionHandler: completionHandler)
+                let session: ASWebAuthenticationSession
+                switch mode {
+                case .sdkScheme:
+                    // Scheme custom intercepté par la session (historique, tout iOS).
+                    session = ASWebAuthenticationSession(
+                        url: url,
+                        callbackURLScheme: self.baseScheme,
+                        completionHandler: completionHandler)
+
+                case let .universalLink(callback):
+                    // iOS 17.4+ : lien universel intercepté in-band dans la webview via `callback: .https`
+                    // (nécessite l'Associated Domain `webcredentials:<host>`). `@available` est impossible
+                    // sur un case d'enum porteur de valeur, on teste donc la disponibilité ici, à l'usage.
+                    guard #available(iOS 17.4, *), let host = callback.host else {
+                        self.complete(attempt: attempt, .failure(.TechnicalError(reason: "In-sheet universal link callback requires iOS 17.4+ and a host: \(callback)")))
+                        return
+                    }
+                    session = ASWebAuthenticationSession(
+                        url: url,
+                        callback: .https(host: host, path: callback.path),
+                        completionHandler: completionHandler)
+
+                case .externalApp:
+                    // Le flow se termine dans une app externe : la session ne recevra jamais le callback
+                    // (traité hors-bande par `tryComplete`), on ne lui donne donc aucun scheme à intercepter.
+                    session = ASWebAuthenticationSession(
+                        url: url,
+                        callbackURLScheme: nil,
+                        completionHandler: completionHandler)
+                }
 
                 // Fenêtre qui sert d'ancre de présentation à la session.
                 session.presentationContextProvider = presentationContextProvider
@@ -83,6 +124,18 @@ final class WebAuthenticationSession {
         }
     }
 
+    /// Complète le login en cours si l'URL entrante est bien notre callback, et ferme la feuille
+    /// encore ouverte. Renvoie `true` seulement dans ce cas — sinon `false`, pour que l'app hôte puisse
+    /// router elle-même le lien.
+    func tryComplete(externalCallbackURL url: URL) -> Bool {
+        guard let expectedCallback,
+              Self.isOurCallback(url, expectedCallback: expectedCallback) else {
+            return false
+        }
+        complete(attempt: attempt, .success(url))
+        return true
+    }
+
     private func handleSessionCompletion(attempt: Int, callbackURL: URL?, error: Error?) {
         if let error {
             complete(attempt: attempt, .failure(Self.reachFiveError(for: error)))
@@ -94,7 +147,7 @@ final class WebAuthenticationSession {
     }
 
     /// L'unique point de résolution : reprend la continuation avec `result`, nettoie l'état, et ferme
-    /// la feuille si elle est encore présentée (annulation, remplacement).
+    /// la feuille si elle est encore présentée (résolution hors-bande, annulation, remplacement).
     private func complete(attempt: Int, _ result: Result<URL, ReachFiveError>) {
         // Ignore un callback périmé (login plus récent) ou une seconde résolution (`continuation` déjà nil).
         guard attempt == self.attempt, let continuation else { return }
@@ -104,8 +157,20 @@ final class WebAuthenticationSession {
         let openSession = session
         self.continuation = nil
         self.session = nil
+        self.expectedCallback = nil
         continuation.resume(with: result)
         openSession?.cancel()
+    }
+
+    /// `true` si l'URL entrante a le même host (insensible à la casse) et le même path que le
+    /// `redirect_uri` envoyé, et porte un paramètre `code` (succès) ou `error` (refus OAuth, ex.
+    /// `access_denied` — le login se termine alors proprement avec l'`ApiError` du callback au lieu
+    /// de rester bloqué sur la feuille). Le path attendu étant celui qu'on déclare dans l'AASA, ce
+    /// matching exact suffit à distinguer notre callback des autres liens de l'app.
+    nonisolated static func isOurCallback(_ url: URL, expectedCallback expected: URL) -> Bool {
+        url.host?.lowercased() == expected.host?.lowercased()
+        && url.path == expected.path
+        && (url.queryValue("code") != nil || url.queryValue("error") != nil)
     }
 
     /// Mappe une erreur d'`ASWebAuthenticationSession` vers une `ReachFiveError`.

--- a/Sources/Core/Classes/webauth/WebAuthentication.swift
+++ b/Sources/Core/Classes/webauth/WebAuthentication.swift
@@ -1,8 +1,8 @@
 import AuthenticationServices
 
 /// Porte le login web en cours : démarre une `ASWebAuthenticationSession`, attend son callback,
-/// et — pour les providers à lien universel — laisse un lien reçu hors-bande via `application(_:continue:)`
-/// le compléter (``tryComplete(externalCallbackURL:)``).
+/// et — pour les logins hors-bande — laisse un lien reçu via `application(_:open:)` (custom scheme)
+/// ou `application(_:continue:)` (lien universel) le compléter (``tryComplete(externalCallbackURL:)``).
 ///
 /// **Un seul login à la fois.** Sur iPhone, la feuille modale d'une `ASWebAuthenticationSession` rend
 /// un second `start(...)` inatteignable par l'interaction utilisateur : tant qu'elle est présentée rien
@@ -41,12 +41,15 @@ final class WebAuthenticationSession {
     }
 
     /// Démarre un login web et attend son callback (succès, erreur ou annulation). Le ``WebSessionMode``
-    /// décrit comment la session se termine (scheme in-band, lien universel in-band, ou app externe
-    /// hors-bande) et pilote donc à la fois la construction de la session et le canal du callback.
+    /// décrit comment la session se termine — croisement de deux axes (custom scheme vs lien universel,
+    /// in-band vs hors-bande) — et pilote donc à la fois la construction de la session et le canal du
+    /// callback. `redirectUri` est la `redirect_uri` déjà résolue (celle du mode, ou à défaut celle du
+    /// `SdkConfig`) : en hors-bande elle sert à reconnaître le lien entrant (``tryComplete(externalCallbackURL:)``).
     /// Si le `Task` appelant est annulé (vue démontée, timeout…), la feuille est fermée et l'appel se
     /// termine par `.AuthCanceled`.
     func start(url: URL,
                mode: WebSessionMode,
+               redirectUri: URL,
                presentationContextProvider: ASWebAuthenticationPresentationContextProviding,
                prefersEphemeralWebBrowserSession: Bool = false) async throws -> URL {
 
@@ -64,7 +67,7 @@ final class WebAuthenticationSession {
             try await withCheckedThrowingContinuation { continuation in
                 self.continuation = continuation
                 // Seul le mode hors-bande arme `tryComplete` ; en in-band, la session se complète elle-même.
-                self.expectedCallback = mode.outOfBandCallback
+                self.expectedCallback = mode.channel == .outOfBand ? redirectUri : nil
 
                 let completionHandler: ASWebAuthenticationSession.CompletionHandler = { [weak self] callbackURL, error in
                     // Tout passe sur le main thread pour éviter les situations de compétition.
@@ -74,18 +77,19 @@ final class WebAuthenticationSession {
                 }
 
                 let session: ASWebAuthenticationSession
-                switch mode {
-                case .sdkScheme:
+                switch (mode.channel, mode.callback) {
+                case (.inBand, .customScheme):
                     // Scheme custom intercepté par la session (historique, tout iOS).
                     session = ASWebAuthenticationSession(
                         url: url,
                         callbackURLScheme: self.baseScheme,
                         completionHandler: completionHandler)
 
-                case let .universalLink(callback):
+                case let (.inBand, .universalLink(callback)):
                     // iOS 17.4+ : lien universel intercepté in-band dans la webview via `callback: .https`
-                    // (nécessite l'Associated Domain `webcredentials:<host>`). `@available` est impossible
-                    // sur un case d'enum porteur de valeur, on teste donc la disponibilité ici, à l'usage.
+                    // (nécessite l'Associated Domain `webcredentials:<host>`). La disponibilité est déjà
+                    // garantie en amont par la fabrique `@available` de ``WebSessionMode``, on garde ici
+                    // un filet runtime (et l'extraction du host, faillible).
                     guard #available(iOS 17.4, *), let host = callback.host else {
                         self.complete(attempt: attempt, .failure(.TechnicalError(reason: "In-sheet universal link callback requires iOS 17.4+ and a host: \(callback)")))
                         return
@@ -95,9 +99,10 @@ final class WebAuthenticationSession {
                         callback: .https(host: host, path: callback.path),
                         completionHandler: completionHandler)
 
-                case .externalApp:
+                case (.outOfBand, _):
                     // Le flow se termine dans une app externe : la session ne recevra jamais le callback
-                    // (traité hors-bande par `tryComplete`), on ne lui donne donc aucun scheme à intercepter.
+                    // (traité hors-bande par `tryComplete`, quel que soit le type de lien), on ne lui donne
+                    // donc aucun scheme à intercepter.
                     session = ASWebAuthenticationSession(
                         url: url,
                         callbackURLScheme: nil,
@@ -162,13 +167,18 @@ final class WebAuthenticationSession {
         openSession?.cancel()
     }
 
-    /// `true` si l'URL entrante a le même host (insensible à la casse) et le même path que le
-    /// `redirect_uri` envoyé, et porte un paramètre `code` (succès) ou `error` (refus OAuth, ex.
-    /// `access_denied` — le login se termine alors proprement avec l'`ApiError` du callback au lieu
-    /// de rester bloqué sur la feuille). Le path attendu étant celui qu'on déclare dans l'AASA, ce
-    /// matching exact suffit à distinguer notre callback des autres liens de l'app.
+    /// `true` si l'URL entrante a le même scheme et le même host (insensibles à la casse) et le même
+    /// path que le `redirect_uri` envoyé, et porte un paramètre `code` (succès) ou `error` (refus OAuth,
+    /// ex. `access_denied` — le login se termine alors proprement avec l'`ApiError` du callback au lieu
+    /// de rester bloqué sur la feuille). Comparer le scheme est ce qui permet aux deux canaux hors-bande
+    /// (custom scheme via `application(_:open:)`, lien universel via `application(_:continue:)`) de
+    /// partager ce même matcher sans faux positif : un login attendu en scheme ne matche que des URL de
+    /// ce scheme, un login attendu en https que des liens universels. Le path attendu étant celui qu'on
+    /// déclare (AASA pour l'https, redirect_uri pour le scheme), ce matching exact suffit à distinguer
+    /// notre callback des autres liens de l'app.
     nonisolated static func isOurCallback(_ url: URL, expectedCallback expected: URL) -> Bool {
-        url.host?.lowercased() == expected.host?.lowercased()
+        url.scheme?.lowercased() == expected.scheme?.lowercased()
+        && url.host?.lowercased() == expected.host?.lowercased()
         && url.path == expected.path
         && (url.queryValue("code") != nil || url.queryValue("error") != nil)
     }

--- a/Sources/Core/Classes/webauth/WebAuthentication.swift
+++ b/Sources/Core/Classes/webauth/WebAuthentication.swift
@@ -35,21 +35,21 @@ final class WebAuthenticationSession {
     /// Identifie la tentative en cours ; un callback capturant un `attempt` périmé est ignoré.
     private var attempt = 0
     private let baseScheme: String
+    /// La `redirect_uri` du `SdkConfig`, utilisée par défaut quand le mode n'en porte pas (custom scheme).
+    private let sdkRedirectUri: URL
 
-    nonisolated init(baseScheme: String) {
+    nonisolated init(baseScheme: String, sdkRedirectUri: URL) {
         self.baseScheme = baseScheme
+        self.sdkRedirectUri = sdkRedirectUri
     }
 
     /// Démarre un login web et attend son callback (succès, erreur ou annulation). Le ``WebSessionMode``
     /// décrit comment la session se termine — croisement de deux axes (custom scheme vs lien universel,
     /// in-band vs hors-bande) — et pilote donc à la fois la construction de la session et le canal du
-    /// callback. `redirectUri` est la `redirect_uri` déjà résolue (celle du mode, ou à défaut celle du
-    /// `SdkConfig`) : en hors-bande elle sert à reconnaître le lien entrant (``tryComplete(externalCallbackURL:)``).
-    /// Si le `Task` appelant est annulé (vue démontée, timeout…), la feuille est fermée et l'appel se
-    /// termine par `.AuthCanceled`.
+    /// callback. Si le `Task` appelant est annulé (vue démontée, timeout…), la feuille est fermée et
+    /// l'appel se termine par `.AuthCanceled`.
     func start(url: URL,
                mode: WebSessionMode,
-               redirectUri: URL,
                presentationContextProvider: ASWebAuthenticationPresentationContextProviding,
                prefersEphemeralWebBrowserSession: Bool = false) async throws -> URL {
 
@@ -67,7 +67,8 @@ final class WebAuthenticationSession {
             try await withCheckedThrowingContinuation { continuation in
                 self.continuation = continuation
                 // Seul le mode hors-bande arme `tryComplete` ; en in-band, la session se complète elle-même.
-                self.expectedCallback = mode.channel == .outOfBand ? redirectUri : nil
+                // La `redirect_uri` attendue est celle du mode (lien universel) ou, à défaut, celle du SdkConfig.
+                self.expectedCallback = mode.channel == .outOfBand ? (mode.redirectUri ?? sdkRedirectUri) : nil
 
                 let completionHandler: ASWebAuthenticationSession.CompletionHandler = { [weak self] callbackURL, error in
                     // Tout passe sur le main thread pour éviter les situations de compétition.

--- a/Sources/Core/Classes/webauth/WebSessionMode.swift
+++ b/Sources/Core/Classes/webauth/WebSessionMode.swift
@@ -3,7 +3,7 @@ import Foundation
 /// Describes how an `ASWebAuthenticationSession` ends — hence **how it's built** and
 /// **which channel receives the callback**.
 /// Two channels, mutually exclusive for a given login:
-/// - **in-band** (``sdkScheme`` & ``universalLink``): the final redirection is intercepted INSIDE the session's webview,
+/// - **in-band** (``sdkScheme`` & ``universalLink``): the final redirection is intercepted _inside_ the session's webview,
 ///   which then triggers its completion handler.
 /// - **out-of-band** (``externalApp``): the flow ends in an external app that reopens the host app
 ///   via a universal link (`application(_:continue:)` → ``WebAuthenticationSession/tryComplete(externalCallbackURL:)``);
@@ -12,17 +12,17 @@ public enum WebSessionMode {
     /// Custom scheme intercepted by the session (works on all iOS versions). E.g. `reachfive-<clientId>`.
     case sdkScheme
 
-    /// Universal link intercepted INSIDE the webview (iOS 17.4+ via `callback: .https`). Requires
+    /// Universal link intercepted _inside_ the webview (iOS 17.4+ via `callback: .https`). Requires
     /// the `webcredentials:<host>` Associated Domain. Reserve for flows that end
     /// entirely within the sheet (no jump to an external app).
     case universalLink(URL)
 
-    /// OUT-OF-BAND completion: universal link returned by an external app. Requires
+    /// out-of-band completion: universal link returned by an external app. Requires
     /// the `applinks:<host>` Associated Domain on the host app side. The carried value is the expected
     /// `redirect_uri`, recognized by `tryComplete`.
     case externalApp(URL)
 
-    /// The universal link expected OUT-OF-BAND (via `tryComplete`), `nil` in in-band mode.
+    /// The universal link expected out-of-band (via `tryComplete`), `nil` in in-band mode.
     var outOfBandCallback: URL? {
         switch self {
         case .externalApp(let url): url

--- a/Sources/Core/Classes/webauth/WebSessionMode.swift
+++ b/Sources/Core/Classes/webauth/WebSessionMode.swift
@@ -1,41 +1,69 @@
 import Foundation
 
 /// Describes how an `ASWebAuthenticationSession` ends — hence **how it's built** and
-/// **which channel receives the callback**.
-/// Two channels, mutually exclusive for a given login:
-/// - **in-band** (``sdkScheme`` & ``universalLink``): the final redirection is intercepted _inside_ the session's webview,
-///   which then triggers its completion handler.
-/// - **out-of-band** (``externalApp``): the flow ends in an external app that reopens the host app
-///   via a universal link (`application(_:continue:)` → ``WebAuthenticationSession/tryComplete(externalCallbackURL:)``);
-///   the session never sees this callback, so it's opened as a plain web host and then cancelled.
-public enum WebSessionMode {
-    /// Custom scheme intercepted by the session (works on all iOS versions). E.g. `reachfive-<clientId>`.
-    case sdkScheme
-
-    /// Universal link intercepted _inside_ the webview (iOS 17.4+ via `callback: .https`). Requires
-    /// the `webcredentials:<host>` Associated Domain. Reserve for flows that end
-    /// entirely within the sheet (no jump to an external app).
-    case universalLink(URL)
-
-    /// out-of-band completion: universal link returned by an external app. Requires
-    /// the `applinks:<host>` Associated Domain on the host app side. The carried value is the expected
-    /// `redirect_uri`, recognized by `tryComplete`.
-    case externalApp(URL)
-
-    /// The universal link expected out-of-band (via `tryComplete`), `nil` in in-band mode.
-    var outOfBandCallback: URL? {
-        switch self {
-        case .externalApp(let url): url
-        case .sdkScheme, .universalLink: nil
-        }
+/// **which channel receives the callback**. Two orthogonal axes:
+///
+/// - ``Callback``: the shape of the redirection the SDK waits for — a **custom scheme**
+///   (delivered to the app through `application(_:open:)`) or an **HTTPS universal link**
+///   (delivered through `application(_:continue:)`).
+/// - ``Channel``: where the redirection is intercepted — **in-band**, inside the session's own
+///   webview (which then fires its completion handler), or **out-of-band**, when the flow hands
+///   off to an external app that reopens the host app.
+///
+/// Only the four meaningful combinations are reachable, exposed as named factories (the memberwise
+/// init is private). The in-sheet universal link is the sole combination that requires iOS 17.4+,
+/// and its factory is annotated accordingly.
+public struct WebSessionMode {
+    enum Callback {
+        /// Custom scheme (e.g. `reachfive-<clientId>`). `redirect_uri` = the `SdkConfig`'s.
+        case customScheme
+        /// HTTPS universal link. `redirect_uri` = the carried URL.
+        case universalLink(URL)
     }
 
-    /// The OAuth `redirect_uri` carried by the mode; `nil` for ``sdkScheme``, where the `SdkConfig`'s
+    public enum Channel {
+        /// The redirection is intercepted _inside_ the session's webview.
+        case inBand
+        /// The flow ends in an external app that reopens the host app.
+        case outOfBand
+    }
+
+    let callback: Callback
+    let channel: Channel
+
+    private init(callback: Callback, channel: Channel) {
+        self.callback = callback
+        self.channel = channel
+    }
+
+    /// Custom scheme intercepted _inside_ the sheet — the historical flow, on every iOS version.
+    public static let sdkScheme = WebSessionMode(callback: .customScheme, channel: .inBand)
+
+    /// out-of-band: an external app reopens the host app via the custom scheme, delivered through
+    /// `application(_:open:)`. The expected `redirect_uri` is the `SdkConfig`'s.
+    public static let externalAppScheme = WebSessionMode(callback: .customScheme, channel: .outOfBand)
+
+    /// out-of-band: an external app reopens the host app via a universal link, delivered through
+    /// `application(_:continue:)`. Requires the `applinks:<host>` Associated Domain. `link` is the
+    /// expected `redirect_uri`, recognized by `tryComplete`.
+    public static func externalAppUniversalLink(_ link: URL) -> WebSessionMode {
+        WebSessionMode(callback: .universalLink(link), channel: .outOfBand)
+    }
+
+    /// Universal link intercepted _inside_ the webview (iOS 17.4+ via `callback: .https`). Requires the
+    /// `webcredentials:<host>` Associated Domain. Reserve for flows that stay within the sheet (no jump
+    /// to an external app). `link` is the expected `redirect_uri`.
+    @available(iOS 17.4, *)
+    public static func inSheetUniversalLink(_ link: URL) -> WebSessionMode {
+        WebSessionMode(callback: .universalLink(link), channel: .inBand)
+    }
+
+    /// The OAuth `redirect_uri` carried by the mode; `nil` for a custom scheme, where the `SdkConfig`'s
     /// applies instead (both to `/authorize` and to the code exchange).
     var redirectUri: URL? {
-        switch self {
-        case .externalApp(let url), .universalLink(let url): url
-        case .sdkScheme: nil
+        switch callback {
+        case .customScheme: nil
+        case .universalLink(let url): url
         }
     }
 }

--- a/Sources/Core/Classes/webauth/WebSessionMode.swift
+++ b/Sources/Core/Classes/webauth/WebSessionMode.swift
@@ -1,23 +1,12 @@
 import Foundation
 
-/// Describes how an `ASWebAuthenticationSession` ends — hence **how it's built** and
-/// **which channel receives the callback**. Two orthogonal axes:
-///
-/// - ``Callback``: the shape of the redirection the SDK waits for — a **custom scheme**
-///   (delivered to the app through `application(_:open:)`) or an **HTTPS universal link**
-///   (delivered through `application(_:continue:)`).
-/// - ``Channel``: where the redirection is intercepted — **in-band**, inside the session's own
-///   webview (which then fires its completion handler), or **out-of-band**, when the flow hands
-///   off to an external app that reopens the host app.
-///
-/// Only the four meaningful combinations are reachable, exposed as named factories (the memberwise
-/// init is private). The in-sheet universal link is the sole combination that requires iOS 17.4+,
-/// and its factory is annotated accordingly.
+/// How an `ASWebAuthenticationSession` completes, on two orthogonal axes: the ``Callback`` shape (custom
+/// scheme, delivered via `application(_:open:)`, or universal link, via `application(_:continue:)`) and
+/// the ``Channel`` where it's intercepted (in the session's webview, or out-of-band via an external app).
+/// Use the factories below; only the in-sheet universal link needs iOS 17.4+.
 public struct WebSessionMode {
     enum Callback {
-        /// Custom scheme (e.g. `reachfive-<clientId>`). `redirect_uri` = the `SdkConfig`'s.
         case customScheme
-        /// HTTPS universal link. `redirect_uri` = the carried URL.
         case universalLink(URL)
     }
 
@@ -36,30 +25,26 @@ public struct WebSessionMode {
         self.channel = channel
     }
 
-    /// Custom scheme intercepted _inside_ the sheet — the historical flow, on every iOS version.
+    /// Custom scheme intercepted in the sheet — the historical flow, on every iOS version.
     public static let sdkScheme = WebSessionMode(callback: .customScheme, channel: .inBand)
 
-    /// out-of-band: an external app reopens the host app via the custom scheme, delivered through
-    /// `application(_:open:)`. The expected `redirect_uri` is the `SdkConfig`'s.
+    /// An external app reopens the host app via the custom scheme.
     public static let externalAppScheme = WebSessionMode(callback: .customScheme, channel: .outOfBand)
 
-    /// out-of-band: an external app reopens the host app via a universal link, delivered through
-    /// `application(_:continue:)`. Requires the `applinks:<host>` Associated Domain. `link` is the
-    /// expected `redirect_uri`, recognized by `tryComplete`.
+    /// An external app reopens the host app via a universal link. Requires the `applinks:<host>`
+    /// Associated Domain; `link` is the expected `redirect_uri`.
     public static func externalAppUniversalLink(_ link: URL) -> WebSessionMode {
         WebSessionMode(callback: .universalLink(link), channel: .outOfBand)
     }
 
-    /// Universal link intercepted _inside_ the webview (iOS 17.4+ via `callback: .https`). Requires the
-    /// `webcredentials:<host>` Associated Domain. Reserve for flows that stay within the sheet (no jump
-    /// to an external app). `link` is the expected `redirect_uri`.
+    /// Universal link intercepted in the sheet (via `callback: .https`). Requires the
+    /// `webcredentials:<host>` Associated Domain; `link` is the expected `redirect_uri`.
     @available(iOS 17.4, *)
     public static func inSheetUniversalLink(_ link: URL) -> WebSessionMode {
         WebSessionMode(callback: .universalLink(link), channel: .inBand)
     }
 
-    /// The OAuth `redirect_uri` carried by the mode; `nil` for a custom scheme, where the `SdkConfig`'s
-    /// applies instead (both to `/authorize` and to the code exchange).
+    /// The OAuth `redirect_uri` carried by the mode; `nil` for a custom scheme, where the `SdkConfig`'s applies.
     var redirectUri: URL? {
         switch callback {
         case .customScheme: nil

--- a/Sources/Core/Classes/webauth/WebSessionMode.swift
+++ b/Sources/Core/Classes/webauth/WebSessionMode.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// Describes how an `ASWebAuthenticationSession` ends — hence **how it's built** and
+/// **which channel receives the callback**.
+/// Two channels, mutually exclusive for a given login:
+/// - **in-band** (``sdkScheme`` & ``universalLink``): the final redirection is intercepted INSIDE the session's webview,
+///   which then triggers its completion handler.
+/// - **out-of-band** (``externalApp``): the flow ends in an external app that reopens the host app
+///   via a universal link (`application(_:continue:)` → ``WebAuthenticationSession/tryComplete(externalCallbackURL:)``);
+///   the session never sees this callback, so it's opened as a plain web host and then cancelled.
+public enum WebSessionMode {
+    /// Custom scheme intercepted by the session (works on all iOS versions). E.g. `reachfive-<clientId>`.
+    case sdkScheme
+
+    /// Universal link intercepted INSIDE the webview (iOS 17.4+ via `callback: .https`). Requires
+    /// the `webcredentials:<host>` Associated Domain. Reserve for flows that end
+    /// entirely within the sheet (no jump to an external app).
+    case universalLink(URL)
+
+    /// OUT-OF-BAND completion: universal link returned by an external app. Requires
+    /// the `applinks:<host>` Associated Domain on the host app side. The carried value is the expected
+    /// `redirect_uri`, recognized by `tryComplete`.
+    case externalApp(URL)
+
+    /// The universal link expected OUT-OF-BAND (via `tryComplete`), `nil` in in-band mode.
+    var outOfBandCallback: URL? {
+        switch self {
+        case .externalApp(let url): url
+        case .sdkScheme, .universalLink: nil
+        }
+    }
+
+    /// The OAuth `redirect_uri` carried by the mode; `nil` for ``sdkScheme``, where the `SdkConfig`'s
+    /// applies instead (both to `/authorize` and to the code exchange).
+    var redirectUri: URL? {
+        switch self {
+        case .externalApp(let url), .universalLink(let url): url
+        case .sdkScheme: nil
+        }
+    }
+}

--- a/Sources/Reach5.xcodeproj/project.pbxproj
+++ b/Sources/Reach5.xcodeproj/project.pbxproj
@@ -24,7 +24,6 @@
 		2ADFF84F2BFE661300A659FE /* RequestAccountRecoveryRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2ADFF84E2BFE661200A659FE /* RequestAccountRecoveryRequest.swift */; };
 		2AE040E42C88E33900162014 /* AppleProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AE040E32C88E33900162014 /* AppleProvider.swift */; };
 		2AE18CDB29FC1DAF00258D2B /* LoginWKWebview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AE18CDA29FC1DAF00258D2B /* LoginWKWebview.swift */; };
-		2AE326CD2E3A6DC7007D6763 /* WebAuthentication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AE326CC2E3A6DBA007D6763 /* WebAuthentication.swift */; };
 		2AE326D72E3D099B007D6763 /* WebSessionLogoutRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AE326D62E3D098D007D6763 /* WebSessionLogoutRequest.swift */; };
 		2AE533062994629400EF97E0 /* StringUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AE533052994629400EF97E0 /* StringUtils.swift */; };
 		2AE5330B299462DD00EF97E0 /* ReachFiveWebviewLogin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AE53307299462DD00EF97E0 /* ReachFiveWebviewLogin.swift */; };
@@ -126,7 +125,6 @@
 		2ADFF84E2BFE661200A659FE /* RequestAccountRecoveryRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestAccountRecoveryRequest.swift; sourceTree = "<group>"; };
 		2AE040E32C88E33900162014 /* AppleProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleProvider.swift; sourceTree = "<group>"; };
 		2AE18CDA29FC1DAF00258D2B /* LoginWKWebview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginWKWebview.swift; sourceTree = "<group>"; };
-		2AE326CC2E3A6DBA007D6763 /* WebAuthentication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebAuthentication.swift; sourceTree = "<group>"; };
 		2AE326D62E3D098D007D6763 /* WebSessionLogoutRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSessionLogoutRequest.swift; sourceTree = "<group>"; };
 		2AE533052994629400EF97E0 /* StringUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StringUtils.swift; sourceTree = "<group>"; };
 		2AE53307299462DD00EF97E0 /* ReachFiveWebviewLogin.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReachFiveWebviewLogin.swift; sourceTree = "<group>"; };
@@ -269,7 +267,6 @@
 				34B5295922D376FF00B7B6AA /* Pkce.swift */,
 				349E16EF230C49E0002EA06B /* Storage.swift */,
 				2AE533052994629400EF97E0 /* StringUtils.swift */,
-				2AE326CC2E3A6DBA007D6763 /* WebAuthentication.swift */,
 			);
 			path = utils;
 			sourceTree = "<group>";
@@ -639,7 +636,6 @@
 				8496EB4325DEB141005098DD /* AuthenticationToken.swift in Sources */,
 				34BDDA4422E5D95B00D16DAE /* ReachFiveProfile.swift in Sources */,
 				2AE18CDB29FC1DAF00258D2B /* LoginWKWebview.swift in Sources */,
-				2AE326CD2E3A6DC7007D6763 /* WebAuthentication.swift in Sources */,
 				2A1957162E4215AE008393DB /* ReachFiveToken.swift in Sources */,
 				34BDDA4022E5D73900D16DAE /* ReachFiveProviders.swift in Sources */,
 				347FDB67229C02FE00660687 /* ReachFive.swift in Sources */,

--- a/Tests/Reach5Tests/WebAuth/WebAuthCallbackMatchingTests.swift
+++ b/Tests/Reach5Tests/WebAuth/WebAuthCallbackMatchingTests.swift
@@ -1,0 +1,43 @@
+import XCTest
+@testable import Reach5
+
+/// Reconnaissance « est-ce notre callback ? » par forme d'URL (host + path + présence d'un `code` ou d'un `error`).
+final class WebAuthCallbackMatchingTests: XCTestCase {
+
+    private func isOurs(_ incoming: String, expected: String) -> Bool {
+        WebAuthenticationSession.isOurCallback(URL(string: incoming)!, expectedCallback: URL(string: expected)!)
+    }
+
+    func testMatchesSameHostPathWithCode() {
+        XCTAssertTrue(isOurs("https://host.example.com/cb?code=abc&state=x", expected: "https://host.example.com/cb"))
+    }
+
+    func testMatchesErrorCallback() {
+        XCTAssertTrue(isOurs("https://host.example.com/cb?error=access_denied&state=x", expected: "https://host.example.com/cb"))
+    }
+
+    func testRejectsMissingCodeAndError() {
+        XCTAssertFalse(isOurs("https://host.example.com/cb?state=x", expected: "https://host.example.com/cb"))
+    }
+
+    func testRejectsDifferentHost() {
+        XCTAssertFalse(isOurs("https://evil.example.com/cb?code=abc", expected: "https://host.example.com/cb"))
+    }
+
+    func testHostIsCaseInsensitive() {
+        XCTAssertTrue(isOurs("https://HOST.example.com/cb?code=abc", expected: "https://host.EXAMPLE.com/cb"))
+    }
+
+    func testRejectsDifferentPath() {
+        XCTAssertFalse(isOurs("https://host.example.com/other?code=abc", expected: "https://host.example.com/cb"))
+    }
+
+    func testPathIsExactNotPrefix() {
+        XCTAssertFalse(isOurs("https://host.example.com/cbextra?code=abc", expected: "https://host.example.com/cb"))
+        XCTAssertFalse(isOurs("https://host.example.com/cb/sub?code=abc", expected: "https://host.example.com/cb"))
+    }
+
+    func testMatchesWithCodeAmongManyParams() {
+        XCTAssertTrue(isOurs("https://host.example.com/cb?a=1&code=abc&b=2", expected: "https://host.example.com/cb"))
+    }
+}

--- a/Tests/Reach5Tests/WebAuth/WebAuthCallbackMatchingTests.swift
+++ b/Tests/Reach5Tests/WebAuth/WebAuthCallbackMatchingTests.swift
@@ -1,7 +1,7 @@
 import XCTest
 @testable import Reach5
 
-/// Reconnaissance « est-ce notre callback ? » par forme d'URL (host + path + présence d'un `code` ou d'un `error`).
+/// Reconnaissance « est-ce notre callback ? » par forme d'URL (scheme + host + path + présence d'un `code` ou d'un `error`).
 final class WebAuthCallbackMatchingTests: XCTestCase {
 
     private func isOurs(_ incoming: String, expected: String) -> Bool {
@@ -39,5 +39,22 @@ final class WebAuthCallbackMatchingTests: XCTestCase {
 
     func testMatchesWithCodeAmongManyParams() {
         XCTAssertTrue(isOurs("https://host.example.com/cb?a=1&code=abc&b=2", expected: "https://host.example.com/cb"))
+    }
+
+    // MARK: Custom scheme (out-of-band via application(_:open:))
+
+    func testMatchesCustomSchemeCallback() {
+        XCTAssertTrue(isOurs("reachfive-clientId://callback?code=abc", expected: "reachfive-clientId://callback"))
+    }
+
+    func testSchemeIsCaseInsensitive() {
+        XCTAssertTrue(isOurs("REACHFIVE-clientId://callback?code=abc", expected: "reachfive-clientId://callback"))
+    }
+
+    func testRejectsDifferentScheme() {
+        // Même host et path, mais un scheme https ne doit pas matcher un callback attendu en custom scheme
+        // (et inversement) : c'est ce qui sépare les deux canaux hors-bande.
+        XCTAssertFalse(isOurs("https://callback/?code=abc", expected: "reachfive-clientId://callback"))
+        XCTAssertFalse(isOurs("reachfive-clientId://callback?code=abc", expected: "https://callback/"))
     }
 }

--- a/Tests/Reach5Tests/WebAuth/WebviewLoginRequestTests.swift
+++ b/Tests/Reach5Tests/WebAuth/WebviewLoginRequestTests.swift
@@ -24,23 +24,32 @@ final class WebviewLoginRequestTests: XCTestCase {
     }
 
     func testWebSessionModeDefaultsToSdkScheme() {
-        guard case .sdkScheme = WebviewLoginRequest(presentationContextProvider: provider).webSessionMode else {
-            return XCTFail("webSessionMode should default to .sdkScheme")
+        let mode = WebviewLoginRequest(presentationContextProvider: provider).webSessionMode
+        guard case .customScheme = mode.callback, mode.channel == .inBand else {
+            return XCTFail("webSessionMode should default to .sdkScheme (customScheme + inBand)")
         }
     }
 
-    func testExternalAppModeIsPreserved() {
-        let r = WebviewLoginRequest(presentationContextProvider: provider, webSessionMode: .externalApp(URL(string: "https://h/cb")!))
-        guard case .externalApp(let link) = r.webSessionMode else {
-            return XCTFail("webSessionMode should be .externalApp")
+    func testExternalAppSchemeModeIsPreserved() {
+        let mode = WebviewLoginRequest(presentationContextProvider: provider, webSessionMode: .externalAppScheme).webSessionMode
+        guard case .customScheme = mode.callback, mode.channel == .outOfBand else {
+            return XCTFail("webSessionMode should be external-app custom scheme")
+        }
+    }
+
+    func testExternalAppUniversalLinkModeIsPreserved() {
+        let mode = WebviewLoginRequest(presentationContextProvider: provider, webSessionMode: .externalAppUniversalLink(URL(string: "https://h/cb")!)).webSessionMode
+        guard case .universalLink(let link) = mode.callback, mode.channel == .outOfBand else {
+            return XCTFail("webSessionMode should be external-app universal link")
         }
         XCTAssertEqual(link.absoluteString, "https://h/cb")
     }
 
-    func testUniversalLinkModeIsPreserved() {
-        let r = WebviewLoginRequest(presentationContextProvider: provider, webSessionMode: .universalLink(URL(string: "https://h/cb")!))
-        guard case .universalLink(let link) = r.webSessionMode else {
-            return XCTFail("webSessionMode should be .universalLink")
+    func testInSheetUniversalLinkModeIsPreserved() throws {
+        guard #available(iOS 17.4, *) else { throw XCTSkip("In-sheet universal link requires iOS 17.4+") }
+        let mode = WebviewLoginRequest(presentationContextProvider: provider, webSessionMode: .inSheetUniversalLink(URL(string: "https://h/cb")!)).webSessionMode
+        guard case .universalLink(let link) = mode.callback, mode.channel == .inBand else {
+            return XCTFail("webSessionMode should be in-sheet universal link")
         }
         XCTAssertEqual(link.absoluteString, "https://h/cb")
     }

--- a/Tests/Reach5Tests/WebAuth/WebviewLoginRequestTests.swift
+++ b/Tests/Reach5Tests/WebAuth/WebviewLoginRequestTests.swift
@@ -22,4 +22,26 @@ final class WebviewLoginRequestTests: XCTestCase {
     func testProvidedNonceIsPreserved() {
         XCTAssertEqual(WebviewLoginRequest(nonce: "my-nonce", presentationContextProvider: provider).nonce, "my-nonce")
     }
+
+    func testWebSessionModeDefaultsToSdkScheme() {
+        guard case .sdkScheme = WebviewLoginRequest(presentationContextProvider: provider).webSessionMode else {
+            return XCTFail("webSessionMode should default to .sdkScheme")
+        }
+    }
+
+    func testExternalAppModeIsPreserved() {
+        let r = WebviewLoginRequest(presentationContextProvider: provider, webSessionMode: .externalApp(URL(string: "https://h/cb")!))
+        guard case .externalApp(let link) = r.webSessionMode else {
+            return XCTFail("webSessionMode should be .externalApp")
+        }
+        XCTAssertEqual(link.absoluteString, "https://h/cb")
+    }
+
+    func testUniversalLinkModeIsPreserved() {
+        let r = WebviewLoginRequest(presentationContextProvider: provider, webSessionMode: .universalLink(URL(string: "https://h/cb")!))
+        guard case .universalLink(let link) = r.webSessionMode else {
+            return XCTFail("webSessionMode should be .universalLink")
+        }
+        XCTAssertEqual(link.absoluteString, "https://h/cb")
+    }
 }

--- a/docs/modules/ROOT/pages/application/applicationContinueUserActivity.adoc
+++ b/docs/modules/ROOT/pages/application/applicationContinueUserActivity.adoc
@@ -9,11 +9,19 @@ AppDelegate.reachfive().application(<<application, application>>, continue: <<ap
 == Description
 
 Allows {company} to handle user activity continuation such as handoffs, and more importantly, universal links.
-Currently, this method is only used by xref:index.adoc#wechat-connect[WeChat].
 
-Call this to enable the SDK to process activities passed to the app, such as restoring state from another device.
+This method is required by xref:index.adoc#wechat-connect[WeChat] and by any *universal-link provider* (such as B.connect): when an external app reopens your app via a universal link to finish a login, the SDK completes the in-flight web authentication session out-of-band through this hook.
 
-Call this method in response to the equivalent UIKit method link:https://developer.apple.com/documentation/uikit/uiapplicationdelegate/[`application(_:continue:restorationHandler:)`^].
+Call this method in response to the equivalent UIKit method link:https://developer.apple.com/documentation/uikit/uiapplicationdelegate/[`application(_:continue:restorationHandler:)`^]. If your app uses scenes, forward link:https://developer.apple.com/documentation/uikit/uiscenedelegate/[`scene(_:continue:)`^] here as well.
+
+[IMPORTANT]
+====
+The method returns a `Bool` that tells you whether {company} actually consumed the activity. It returns `true` only when a {company} login was waiting for that universal link; otherwise it returns `false` so your app can route the link itself. Do not assume {company} handles every universal link you forward — honour the returned value.
+
+Universal-link delivery requires an `applinks:<host>` Associated Domain (see xref:configure.adoc[Configure the SDK]).
+
+The in-flight login only lives in memory. If iOS terminates your app while the user is in the external app, the login is lost: when the universal link relaunches your app, this method returns `false` and the user must start the login again.
+====
 
 == Examples
 

--- a/docs/modules/ROOT/pages/application/applicationOpenUrl.adoc
+++ b/docs/modules/ROOT/pages/application/applicationOpenUrl.adoc
@@ -12,9 +12,11 @@ Allows {company} to handle URLs in the following format:
 
 * `reachfive-clientId://`
 
+This includes the *custom-scheme out-of-band* login flow: when an external app finishes a login by reopening your app through the SDK's custom scheme, the SDK completes the in-flight web authentication session here. This is the custom-scheme counterpart of the universal-link flow handled by xref:applicationContinueUserActivity.adoc[`application(_:continue:)`].
+
 Additionally, the method allows configured providers to handle their own native links.
 
-Call this method in response to the equivalent UIKit method link:https://developer.apple.com/documentation/uikit/uiapplicationdelegate/[`application(_:open:options)`^].
+Call this method in response to the equivalent UIKit method link:https://developer.apple.com/documentation/uikit/uiapplicationdelegate/[`application(_:open:options)`^]. If your app uses scenes, forward link:https://developer.apple.com/documentation/uikit/uiscenedelegate/[`scene(_:openURLContexts:)`^] here as well.
 
 == Examples
 


### PR DESCRIPTION
<img width="1015" height="529" alt="Capture d’écran 2026-06-19 à 18 26 40" src="https://github.com/user-attachments/assets/53098c84-2f19-4ea1-b1cd-f3836171f84a" />


Remplace #102, recentrée après découpage. **Empilée sur #110** (et contient #109 par merge — leurs commits disparaîtront du diff une fois #109 et #110 mergées).

La feature B.connect proprement dite :

- **`WebSessionMode`** : décrit comment l'`ASWebAuthenticationSession` se termine : app externe, lien custom scheme ou lien universel interne
- **`WebProvider`** : enregistre un provider **web** (sans composant SDK natif) avec sa variante et son mode, ex. `WebProvider(name: .bconnect, mode: .externalApp)`. `DefaultProvider` résout le lien universel de la config provider selon le mode.
