### PR TITLE
Doc : providers web, webSessionMode et guide custom-provider

### DIFF
--- a/docs/modules/ROOT/examples/customProviderProtocols.swift
+++ b/docs/modules/ROOT/examples/customProviderProtocols.swift
@@ -1,0 +1,18 @@
+public protocol ProviderCreator {
+    var name: String { get }
+    var variant: String? { get }
+
+    func create(reachFive: ReachFive, providerConfig: ProviderConfig, clientConfigResponse: ClientConfigResponse) -> Provider
+}
+
+public protocol Provider {
+    var name: String { get }
+    func login(scope: [String]?, origin: String, viewController: UIViewController?) async throws -> AuthToken
+    func logout() async throws
+
+    // Default (no-op) implementations provided — override only what your provider needs:
+    func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any]) -> Bool
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool
+    func applicationDidBecomeActive(_ application: UIApplication)
+    func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool
+}

--- a/docs/modules/ROOT/examples/customProviderWrappingNativeSDK.swift
+++ b/docs/modules/ROOT/examples/customProviderWrappingNativeSDK.swift
@@ -1,0 +1,35 @@
+public class MyProvider: ProviderCreator {
+    public var name: String = "my-provider"
+    public var variant: String?
+
+    public init(variant: String? = nil) {
+        self.variant = variant
+    }
+
+    public func create(reachFive: ReachFive, providerConfig: ProviderConfig, clientConfigResponse: ClientConfigResponse) -> Provider {
+        ConfiguredMyProvider(reachFive: reachFive, providerConfig: providerConfig)
+    }
+}
+
+class ConfiguredMyProvider: NSObject, Provider {
+    let name: String
+    private weak var reachFive: ReachFive? // weak: see the retain-cycle note above
+
+    init(reachFive: ReachFive, providerConfig: ProviderConfig) {
+        self.name = providerConfig.provider
+        self.reachFive = reachFive
+    }
+
+    func login(scope: [String]?, origin: String, viewController: UIViewController?) async throws -> AuthToken {
+        // 1. Drive your native SDK's own login UI/flow here, e.g.:
+        let code = try await MyNativeSDK.shared.login(presenting: viewController)
+
+        // 2. Exchange its authorization code for a ReachFive AuthToken.
+        guard let reachFive else { throw ReachFiveError.TechnicalError(reason: "ReachFive instance was deallocated") }
+        return try await reachFive.authWithCode(code: code, pkce: nil)
+    }
+
+    func logout() {
+        MyNativeSDK.shared.logout()
+    }
+}

--- a/docs/modules/ROOT/examples/providerCreator.swift
+++ b/docs/modules/ROOT/examples/providerCreator.swift
@@ -4,5 +4,7 @@ static let reachfive: ReachFive = ReachFive(
         GoogleProvider(),
         FacebookProvider(),
         AppleProvider(variant: "ios_native"),
-        WeChat()]
+        WeChat(),
+        WebProvider(name: .bconnect, variant: "natif", mode: .externalApp)
+    ]
 )

--- a/docs/modules/ROOT/examples/registerCustomProvider.swift
+++ b/docs/modules/ROOT/examples/registerCustomProvider.swift
@@ -1,0 +1,4 @@
+let reachfive = ReachFive(
+    sdkConfig: SdkConfig(domain: DOMAIN, clientId: CLIENT_ID),
+    providersCreators: [MyProvider(variant: "ios")]
+)

--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -9,6 +9,7 @@
 ** xref:guides/passkeys.adoc[]
 ** xref:guides/migrate-futures.adoc[]
 ** xref:guides/migrate-reach5future.adoc[]
+** xref:guides/custom-provider.adoc[]
 
 .Configuration icon:cogs[]
 ** `application`()

--- a/docs/modules/ROOT/pages/application/applicationContinueUserActivity.adoc
+++ b/docs/modules/ROOT/pages/application/applicationContinueUserActivity.adoc
@@ -18,7 +18,7 @@ Call this method in response to the equivalent UIKit method link:https://develop
 ====
 The method returns a `Bool` that tells you whether {company} actually consumed the activity. It returns `true` only when a {company} login was waiting for that universal link; otherwise it returns `false` so your app can route the link itself. Do not assume {company} handles every universal link you forward — honour the returned value.
 
-Universal-link delivery requires an `applinks:<host>` Associated Domain (see xref:configure.adoc[Configure the SDK]).
+Universal-link delivery requires an `applinks:<host>` Associated Domain (see xref:index.adoc#configure-the-ios-sdk[Configure the SDK]).
 
 The in-flight login only lives in memory. If iOS terminates your app while the user is in the external app, the login is lost: when the universal link relaunches your app, this method returns `false` and the user must start the login again.
 ====

--- a/docs/modules/ROOT/pages/getProvider.adoc
+++ b/docs/modules/ROOT/pages/getProvider.adoc
@@ -19,9 +19,15 @@ Refer at the iOS SDK Installation to initialize the providers at the client's in
 
 == Usage
 
-When using the <<Examples,`viewController`>> property for `.login`, you must ensure that your link:https://developer.apple.com/documentation/uikit/uiviewcontroller[UIViewController^] implements the `ASWebAuthenticationPresentationContextProviding` protocol.
+When calling `.login`, pass a link:https://developer.apple.com/documentation/uikit/uiviewcontroller[UIViewController^] as the <<Examples,`viewController`>> argument.
+Whether it must implement link:https://developer.apple.com/documentation/authenticationservices/aswebauthenticationpresentationcontextproviding[`ASWebAuthenticationPresentationContextProviding`^] depends on how the provider authenticates:
 
-To do this, add the following to your `UIViewController`:
+* *Required* for web-based providers: xref:providerCreator.adoc[`WebProvider`], and any provider with no matching native creator (falls back to `DefaultProvider`).
+These open an `ASWebAuthenticationSession` and need a presentation anchor.
+* *Not required* for native SDK providers (`GoogleProvider`, `FacebookProvider`, `WeChat`).
+`AppleProvider` needs the view controller in the app's view hierarchy instead.
+
+Add the following to your `UIViewController` when the protocol is required:
 
 [source,swift]
 ----
@@ -29,13 +35,6 @@ func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentati
     view.window!
 }
 ----
-
-[NOTE]
-====
-This is not applicable for `.logout`.
-
-This only applies to providers that were not explicitly set in the provider list at configuration time.
-====
 
 == Examples
 

--- a/docs/modules/ROOT/pages/guides/custom-provider.adoc
+++ b/docs/modules/ROOT/pages/guides/custom-provider.adoc
@@ -13,24 +13,7 @@ A provider is made of two pieces, both in `Sources/Core/Classes/Provider.swift`:
 
 [source,swift]
 ----
-public protocol ProviderCreator {
-    var name: String { get }
-    var variant: String? { get }
-
-    func create(reachFive: ReachFive, providerConfig: ProviderConfig, clientConfigResponse: ClientConfigResponse) -> Provider
-}
-
-public protocol Provider {
-    var name: String { get }
-    func login(scope: [String]?, origin: String, viewController: UIViewController?) async throws -> AuthToken
-    func logout() async throws
-
-    // Default (no-op) implementations provided — override only what your provider needs:
-    func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any]) -> Bool
-    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool
-    func applicationDidBecomeActive(_ application: UIApplication)
-    func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool
-}
+include::example$customProviderProtocols.swift[]
 ----
 
 `name` must match the provider's name as configured on your {cc} — this is how ReachFive matches your `ProviderCreator` against the provider configurations it fetches from the backend. A configured provider with no matching creator (and that isn't Apple) still logs in, falling back to a generic web-based `DefaultProvider`.
@@ -44,10 +27,7 @@ Do not store the `reachFive` instance strongly in your `Provider`. ReachFive ret
 
 [source,swift]
 ----
-let reachfive = ReachFive(
-    sdkConfig: SdkConfig(domain: DOMAIN, clientId: CLIENT_ID),
-    providersCreators: [MyProvider(variant: "ios")]
-)
+include::example$registerCustomProvider.swift[]
 ----
 
 == Example: wrapping a native SDK
@@ -56,41 +36,7 @@ This is the shape used by our own `AppleProvider` (link:https://github.com/Reach
 
 [source,swift]
 ----
-public class MyProvider: ProviderCreator {
-    public var name: String = "my-provider"
-    public var variant: String?
-
-    public init(variant: String? = nil) {
-        self.variant = variant
-    }
-
-    public func create(reachFive: ReachFive, providerConfig: ProviderConfig, clientConfigResponse: ClientConfigResponse) -> Provider {
-        ConfiguredMyProvider(reachFive: reachFive, providerConfig: providerConfig)
-    }
-}
-
-class ConfiguredMyProvider: NSObject, Provider {
-    let name: String
-    private weak var reachFive: ReachFive? // weak: see the retain-cycle note above
-
-    init(reachFive: ReachFive, providerConfig: ProviderConfig) {
-        self.name = providerConfig.provider
-        self.reachFive = reachFive
-    }
-
-    func login(scope: [String]?, origin: String, viewController: UIViewController?) async throws -> AuthToken {
-        // 1. Drive your native SDK's own login UI/flow here, e.g.:
-        let code = try await MyNativeSDK.shared.login(presenting: viewController)
-
-        // 2. Exchange its authorization code for a ReachFive AuthToken.
-        guard let reachFive else { throw ReachFiveError.TechnicalError(reason: "ReachFive instance was deallocated") }
-        return try await reachFive.authWithCode(code: code, pkce: nil)
-    }
-
-    func logout() {
-        MyNativeSDK.shared.logout()
-    }
-}
+include::example$customProviderWrappingNativeSDK.swift[]
 ----
 
 == Example: a fully custom web flow

--- a/docs/modules/ROOT/pages/guides/custom-provider.adoc
+++ b/docs/modules/ROOT/pages/guides/custom-provider.adoc
@@ -1,29 +1,37 @@
 = Implement a custom provider
 
-Our built-in provider creators (`GoogleProvider`, `FacebookProvider`, `AppleProvider`, `WeChat`, `WebProvider` — see xref:providerCreator.adoc[]) cover the common cases. This guide is for the rest: a social/SSO provider with its own native SDK, or a login flow that none of the built-ins model.
+Our built-in xref:providerCreator.adoc[provider creators] cover the most common use cases for provider creation:
 
-TIP: If your provider has no native SDK component and only needs to choose *how* its `ASWebAuthenticationSession` returns to the app (custom scheme, universal link, out-of-band), you don't need a custom provider at all — configure a xref:providerCreator.adoc[`WebProvider`] instead.
+* `GoogleProvider`
+* `FacebookProvider`
+* `AppleProvider`
+* `WeChat`
+* `WebProvider`
+
+This custom provider guide instructs you how to implement a provider that none of the built-ins model such as a social/SSO provider with its own native SDK, or a login flow that none of the built-ins model.
+
+If your provider has no native SDK component and only needs to choose *how* its `ASWebAuthenticationSession` returns to the app (custom scheme, universal link, out-of-band), you don't need a custom provider, instead configure a xref:providerCreator.adoc[`WebProvider`].
 
 == The two protocols
 
-A provider is made of two pieces, both in `Sources/Core/Classes/Provider.swift`:
+A provider is made of two pieces, both found in `Sources/Core/Classes/Provider.swift`:
 
-* `ProviderCreator`: a lightweight factory you list in `ReachFive(providersCreators:)`. It only carries a `name` and an optional `variant`, and builds the actual `Provider` once ReachFive has fetched that provider's configuration from the backend.
-* `Provider`: the object doing the actual work — `login`, `logout`, and the app-lifecycle hooks it needs to intercept its own callback.
-
+* `ProviderCreator`: a lightweight factory you list in `ReachFive(providersCreators:)`. 
+It carries a `name` and an optional `variant` and builds the actual `Provider` once {company} has fetched that provider's configuration from the backend.
+Its `create` method also receives the shared `ReachFive` instance.
+See <<Example: wrapping a native SDK>> for how to hold that reference safely in the `Provider` you return.
+* `Provider`: the object doing the actual work: `login`, `logout`, and the app-lifecycle hooks it needs to intercept its own callback.
++
 [source,swift]
 ----
 include::example$customProviderProtocols.swift[]
 ----
 
-`name` must match the provider's name as configured on your {cc} — this is how ReachFive matches your `ProviderCreator` against the provider configurations it fetches from the backend. A configured provider with no matching creator (and that isn't Apple) still logs in, falling back to a generic web-based `DefaultProvider`.
+IMPORTANT: `name` must match the provider's name as configured on your {cc}.
+This is how {company} matches your `ProviderCreator` against the provider configurations it fetches from the backend.
+A configured provider with no matching creator still logs in, falling back to either native Sign in with Apple or a generic web-based provider.
 
-[CAUTION]
-====
-Do not store the `reachFive` instance strongly in your `Provider`. ReachFive retains its providers, so a strong back-reference creates a retain cycle (`ReachFive` ↔ `Provider`) and the whole SDK graph never gets deallocated. Hold it `weak`, or copy the values you need (`sdkConfig`, `reachFiveApi`, `scope`, …) at creation time instead.
-====
-
-== Register it
+== Register the custom provider
 
 [source,swift]
 ----
@@ -32,7 +40,23 @@ include::example$registerCustomProvider.swift[]
 
 == Example: wrapping a native SDK
 
-This is the shape used by our own `AppleProvider` (link:https://github.com/ReachFive/reachfive-ios/blob/master/Sources/Core/Classes/AppleProvider.swift[source^]): the creator is a thin factory, and the actual `Provider` calls into the third-party native SDK, then exchanges its result for a {company} `AuthToken` — here through `reachFive.authWithCode`, which is the same helper used internally by native login.
+This is the shape used by our own (link:https://github.com/ReachFive/reachfive-ios/blob/master/Sources/Core/Classes/AppleProvider.swift[`AppleProvider.swift`^]): 
+
+* The creator is a thin factory.
+* The actual `Provider` calls into the third-party native SDK, then exchanges its result for a {company} `AuthToken` through `reachFive.authWithCode`, which is the same helper used internally by native login.
+
+Your `create` method receives the shared `ReachFive` instance, which the SDK also stores in `ReachFive.providers`.
+When you build your `Provider`, decide how to access it from `login`:
+
+[CAUTION]
+====
+When `create(reachFive:)` runs, the SDK has already decided to keep your `Provider` in `ReachFive.providers`.
+If your provider also keeps a *strong* reference back to that same `ReachFive` instance, neither object can ever be released — a *retain cycle* (`ReachFive` ↔ `Provider`) that pins the whole SDK object graph in memory.
+
+Use `weak var reachFive` in your provider, or copy only the properties you need at init time (e.g. `sdkConfig`, `reachFiveApi`, `scope`).
+
+For background on why this happens and how `weak` breaks the cycle, see link:https://docs.swift.org/swift-book/documentation/the-swift-programming-language/automaticreferencecounting/#Strong-Reference-Cycles-Between-Class-Instances[Apple: strong reference cycles between class instances^] and link:https://docs.swift.org/swift-book/documentation/the-swift-programming-language/automaticreferencecounting/#Weak-References[`weak` references^].
+====
 
 [source,swift]
 ----
@@ -51,16 +75,25 @@ Only implement the hooks your provider actually needs to intercept its own callb
 |===
 |Hook |When to implement it
 
-|application(_:open:options:)
+|xref:application/applicationOpenUrl.adoc[application(_:open:options:)]
 |Your provider's callback arrives through a custom URL scheme (`myapp://...`) rather than the completion handler of `ASWebAuthenticationSession`.
 
-|application(_:didFinishLaunchingWithOptions:)
-|Your provider's native SDK needs an explicit startup call (e.g. registering itself before the app finishes launching).
+|xref:application/applicationDidFinishLaunchingWithOptions.adoc[application(_:didFinishLaunchingWithOptions:)]
+|Your provider's native SDK needs an explicit startup call.
 
-|applicationDidBecomeActive(_:)
-|Your provider needs to react to the app returning to the foreground (e.g. resuming a paused native SDK session).
+An example of this is registering itself before the app finishes launching.
 
-|application(_:continue:restorationHandler:)
-|Your provider's callback arrives as a *universal link* (`NSUserActivityTypeBrowsingWeb`) — e.g. an out-of-band flow like `WebProvider` `.externalApp` mode. Return `true` only if you actually consumed the activity; ReachFive relies on that return value (see xref:application/applicationContinueUserActivity.adoc[]).
+|xref:application/applicationDidBecomeActive.adoc[applicationDidBecomeActive(_:)]
+|Your provider needs to react to the app returning to the foreground.
+
+An example of this is resuming a paused native SDK session.
+
+|xref:application/applicationContinueUserActivity.adoc[application(_:continue:restorationHandler:)]
+|Your provider's callback arrives as a *universal link* (`NSUserActivityTypeBrowsingWeb`).
+
+An example of this is an out-of-band flow like `WebProvider` `.externalApp` mode. 
+
+Return `true` only if you actually consumed the activity.
+{company} relies on that return value (see xref:application/applicationContinueUserActivity.adoc[] for details).
 
 |===

--- a/docs/modules/ROOT/pages/guides/custom-provider.adoc
+++ b/docs/modules/ROOT/pages/guides/custom-provider.adoc
@@ -1,0 +1,120 @@
+= Implement a custom provider
+
+Our built-in provider creators (`GoogleProvider`, `FacebookProvider`, `AppleProvider`, `WeChat`, `WebProvider` — see xref:providerCreator.adoc[]) cover the common cases. This guide is for the rest: a social/SSO provider with its own native SDK, or a login flow that none of the built-ins model.
+
+TIP: If your provider has no native SDK component and only needs to choose *how* its `ASWebAuthenticationSession` returns to the app (custom scheme, universal link, out-of-band), you don't need a custom provider at all — configure a xref:providerCreator.adoc[`WebProvider`] instead.
+
+== The two protocols
+
+A provider is made of two pieces, both in `Sources/Core/Classes/Provider.swift`:
+
+* `ProviderCreator`: a lightweight factory you list in `ReachFive(providersCreators:)`. It only carries a `name` and an optional `variant`, and builds the actual `Provider` once ReachFive has fetched that provider's configuration from the backend.
+* `Provider`: the object doing the actual work — `login`, `logout`, and the app-lifecycle hooks it needs to intercept its own callback.
+
+[source,swift]
+----
+public protocol ProviderCreator {
+    var name: String { get }
+    var variant: String? { get }
+
+    func create(reachFive: ReachFive, providerConfig: ProviderConfig, clientConfigResponse: ClientConfigResponse) -> Provider
+}
+
+public protocol Provider {
+    var name: String { get }
+    func login(scope: [String]?, origin: String, viewController: UIViewController?) async throws -> AuthToken
+    func logout() async throws
+
+    // Default (no-op) implementations provided — override only what your provider needs:
+    func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any]) -> Bool
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool
+    func applicationDidBecomeActive(_ application: UIApplication)
+    func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool
+}
+----
+
+`name` must match the provider's name as configured on your {cc} — this is how ReachFive matches your `ProviderCreator` against the provider configurations it fetches from the backend. A configured provider with no matching creator (and that isn't Apple) still logs in, falling back to a generic web-based `DefaultProvider`.
+
+[CAUTION]
+====
+Do not store the `reachFive` instance strongly in your `Provider`. ReachFive retains its providers, so a strong back-reference creates a retain cycle (`ReachFive` ↔ `Provider`) and the whole SDK graph never gets deallocated. Hold it `weak`, or copy the values you need (`sdkConfig`, `reachFiveApi`, `scope`, …) at creation time instead.
+====
+
+== Register it
+
+[source,swift]
+----
+let reachfive = ReachFive(
+    sdkConfig: SdkConfig(domain: DOMAIN, clientId: CLIENT_ID),
+    providersCreators: [MyProvider(variant: "ios")]
+)
+----
+
+== Example: wrapping a native SDK
+
+This is the shape used by our own `AppleProvider` (link:https://github.com/ReachFive/reachfive-ios/blob/master/Sources/Core/Classes/AppleProvider.swift[source^]): the creator is a thin factory, and the actual `Provider` calls into the third-party native SDK, then exchanges its result for a {company} `AuthToken` — here through `reachFive.authWithCode`, which is the same helper used internally by native login.
+
+[source,swift]
+----
+public class MyProvider: ProviderCreator {
+    public var name: String = "my-provider"
+    public var variant: String?
+
+    public init(variant: String? = nil) {
+        self.variant = variant
+    }
+
+    public func create(reachFive: ReachFive, providerConfig: ProviderConfig, clientConfigResponse: ClientConfigResponse) -> Provider {
+        ConfiguredMyProvider(reachFive: reachFive, providerConfig: providerConfig)
+    }
+}
+
+class ConfiguredMyProvider: NSObject, Provider {
+    let name: String
+    private weak var reachFive: ReachFive? // weak: see the retain-cycle note above
+
+    init(reachFive: ReachFive, providerConfig: ProviderConfig) {
+        self.name = providerConfig.provider
+        self.reachFive = reachFive
+    }
+
+    func login(scope: [String]?, origin: String, viewController: UIViewController?) async throws -> AuthToken {
+        // 1. Drive your native SDK's own login UI/flow here, e.g.:
+        let code = try await MyNativeSDK.shared.login(presenting: viewController)
+
+        // 2. Exchange its authorization code for a ReachFive AuthToken.
+        guard let reachFive else { throw ReachFiveError.TechnicalError(reason: "ReachFive instance was deallocated") }
+        return try await reachFive.authWithCode(code: code, pkce: nil)
+    }
+
+    func logout() {
+        MyNativeSDK.shared.logout()
+    }
+}
+----
+
+== Example: a fully custom web flow
+
+If your provider has no native SDK but needs behaviour `WebProvider` doesn't offer, drive `ASWebAuthenticationSession` yourself (or reuse `reachFive.webviewLogin(_:)`, see xref:webviewLogin.adoc[]) inside `login`, then return the resulting `AuthToken` the same way.
+
+== App-lifecycle hooks
+
+Only implement the hooks your provider actually needs to intercept its own callback; every other hook has a default no-op implementation.
+
+[cols="3m,7a"]
+|===
+|Hook |When to implement it
+
+|application(_:open:options:)
+|Your provider's callback arrives through a custom URL scheme (`myapp://...`) rather than the completion handler of `ASWebAuthenticationSession`.
+
+|application(_:didFinishLaunchingWithOptions:)
+|Your provider's native SDK needs an explicit startup call (e.g. registering itself before the app finishes launching).
+
+|applicationDidBecomeActive(_:)
+|Your provider needs to react to the app returning to the foreground (e.g. resuming a paused native SDK session).
+
+|application(_:continue:restorationHandler:)
+|Your provider's callback arrives as a *universal link* (`NSUserActivityTypeBrowsingWeb`) — e.g. an out-of-band flow like `WebProvider` `.externalApp` mode. Return `true` only if you actually consumed the activity; ReachFive relies on that return value (see xref:application/applicationContinueUserActivity.adoc[]).
+
+|===

--- a/docs/modules/ROOT/pages/loadLoginWebview.adoc
+++ b/docs/modules/ROOT/pages/loadLoginWebview.adoc
@@ -22,6 +22,8 @@ include::docs:ROOT:partial$general/snippets/r_orchestrated-flows-min-version.ado
 
 CAUTION: We recommend using the standard native login or standard webview login for iOS. Proceed with caution while using this particular method for user authentication.
 
+CAUTION: *Universal-link* providers are not supported by this method: their out-of-band callback is delivered through `application(_:continue:)` and completes the session held by `ReachFive` itself, not this embedded webview. Use xref:webviewLogin.adoc[] (with a `WebProvider`, see xref:providerCreator.adoc[]) for them instead.
+
 == Examples
 
 [source, swift]

--- a/docs/modules/ROOT/pages/providerCreator.adoc
+++ b/docs/modules/ROOT/pages/providerCreator.adoc
@@ -27,6 +27,8 @@ Otherwise, the default variant is chosen.
 |===
 |Name |Description
 
-include::partial$config/params.adoc[tags="GoogleProvider,FacebookProvider,AppleProvider,WeChat"]
+include::partial$config/params.adoc[tags="GoogleProvider,FacebookProvider,AppleProvider,WeChat,WebProvider"]
 
 |===
+
+TIP: None of these fit your case? See xref:guides/custom-provider.adoc[] to implement your own.

--- a/docs/modules/ROOT/pages/providerCreator.adoc
+++ b/docs/modules/ROOT/pages/providerCreator.adoc
@@ -5,7 +5,7 @@ These specific providers use native calls or external libraries to authenticate 
 
 All providers except xref:docs:ROOT:apple.adoc[Apple] that you configure in the {cc} for which you don't use a specific provider creator will authenticate through an `ASWebAuthenticationSession`.
 
-You should define and configure these providers when you xref:index.adoc#configuration-5[configure the iOS SDK].
+You should define and configure these providers when you xref:index.adoc#configure-the-ios-sdk[configure the iOS SDK].
 
 == Examples
 
@@ -30,5 +30,49 @@ Otherwise, the default variant is chosen.
 include::partial$config/params.adoc[tags="GoogleProvider,FacebookProvider,AppleProvider,WeChat,WebProvider"]
 
 |===
+
+== Universal-link web providers
+
+Some web providers finish login on an *https* universal link instead of the custom scheme.
+Use the checklist for your <<WebProvider,`WebProvider`>> `mode`; you do *not* need xref:guides/custom-provider.adoc[a custom provider] unless none of the built-in options fit.
+
+[tabs]
+====
+`.externalApp`::
++
+--
+Login may hand off to an external app (e.g. a banking app) that reopens yours via a universal link.
+
+[%interactive]
+* [ ] Configure the provider and variant on your {cc}.
+* [ ] Whitelist the provider's `universalLink` URL in *Allowed Callback URLs* (see xref:docs:ROOT:clients.adoc[Clients]).
+* [ ] Register a <<WebProvider,`WebProvider`>> with `mode: .externalApp` in `ReachFive(providersCreators:)`.
+* [ ] Initialize the SDK so provider configurations are fetched and `getProvider` can resolve your provider (see xref:application/applicationDidFinishLaunchingWithOptions.adoc[`applicationDidFinishLaunchingWithOptions(_:)`]).
+* [ ] Add `applinks:$\{host\}` to Associated Domains and the matching `applinks` section in `apple-app-site-association` (see xref:index.adoc#associated-domains-universal-link-providers[`apple-app-site-association`]).
+* [ ] Forward `application(_:continue:restorationHandler:)` to {company} and honour the returned `Bool` (see xref:application/applicationContinueUserActivity.adoc[`application(_:continue:restorationHandler:)`]).
+* [ ] Call xref:getProvider.adoc[`getProvider(name:).login(...)`] from a `UIViewController` that implements `ASWebAuthenticationPresentationContextProviding`.
+
+Do *not* use xref:loadLoginWebview.adoc[`loadLoginWebview`]: the callback is delivered through xref:application/applicationContinueUserActivity.adoc[`application(_:continue:)`], not an embedded webview.
+
+If iOS terminates your app while the user is in the external app, the in-flight login is lost and must be restarted (see xref:application/applicationContinueUserActivity.adoc[`application(_:continue:restorationHandler:)`]).
+--
+`.universalLink` (iOS 17.4+)::
++
+--
+This is the same flow as the default custom-scheme login, but the OAuth `redirect_uri` is the provider's `https://` universal link and the authentication sheet intercepts it *in-band* meaning no external-app handoff.
+
+[%interactive]
+* [ ] Configure the provider and variant on your {cc}.
+* [ ] Whitelist the provider's `universalLink` URL in *Allowed Callback URLs* (see xref:docs:ROOT:clients.adoc[Clients]).
+* [ ] Register a <<WebProvider,`WebProvider`>> with `mode: .universalLink` in `ReachFive(providersCreators:)` (iOS 17.4+).
+* [ ] Initialize the SDK so provider configurations are fetched and `getProvider` can resolve your provider (see xref:application/applicationDidFinishLaunchingWithOptions.adoc[`applicationDidFinishLaunchingWithOptions(_:)`]).
+* [ ] Add `webcredentials:$\{host\}` to Associated Domains and the matching `webcredentials` section in `apple-app-site-association` (see xref:index.adoc#associated-domains-universal-link-providers[`apple-app-site-association`]).
+* [ ] Call xref:getProvider.adoc[`getProvider(name:).login(...)`] from a `UIViewController` that implements `ASWebAuthenticationPresentationContextProviding`.
+
+No `application(_:continue:)` wiring is required for login completion; the `ASWebAuthenticationSession` completes inside the sheet.
+
+Do *not* use xref:loadLoginWebview.adoc[`loadLoginWebview`]: use `WebProvider` or xref:webviewLogin.adoc[`webviewLogin`] with a secure session instead of an embedded webview.
+--
+====
 
 TIP: None of these fit your case? See xref:guides/custom-provider.adoc[] to implement your own.

--- a/docs/modules/ROOT/pages/webviewLogin.adoc
+++ b/docs/modules/ROOT/pages/webviewLogin.adoc
@@ -11,11 +11,13 @@ AppDelegate.reachfive().{docname}(WebviewLoginRequest(
     <<scope>>, <1>
     <<origin>>,
     <<prefersEphemeralWebBrowserSession>>, <2>
+    <<webSessionMode>>, <3>
 ))
 ----
 <1> Scope isn't explicitly required.
 If not provided here, it defaults to the scopes set up in the client configuration which is picked up when you initialize the iOS SDK.
 <2> Available starting with version 7.1.3
+<3> Optional, defaults to `.sdkScheme`. Use `.externalApp`/`.universalLink` for providers that finish their login on a universal link — see xref:providerCreator.adoc[WebProvider].
 
 == Description
 
@@ -67,6 +69,7 @@ include::partial$params.adoc[tag="nonce"]
 include::partial$params.adoc[tag="scope"]
 include::partial$params.adoc[tag="origin"]
 include::partial$params.adoc[tag="prefersEphemeralWebBrowserSession"]
+include::partial$params.adoc[tag="webSessionMode"]
 
 |===
 

--- a/docs/modules/ROOT/partials/config/params.adoc
+++ b/docs/modules/ROOT/partials/config/params.adoc
@@ -19,7 +19,7 @@ GoogleProvider(variant: "native") <1>
 This provider takes two optional parameters:
 
 * variant `string`: the provider variant to use.
-* prefersLoginTracking `FBSDKLoginKit.LoginTracking`: Indicates preference to the Facebook SDK for the limited or classic login. 
+* prefersLoginTracking `FBSDKLoginKit.LoginTracking`: Indicates preference to the Facebook SDK for the limited or classic login.
 Facebook SDK is ultimately responsible for the decision.
 
 [source,swift]
@@ -59,3 +59,26 @@ WeChat() <1>
 <1> WeChat takes no parameters.
 
 // end::WeChat[]
+
+// tag::WebProvider[]
+|[[WebProvider,WebProvider]]WebProvider
+|The object for configuring a **web-only** provider — one with no native SDK component, authenticated entirely through an `ASWebAuthenticationSession`.
+
+Takes a `name` (one of `.facebook`, `.google`, `.line`, `.bconnect`), an optional `variant`, and a `mode` controlling how the session's redirection reaches the app:
+
+* `.sdkScheme` (default): custom scheme, works on all supported iOS versions.
+* `.externalApp`: *out-of-band* — the flow ends in an external app (e.g. a banking app) that reopens yours via a universal link, forwarded to {company} through xref:application/applicationContinueUserActivity.adoc[]. Requires the `applinks:` Associated Domain.
+* `.universalLink` (iOS 17.4+): *in-band* — the universal-link redirect is intercepted directly inside the authentication sheet. Requires the `webcredentials:` Associated Domain.
+
+See the "Associated Domains" section of xref:index.adoc[] for the entitlement setup.
+
+[source,swift]
+----
+WebProvider(name: .bconnect, variant: "natif", mode: .externalApp)
+----
+
+NOTE: A provider configured on your client with no matching entry in `providersCreators` still logs in, falling back to `.sdkScheme` automatically. Add an explicit `WebProvider` only when you need `.externalApp`/`.universalLink`, or a specific `variant`.
+
+TIP: To implement your own provider (native SDK, custom flow) instead, see xref:guides/custom-provider.adoc[].
+
+// end::WebProvider[]

--- a/docs/modules/ROOT/partials/config/params.adoc
+++ b/docs/modules/ROOT/partials/config/params.adoc
@@ -79,6 +79,8 @@ WebProvider(name: .bconnect, variant: "natif", mode: .externalApp)
 
 NOTE: A provider configured on your client with no matching entry in `providersCreators` still logs in, falling back to `.sdkScheme` automatically. Add an explicit `WebProvider` only when you need `.externalApp`/`.universalLink`, or a specific `variant`.
 
+TIP: Integrating a universal-link provider? See xref:providerCreator.adoc#universal-link-web-providers[the universal-link checklist].
+
 TIP: To implement your own provider (native SDK, custom flow) instead, see xref:guides/custom-provider.adoc[].
 
 // end::WebProvider[]

--- a/docs/modules/ROOT/partials/models.adoc
+++ b/docs/modules/ROOT/partials/models.adoc
@@ -149,6 +149,8 @@ The provider which name matches the name passed in argument.
 - `franceconnect`
 - `apple`
 - `oney`
+- `bconnect`
+- `line`
 
 | login `function` | Expect the following arguments:
 

--- a/docs/modules/ROOT/partials/params.adoc
+++ b/docs/modules/ROOT/partials/params.adoc
@@ -404,6 +404,18 @@ TIP: For more, see link:https://developer.apple.com/documentation/authentication
 
 // end::prefersEphemeralWebBrowserSession[]
 
+// tag::webSessionMode[]
+|[[webSessionMode,webSessionMode]] webSessionMode `WebSessionMode`
+|Controls the return channel of the `ASWebAuthenticationSession` and its `redirect_uri`. Defaults to `.sdkScheme`.
+
+.Values
+* `.sdkScheme`: custom scheme, intercepted inside the session. Works on all supported iOS versions.
+* `.universalLink(URL)`: universal link intercepted inside the session (iOS 17.4+). Requires the `webcredentials:` Associated Domain.
+* `.externalApp(URL)`: *out-of-band* — an external app reopens the host app via the universal link, forwarded to {company} through xref:application/applicationContinueUserActivity.adoc[]. Requires the `applinks:` Associated Domain.
+
+TIP: See the "Associated Domains" section of xref:index.adoc[] for entitlement setup, and the xref:providerCreator.adoc[WebProvider] entry for a ready-made provider using this mechanism.
+// end::webSessionMode[]
+
 // tag::state[]
 |[[state,state]] state `string`
 |The OAuth2 state value.

--- a/docs/modules/ROOT/partials/params.adoc
+++ b/docs/modules/ROOT/partials/params.adoc
@@ -284,6 +284,8 @@ If `expiresIn` is less than or equal to `0`, the `AuthToken` is expired.
 - `franceconnect`
 - `apple`
 - `oney`
+- `bconnect`
+- `line`
 
 // end::name[]
 

--- a/docs/modules/ROOT/partials/r_configure.adoc
+++ b/docs/modules/ROOT/partials/r_configure.adoc
@@ -70,6 +70,29 @@ let ReachFive = ReachFive(
 <2> Where the callback mfaUri `scheme` ends with `myOwnMfaScheme`.
 <3> Where the callback accountRecoveryUri `scheme` ends with `myOwnRecoveryScheme`.
 
+=== Associated Domains (universal-link providers)
+
+Some providers (such as B.connect) finish their login on an *https universal link* instead of the custom scheme. To support them, declare the universal-link host in your app's *Associated Domains* entitlement with *two* service types, and host a matching `apple-app-site-association` file on that host:
+
+[cols="4m,6a"]
+|===
+|Entry |Role
+
+|applinks:$\{host\}
+|*Out-of-band* return (all iOS versions). When an external app (e.g. a bank) reopens your app via the universal link, iOS delivers it to `application(_:continue:)`, which you must forward to {company} (see xref:application/applicationContinueUserActivity.adoc[]).
+
+|webcredentials:$\{host\}
+|*In-band* completion on *iOS 17.4+*. Lets `ASWebAuthenticationSession` intercept the redirect to the universal link directly inside its web view, without leaving the app. If this entry (or the association file) is missing, the session fails to start.
+
+|===
+
+`$\{host\}` is the host of the `universalLink` returned by {company} for that provider. Both the entitlement entry and the `apple-app-site-association` file are required for iOS to honour the domain.
+
+[NOTE]
+====
+If the association file restricts the callback path with a `components` filter, make sure it lets through both the success callback (`?code=...`) *and* the OAuth error callback (`?error=...`, e.g. when the user denies consent), so that the SDK can end the login cleanly with the error instead of leaving the authentication sheet open.
+====
+
 === Customise storage
 
 Storage is used by the iOS SDK to store the PKCE code during passwordless and MFA flows.

--- a/docs/modules/ROOT/partials/r_configure.adoc
+++ b/docs/modules/ROOT/partials/r_configure.adoc
@@ -88,9 +88,32 @@ Some providers (such as B.connect) finish their login on an *https universal lin
 
 `$\{host\}` is the host of the `universalLink` returned by {company} for that provider. Both the entitlement entry and the `apple-app-site-association` file are required for iOS to honour the domain.
 
+The file must be served at `\https://$\{host\}/.well-known/apple-app-site-association` with a `200` response and a JSON `Content-Type`; a redirect or a non-JSON content type causes verification to fail.
+
+.apple-app-site-association example
+[source,json]
+----
+{
+  "applinks": {
+    "details": [
+      {
+        "appIDs": ["ABCDE12345.com.example.app"], <1>
+        "components": [
+          {"/": "/_dev/mobile/callback"} <2>
+        ]
+      }
+    ]
+  },
+  "webcredentials": {"apps": ["ABCDE12345.com.example.app"]} <3>
+}
+----
+<1> `<Application Identifier Prefix>.<Bundle Identifier>`.
+<2> Restrict to the callback path of the `universalLink` returned by {company} for this provider. Omit the whole `components` array to match every path on the host.
+<3> Only needed if you also declare `webcredentials:$\{host\}` (`.universalLink` in-band mode), or use xref:guides/passkeys.adoc[passkeys] on the same host.
+
 [NOTE]
 ====
-If the association file restricts the callback path with a `components` filter, make sure it lets through both the success callback (`?code=...`) *and* the OAuth error callback (`?error=...`, e.g. when the user denies consent), so that the SDK can end the login cleanly with the error instead of leaving the authentication sheet open.
+If you restrict `components` to a path, make sure it lets through both the success callback (`?code=...`) *and* the OAuth error callback (`?error=...`, e.g. when the user denies consent), so that the SDK can end the login cleanly with the error instead of leaving the authentication sheet open.
 ====
 
 === Customise storage

--- a/docs/modules/ROOT/partials/r_configure.adoc
+++ b/docs/modules/ROOT/partials/r_configure.adoc
@@ -72,23 +72,38 @@ let ReachFive = ReachFive(
 
 === Associated Domains (universal-link providers)
 
-Some providers (such as B.connect) finish their login on an *https universal link* instead of the custom scheme. To support them, declare the universal-link host in your app's *Associated Domains* entitlement with *two* service types, and host a matching `apple-app-site-association` file on that host:
+Some providers (such as B.connect) finish their login on an *https universal link* instead of the custom scheme.
+Which Associated Domains entry you declare depends on your xref:providerCreator.adoc[`WebProvider`] mode—add `applinks:$\{host\}` for `.externalApp`, or `webcredentials:$\{host\}` for `.universalLink` (iOS 17.4+).
+Declare both only if you support both modes on the same host, or also use xref:guides/passkeys.adoc[passkeys] on that host.
+Host a matching `apple-app-site-association` file on `$\{host\}` with the sections that match the entitlements you declared.
 
 [cols="4m,6a"]
 |===
 |Entry |Role
 
 |applinks:$\{host\}
-|*Out-of-band* return (all iOS versions). When an external app (e.g. a bank) reopens your app via the universal link, iOS delivers it to `application(_:continue:)`, which you must forward to {company} (see xref:application/applicationContinueUserActivity.adoc[]).
+|*Out-of-band* return (all iOS versions).
+When an external app (e.g. a bank) reopens your app via the universal link, iOS delivers it to `application(_:continue:)`, which you must forward to {company}.
+See xref:application/applicationContinueUserActivity.adoc[] for details.
 
 |webcredentials:$\{host\}
-|*In-band* completion on *iOS 17.4+*. Lets `ASWebAuthenticationSession` intercept the redirect to the universal link directly inside its web view, without leaving the app. If this entry (or the association file) is missing, the session fails to start.
+|*In-band* completion on *iOS 17.4+*. 
+Lets `ASWebAuthenticationSession` intercept the redirect to the universal link directly inside its web view, without leaving the app. 
+If this entry (or the association file) is missing, the session fails to start.
 
 |===
 
-`$\{host\}` is the host of the `universalLink` returned by {company} for that provider. Both the entitlement entry and the `apple-app-site-association` file are required for iOS to honour the domain.
+`$\{host\}` is the host of the `universalLink` returned by {company} for that provider.
+An `apple-app-site-association` file on that host is always required; include the `applinks` and/or `webcredentials` sections that correspond to the Associated Domains entries you declared above.
+
+IMPORTANT: Whitelist the full `universalLink` URL (e.g. `https://$\{host\}/path/to/callback`) in *Allowed Callback URLs* on your {cc} in addition to the custom-scheme entries above.
+The SDK sends this URL as the OAuth `redirect_uri` for both `/authorize` and the code exchange when using xref:providerCreator.adoc[`WebProvider`] with `.externalApp` or `.universalLink`, or xref:webviewLogin.adoc[`webviewLogin`] with a matching `webSessionMode`.
+Use the exact URL returned in your provider configuration for the chosen variant—the same value that supplies `$\{host\}` and the callback path below.
+See xref:docs:ROOT:clients.adoc[] for how to configure Allowed Callback URLs.
 
 The file must be served at `\https://$\{host\}/.well-known/apple-app-site-association` with a `200` response and a JSON `Content-Type`; a redirect or a non-JSON content type causes verification to fail.
+
+The sample below includes both sections for a host used in both modes; for `.externalApp` only, include `applinks` and omit `webcredentials`.
 
 .apple-app-site-association example
 [source,json]


### PR DESCRIPTION
Documentation for the B.connect feature (CA-6191), **stacked on #111**:

- New guide `guides/custom-provider.adoc`: implementing your own `ProviderCreator`.
- `WebProvider` entry in the configuration params (`.sdkScheme`/`.externalApp`/`.universalLink` modes, required Associated Domains).
- `webSessionMode` param of `webviewLogin`, cross-references from `providerCreator.adoc` and `webviewLogin.adoc`.
- Note on `loadLoginWebview`: universal-link providers aren't supported there.
- Associated Domains section in `r_configure.adoc`, including an `apple-app-site-association` example combining `applinks` and `webcredentials`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)