### PR TITLE
Refactorisation du Credential Manager

### DIFF
--- a/Sources/Core/Classes/AppleProvider.swift
+++ b/Sources/Core/Classes/AppleProvider.swift
@@ -29,8 +29,8 @@ class ConfiguredAppleProvider: NSObject, Provider {
 
     let providerConfig: ProviderConfig
     let clientConfigResponse: ClientConfigResponse
-    /// `weak` : ReachFive retient ses providers, une référence forte ici créerait un cycle
-    /// ReachFive ↔ ConfiguredAppleProvider et le graphe SDK ne serait jamais désalloué.
+    /// `weak`: ReachFive retains its providers, a strong reference here would create a
+    /// ReachFive ↔ ConfiguredAppleProvider cycle and the SDK graph would never be deallocated.
     private weak var reachfive: ReachFive?
 
     init(

--- a/Sources/Core/Classes/AppleProvider.swift
+++ b/Sources/Core/Classes/AppleProvider.swift
@@ -25,20 +25,20 @@ public class AppleProvider: ProviderCreator {
 class ConfiguredAppleProvider: NSObject, Provider {
     let name: String = AppleProvider.NAME
 
-    let sdkConfig: SdkConfig
     let providerConfig: ProviderConfig
     let clientConfigResponse: ClientConfigResponse
-    let credentialManager: CredentialManager
+    // Référence faible : ReachFive retient ses providers, une référence forte créerait un cycle
+    // (même pattern que DefaultProvider).
+    private weak var reachfive: ReachFive?
 
     public init(
         reachFive: ReachFive,
         providerConfig: ProviderConfig,
         clientConfigResponse: ClientConfigResponse
     ) {
-        self.sdkConfig = reachFive.sdkConfig
+        self.reachfive = reachFive
         self.providerConfig = providerConfig
         self.clientConfigResponse = clientConfigResponse
-        self.credentialManager = reachFive.credentialManager
     }
 
     public func login(
@@ -46,12 +46,13 @@ class ConfiguredAppleProvider: NSObject, Provider {
         origin: String,
         presenting: Presentation
     ) async throws -> AuthToken {
+        guard let reachfive else { throw ReachFiveError.TechnicalError(reason: "ReachFive instance was deallocated") }
         let window = try await presenting.anchor()
 
         let scope: [String] = scope ?? clientConfigResponse.scope.components(separatedBy: " ")
-        let request = NativeLoginRequest(anchor: window, originWebAuthn: "https://\(sdkConfig.domain)", scopes: scope, origin: origin)
+        let request = NativeLoginRequest(anchor: window, originWebAuthn: "https://\(reachfive.sdkConfig.domain)", scopes: scope, origin: origin)
 
-        let flow = try await credentialManager.login(withRequest: request, usingModalAuthorizationFor: [.SignInWithApple], display: .Always, appleProvider: self)
+        let flow = try await reachfive.credentialManager.login(withRequest: request, usingModalAuthorizationFor: [.SignInWithApple], display: .Always, appleProvider: self, reachFive: reachfive)
 
         switch flow {
         case .AchievedLogin(let authToken): return authToken

--- a/Sources/Core/Classes/AppleProvider.swift
+++ b/Sources/Core/Classes/AppleProvider.swift
@@ -16,9 +16,11 @@ public class AppleProvider: ProviderCreator {
         providerConfig: ProviderConfig,
         clientConfigResponse: ClientConfigResponse
     ) -> Provider {
-        ConfiguredAppleProvider(reachFive: reachFive,
-                                providerConfig: providerConfig,
-                                clientConfigResponse: clientConfigResponse)
+        ConfiguredAppleProvider(
+            reachFive: reachFive,
+            providerConfig: providerConfig,
+            clientConfigResponse: clientConfigResponse
+        )
     }
 }
 
@@ -27,21 +29,21 @@ class ConfiguredAppleProvider: NSObject, Provider {
 
     let providerConfig: ProviderConfig
     let clientConfigResponse: ClientConfigResponse
-    // `weak` : ReachFive retient ses providers, une référence forte ici créerait un cycle
-    // ReachFive ↔ ConfiguredAppleProvider et le graphe SDK ne serait jamais désalloué.
+    /// `weak` : ReachFive retient ses providers, une référence forte ici créerait un cycle
+    /// ReachFive ↔ ConfiguredAppleProvider et le graphe SDK ne serait jamais désalloué.
     private weak var reachfive: ReachFive?
 
-    public init(
+    init(
         reachFive: ReachFive,
         providerConfig: ProviderConfig,
         clientConfigResponse: ClientConfigResponse
     ) {
-        self.reachfive = reachFive
+        reachfive = reachFive
         self.providerConfig = providerConfig
         self.clientConfigResponse = clientConfigResponse
     }
 
-    public func login(
+    func login(
         scope: [String]?,
         origin: String,
         presenting: Presentation
@@ -55,13 +57,12 @@ class ConfiguredAppleProvider: NSObject, Provider {
         let flow = try await reachfive.credentialManager.login(withRequest: request, usingModalAuthorizationFor: [.SignInWithApple], display: .Always, appleProvider: self, reachFive: reachfive)
 
         switch flow {
-        case .AchievedLogin(let authToken): return authToken
-        case .OngoingStepUp:                throw ReachFiveError.TechnicalError(reason: "Should not happen: MFA Step Up in a Sign In with Apple flow")
+        case let .AchievedLogin(authToken): return authToken
+        case .OngoingStepUp: throw ReachFiveError.TechnicalError(reason: "Should not happen: MFA Step Up in a Sign In with Apple flow")
         }
     }
 
-    public func logout() {
-    }
+    func logout() {}
 
     override var description: String {
         "Provider: \(name)"

--- a/Sources/Core/Classes/AppleProvider.swift
+++ b/Sources/Core/Classes/AppleProvider.swift
@@ -27,8 +27,8 @@ class ConfiguredAppleProvider: NSObject, Provider {
 
     let providerConfig: ProviderConfig
     let clientConfigResponse: ClientConfigResponse
-    // Référence faible : ReachFive retient ses providers, une référence forte créerait un cycle
-    // (même pattern que DefaultProvider).
+    // `weak` : ReachFive retient ses providers, une référence forte ici créerait un cycle
+    // ReachFive ↔ ConfiguredAppleProvider et le graphe SDK ne serait jamais désalloué.
     private weak var reachfive: ReachFive?
 
     public init(

--- a/Sources/Core/Classes/AppleProvider.swift
+++ b/Sources/Core/Classes/AppleProvider.swift
@@ -52,7 +52,7 @@ class ConfiguredAppleProvider: NSObject, Provider {
         let window = try await presenting.anchor()
 
         let scope: [String] = scope ?? clientConfigResponse.scope.components(separatedBy: " ")
-        let request = NativeLoginRequest(anchor: window, originWebAuthn: "https://\(reachfive.sdkConfig.domain)", scopes: scope, origin: origin)
+        let request = ResolvedNativeLoginRequest(anchor: window, originWebAuthn: "https://\(reachfive.sdkConfig.domain)", scopes: scope, origin: origin)
 
         let flow = try await reachfive.credentialManager.login(withRequest: request, usingModalAuthorizationFor: [.SignInWithApple], display: .Always, appleProvider: self, reachFive: reachfive)
 

--- a/Sources/Core/Classes/CredentialManager.swift
+++ b/Sources/Core/Classes/CredentialManager.swift
@@ -1,6 +1,9 @@
 import Foundation
 import AuthenticationServices
 
+// Tous les callbacks d'ASAuthorizationController arrivent sur le main thread ; l'isolation @MainActor
+// protège l'état mutable partagé entre les points d'entrée async et le delegate.
+@MainActor
 public class CredentialManager: NSObject {
     let reachFiveApi: ReachFiveApi
     let storage: Storage
@@ -39,7 +42,8 @@ public class CredentialManager: NSObject {
 
     // MARK: -
 
-    public init(reachFiveApi: ReachFiveApi, storage: Storage) {
+    // nonisolated : appelé depuis l'init synchrone de ReachFive, hors du main actor
+    nonisolated init(reachFiveApi: ReachFiveApi, storage: Storage) {
         self.reachFiveApi = reachFiveApi
         self.storage = storage
     }
@@ -311,16 +315,33 @@ public class CredentialManager: NSObject {
 
 // MARK: - ASAuthorizationControllerPresentationContextProviding
 extension CredentialManager: ASAuthorizationControllerPresentationContextProviding {
-    public func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
-        authenticationAnchor!
+    nonisolated public func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
+        // AuthenticationServices délivre ce callback sur le main thread
+        MainActor.assumeIsolated {
+            authenticationAnchor!
+        }
     }
 }
 
 // MARK: - ASAuthorizationControllerDelegate
 extension CredentialManager: ASAuthorizationControllerDelegate {
 
-    public func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
-        Task {
+    nonisolated public func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
+        // AuthenticationServices délivre ce callback sur le main thread
+        MainActor.assumeIsolated {
+            handleAuthorization(authorization, for: controller)
+        }
+    }
+
+    nonisolated public func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
+        // AuthenticationServices délivre ce callback sur le main thread
+        MainActor.assumeIsolated {
+            handleError(error, for: controller)
+        }
+    }
+
+    private func handleAuthorization(_ authorization: ASAuthorization, for controller: ASAuthorizationController) {
+        Task { @MainActor in
             defer {
                 continuationWithAuthToken = nil
                 continuationRegistration = nil
@@ -463,7 +484,7 @@ extension CredentialManager: ASAuthorizationControllerDelegate {
         }
     }
 
-    public func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
+    private func handleError(_ error: Error, for controller: ASAuthorizationController) {
         defer {
             continuationWithAuthToken = nil
             continuationRegistration = nil

--- a/Sources/Core/Classes/CredentialManager.swift
+++ b/Sources/Core/Classes/CredentialManager.swift
@@ -115,7 +115,7 @@ public class CredentialManager: NSObject {
     // MARK: - Reset
     @available(iOS 16.0, *)
     func resetPasskeys(withRequest request: ResetPasskeyRequest) async throws {
-        // Here it is very important to cancel a running auti-fill request, otherwise it will fail like other modal requests
+        // Here it is very important to cancel a running auto-fill request, otherwise it will fail like other modal requests
         // so can't separate this method from the rest of the class
         authController?.cancel()
         authenticationAnchor = request.anchor
@@ -159,6 +159,8 @@ public class CredentialManager: NSObject {
         scope = webAuthnLoginRequest.scope
 
         let assertionRequestOptions = try await reachFiveApi.createWebAuthnAuthenticationOptions(webAuthnLoginRequest: webAuthnLoginRequest)
+        // Cette garde semble redondante (la méthode est déjà @available(iOS 16.0, *)) mais elle est nécessaire
+        // pour compiler sous Xcode 26 (peut-être un bug Xcode). Ne pas la supprimer. Cf. commit 6a65a83.
         let authorizationRequest = if #available(iOS 16.0, *) {
             try createCredentialAssertionRequest(assertionRequestOptions)
         } else {
@@ -228,7 +230,7 @@ public class CredentialManager: NSObject {
         let webAuthnLoginRequest = WebAuthnLoginRequest(clientId: reachFiveApi.sdkConfig.clientId, origin: request.originWebAuthn!, scope: request.scopes)
 
         try await signInWith(webAuthnLoginRequest, withMode: mode, authorizing: requestTypes, appleProvider: appleProvider) { authenticationOptions in
-            guard #available(iOS 16.0, *) else { // can't happen, because this is called from a >= iOS 15 context
+            guard #available(iOS 16.0, *) else { // can't happen, because this is called from a >= iOS 16 context
                 throw ReachFiveError.TechnicalError(reason: "Must be iOS 16 or higher")
             }
             return try self.createCredentialAssertionRequest(authenticationOptions)
@@ -277,8 +279,9 @@ public class CredentialManager: NSObject {
                     let authOptions = try await self.reachFiveApi.createWebAuthnAuthenticationOptions(webAuthnLoginRequest: webAuthnLoginRequest)
                     let passkeyRequest = try makeAuthorization(authOptions)
                     requests.append(passkeyRequest)
-                } catch _ where requestTypes.count > 1 {
+                } catch let error where requestTypes.count > 1 {
                     // if there are other types of requests, do not block auth if only passkey fails. Just eat the error
+                    Logger.shared.log("Passkey request error ignored in multi-type authorization: \(error)")
                 }
             }
         }
@@ -475,7 +478,7 @@ extension CredentialManager: ASAuthorizationControllerDelegate {
                 reachFiveError = .AuthCanceled
             } else {
                 // Another ASAuthorization error.
-                reachFiveError = .TechnicalError(reason: "\(error)")
+                reachFiveError = .TechnicalError(reason: "ASAuthorizationError \(authorizationError.code.rawValue): \(error)")
             }
         } else {
             reachFiveError = .TechnicalError(reason: "\(error.localizedDescription)")

--- a/Sources/Core/Classes/CredentialManager.swift
+++ b/Sources/Core/Classes/CredentialManager.swift
@@ -380,25 +380,23 @@ extension CredentialManager: ASAuthorizationControllerDelegate {
             continuation.resume(returning: ())
 
         case let .passkeyLogin(scopes, continuation):
+            guard let scopes else { throw ReachFiveError.TechnicalError(reason: "didCompleteWithAuthorization: no scope") }
             let authToken = try await authenticateWithPasskey(authorization, scopes: scopes, reachFive: reachFive, originR5: context.originR5)
             continuation.resume(returning: authToken)
 
         case let .modalLogin(scopes, siwa, continuation):
-            let loginFlow = try await completeModalLogin(authorization, scopes: scopes, siwa: siwa, context: context)
+            guard let scopes else { throw ReachFiveError.TechnicalError(reason: "didCompleteWithAuthorization: no scope") }
+            let loginFlow = try await completeModalLogin(authorization, scopes: scopes, siwa: siwa, reachFive: reachFive, originR5: context.originR5)
             continuation.resume(returning: loginFlow)
         }
     }
 
     /// Complète une connexion modale, seul flux à pouvoir recevoir plusieurs types de credential
     /// (mot de passe, Sign In With Apple ou passkey).
-    private func completeModalLogin(_ authorization: ASAuthorization, scopes: [String]?, siwa: SignInWithApple?, context: RequestContext) async throws -> LoginFlow {
-        let reachFive = context.reachFive
+    private func completeModalLogin(_ authorization: ASAuthorization, scopes: [String], siwa: SignInWithApple?, reachFive: ReachFive, originR5: String?) async throws -> LoginFlow {
         let reachFiveApi = reachFive.reachFiveApi
         let sdkConfig = reachFive.sdkConfig
-
-        guard let scopes else {
-            throw ReachFiveError.TechnicalError(reason: "didCompleteWithAuthorization: no scope")
-        }
+        let scope = scopes.joined(separator: " ")
 
         if let passwordCredential = authorization.credential as? ASPasswordCredential {
             // a password was selected to sign in
@@ -419,11 +417,11 @@ extension CredentialManager: ASAuthorizationControllerDelegate {
                 password: passwordCredential.password,
                 grantType: "password",
                 clientId: sdkConfig.clientId,
-                scope: scopes.joined(separator: " "),
-                origin: context.originR5
+                scope: scope,
+                origin: originR5
             ))
 
-            return try await reachFive.loginFlow(afterPasswordGrant: resp, scopes: scopes, origin: context.originR5)
+            return try await reachFive.loginFlow(afterPasswordGrant: resp, scopes: scopes, origin: originR5)
         } else if let appleIDCredential = authorization.credential as? ASAuthorizationAppleIDCredential {
             guard let siwa else {
                 throw ReachFiveError.TechnicalError(reason: "didCompleteWithAuthorization: no nonce, no apple provider")
@@ -442,11 +440,11 @@ extension CredentialManager: ASAuthorizationControllerDelegate {
                 "id_token": idToken,
                 "response_type": "code",
                 "redirect_uri": sdkConfig.redirectUri.absoluteString,
-                "scope": scopes.joined(separator: " "),
+                "scope": scope,
                 "code_challenge": pkce.codeChallenge,
                 "code_challenge_method": pkce.codeChallengeMethod,
                 "nonce": siwa.nonce.codeVerifier,
-                "origin": context.originR5,
+                "origin": originR5,
                 "given_name": appleIDCredential.fullName?.givenName,
                 "family_name": appleIDCredential.fullName?.familyName
             ])
@@ -454,7 +452,7 @@ extension CredentialManager: ASAuthorizationControllerDelegate {
             return .AchievedLogin(authToken: token)
         } else {
             // a passkey was selected to sign in
-            let authToken = try await authenticateWithPasskey(authorization, scopes: scopes, reachFive: reachFive, originR5: context.originR5)
+            let authToken = try await authenticateWithPasskey(authorization, scopes: scopes, reachFive: reachFive, originR5: originR5)
             return .AchievedLogin(authToken: authToken)
         }
     }
@@ -503,12 +501,9 @@ extension CredentialManager {
     /// Extrait l'assertion de passkey d'une autorisation, la valide auprès du serveur et rend le jeton.
     /// Partagé par la connexion par passkey (auto-fill / non-discoverable) et la branche passkey de la
     /// connexion modale. Lève une erreur technique si l'autorisation n'est pas une assertion de passkey.
-    private func authenticateWithPasskey(_ authorization: ASAuthorization, scopes: [String]?, reachFive: ReachFive, originR5: String?) async throws -> AuthToken {
+    private func authenticateWithPasskey(_ authorization: ASAuthorization, scopes: [String], reachFive: ReachFive, originR5: String?) async throws -> AuthToken {
         guard #available(iOS 16.0, *), let credentialAssertion = authorization.credential as? ASAuthorizationPlatformPublicKeyCredentialAssertion else {
             throw ReachFiveError.TechnicalError(reason: "didCompleteWithAuthorization: expected a passkey assertion")
-        }
-        guard let scopes else {
-            throw ReachFiveError.TechnicalError(reason: "didCompleteWithAuthorization: no scope")
         }
 
         let signature = credentialAssertion.signature.toBase64Url()

--- a/Sources/Core/Classes/CredentialManager.swift
+++ b/Sources/Core/Classes/CredentialManager.swift
@@ -8,31 +8,47 @@ public class CredentialManager: NSObject {
     let reachFiveApi: ReachFiveApi
     let storage: Storage
 
-    // MARK: - these fields serve to remember the context between the start of a request and its completion
-    // Do not erase them at the end of a request because requests can be interleaved (modal and auto-fill requests)
+    // MARK: - Contexte de requête
 
-    // continuation for authentification which can result in an MFA step up (login with password)
-    var continuationWithStepUp: CheckedContinuation<LoginFlow, Error>?
-    // continuation for normal authentification
-    var continuationWithAuthToken: CheckedContinuation<AuthToken, Error>?
-    // continuation for new key registration
-    var continuationRegistration: CheckedContinuation<Void, Error>?
+    // Les requêtes peuvent s'entrelacer (une requête modale peut démarrer pendant une requête auto-fill).
+    // Tout l'état d'une requête vit donc dans un RequestContext indexé par son controller : chaque callback
+    // du delegate retrouve le contexte de SA requête, et une requête ne peut pas écraser l'état d'une autre.
+    private struct RequestContext {
+        enum Pending {
+            // signup, auto-fill, login non-discoverable
+            case authToken(CheckedContinuation<AuthToken, Error>)
+            // login modal (password/SIWA/passkey), qui peut déboucher sur un step-up MFA
+            case loginFlow(CheckedContinuation<LoginFlow, Error>)
+            // enregistrement d'une nouvelle clé (add/reset)
+            case registration(CheckedContinuation<Void, Error>)
+        }
 
-    // anchor for presentationContextProvider
-    var authenticationAnchor: ASPresentationAnchor?
+        // retenu : maintient la requête système en vie jusqu'à sa complétion
+        let controller: ASAuthorizationController
+        let pending: Pending
+        // anchor pour le presentationContextProvider
+        let anchor: ASPresentationAnchor
+        // le scope de la requête, tel qu'envoyé au serveur
+        let scope: String?
+        // origin optionnel pour les événements utilisateur
+        let originR5: String?
+        // données pour signup/register
+        let passkeyCreationType: PasskeyCreationType?
+        // le nonce pour Sign In With Apple
+        let nonce: Pkce?
+        let appleProvider: ConfiguredAppleProvider?
 
-    // the controller for the current request, to cancel it before starting a new request (mainly to cancel an auto-fill request when starting a modal request)
-    var authController: ASAuthorizationController?
+        func fail(with error: Error) {
+            switch pending {
+            case let .authToken(continuation): continuation.resume(throwing: error)
+            case let .loginFlow(continuation): continuation.resume(throwing: error)
+            case let .registration(continuation): continuation.resume(throwing: error)
+            }
+        }
+    }
 
-    // data for signup/register
-    var passkeyCreationType: PasskeyCreationType?
-    // the scope of the request
-    var scope: String?
-    // optional origin for user events
-    var originR5: String?
-    // the nonce for Sign In With Apple
-    var nonce: Pkce?
-    var appleProvider: ConfiguredAppleProvider?
+    // les requêtes en vol, indexées par leur controller
+    private var contexts: [ObjectIdentifier: RequestContext] = [:]
 
     enum PasskeyCreationType {
         case Signup(signupOptions: RegistrationOptions)
@@ -48,71 +64,79 @@ public class CredentialManager: NSObject {
         self.storage = storage
     }
 
-    // MARK: - Signup
-    @available(iOS 16.0, *)
-    func signUp(withRequest request: SignupOptions, anchor: ASPresentationAnchor, originR5: String? = nil) async throws -> AuthToken {
-        authController?.cancel()
-        authenticationAnchor = anchor
-        scope = request.scope
-        self.originR5 = originR5
+    // MARK: - Cycle de vie des requêtes
 
-        let options = try await reachFiveApi.createWebAuthnSignupOptions(webAuthnSignupOptions: request)
-        self.passkeyCreationType = .Signup(signupOptions: options)
-
-        guard let challenge = options.options.publicKey.challenge.decodeBase64Url() else {
-            throw ReachFiveError.TechnicalError(reason: "unreadable challenge: \(options.options.publicKey.challenge)")
-        }
-
-        guard let userID = options.options.publicKey.user.id.decodeBase64Url() else {
-            throw ReachFiveError.TechnicalError(reason: "unreadable userID from public key: \(options.options.publicKey.user.id)")
-        }
-
-        let publicKeyCredentialProvider = ASAuthorizationPlatformPublicKeyCredentialProvider(relyingPartyIdentifier: options.options.publicKey.rp.id)
-        let registrationRequest = publicKeyCredentialProvider.createCredentialRegistrationRequest(challenge: challenge, name: request.friendlyName, userID: userID)
-
-        let authController = ASAuthorizationController(authorizationRequests: [registrationRequest])
-        authController.delegate = self
-        authController.presentationContextProvider = self
-        authController.performRequests()
-        self.authController = authController
-
-        return try await withCheckedThrowingContinuation { continuation in
-            self.continuationWithAuthToken = continuation
+    /// Annule les requêtes en vol, principalement pour annuler une requête auto-fill avant de démarrer
+    /// une requête modale (sinon cette dernière échouerait). Chaque annulation déclenche
+    /// `didCompleteWithError(.canceled)` pour son controller, ce qui résout sa continuation en `.AuthCanceled`.
+    private func cancelInFlightRequests() {
+        guard #available(iOS 16.0, *) else { return } // cancel() n'existe qu'à partir d'iOS 16
+        for context in contexts.values {
+            context.controller.cancel()
         }
     }
 
+    /// Crée le controller, enregistre le contexte de la requête PUIS lance la requête système via `perform` :
+    /// comme tout se passe sur le main actor, la continuation est en place avant que le delegate puisse tirer.
+    private func start(_ pending: RequestContext.Pending,
+                       requests: [ASAuthorizationRequest],
+                       anchor: ASPresentationAnchor,
+                       scope: String?,
+                       originR5: String?,
+                       passkeyCreationType: PasskeyCreationType? = nil,
+                       nonce: Pkce? = nil,
+                       appleProvider: ConfiguredAppleProvider? = nil,
+                       perform: (ASAuthorizationController) -> Void) {
+        let controller = ASAuthorizationController(authorizationRequests: requests)
+        controller.delegate = self
+        controller.presentationContextProvider = self
+        contexts[ObjectIdentifier(controller)] = RequestContext(controller: controller, pending: pending, anchor: anchor, scope: scope, originR5: originR5, passkeyCreationType: passkeyCreationType, nonce: nonce, appleProvider: appleProvider)
+        perform(controller)
+    }
+
+    private func awaitAuthToken(requests: [ASAuthorizationRequest], anchor: ASPresentationAnchor, scope: String?, originR5: String?, passkeyCreationType: PasskeyCreationType? = nil, perform: (ASAuthorizationController) -> Void) async throws -> AuthToken {
+        try await withCheckedThrowingContinuation { continuation in
+            start(.authToken(continuation), requests: requests, anchor: anchor, scope: scope, originR5: originR5, passkeyCreationType: passkeyCreationType, perform: perform)
+        }
+    }
+
+    private func awaitLoginFlow(requests: [ASAuthorizationRequest], anchor: ASPresentationAnchor, scope: String?, originR5: String?, nonce: Pkce? = nil, appleProvider: ConfiguredAppleProvider? = nil, perform: (ASAuthorizationController) -> Void) async throws -> LoginFlow {
+        try await withCheckedThrowingContinuation { continuation in
+            start(.loginFlow(continuation), requests: requests, anchor: anchor, scope: scope, originR5: originR5, nonce: nonce, appleProvider: appleProvider, perform: perform)
+        }
+    }
+
+    private func awaitRegistration(requests: [ASAuthorizationRequest], anchor: ASPresentationAnchor, originR5: String?, passkeyCreationType: PasskeyCreationType, perform: (ASAuthorizationController) -> Void) async throws {
+        try await withCheckedThrowingContinuation { continuation in
+            start(.registration(continuation), requests: requests, anchor: anchor, scope: nil, originR5: originR5, passkeyCreationType: passkeyCreationType, perform: perform)
+        }
+    }
+
+    // MARK: - Signup
+    @available(iOS 16.0, *)
+    func signUp(withRequest request: SignupOptions, anchor: ASPresentationAnchor, originR5: String? = nil) async throws -> AuthToken {
+        cancelInFlightRequests()
+
+        let options = try await reachFiveApi.createWebAuthnSignupOptions(webAuthnSignupOptions: request)
+        let registrationRequest = try makeCredentialRegistrationRequest(from: options, friendlyName: request.friendlyName)
+
+        return try await awaitAuthToken(requests: [registrationRequest], anchor: anchor, scope: request.scope, originR5: originR5, passkeyCreationType: .Signup(signupOptions: options)) {
+            $0.performRequests()
+        }
+    }
 
     // MARK: - Register
     @available(iOS 16.0, *)
     func registerNewPasskey(withRequest request: NewPasskeyRequest, authToken: AuthToken) async throws {
         // Here it is very important to cancel a running auto-fill request, otherwise it will fail like other modal requests
         // so can't separate this method from the rest of the class
-        authController?.cancel()
-        authenticationAnchor = request.anchor
-        self.originR5 = request.origin
+        cancelInFlightRequests()
 
         let options = try await reachFiveApi.createWebAuthnRegistrationOptions(authToken: authToken, registrationRequest: RegistrationRequest(origin: request.originWebAuthn!, friendlyName: request.friendlyName))
-        self.passkeyCreationType = .AddPasskey(authToken: authToken)
+        let registrationRequest = try makeCredentialRegistrationRequest(from: options, friendlyName: request.friendlyName)
 
-        guard let challenge = options.options.publicKey.challenge.decodeBase64Url() else {
-            throw ReachFiveError.TechnicalError(reason: "unreadable challenge: \(options.options.publicKey.challenge)")
-        }
-
-        guard let userID = options.options.publicKey.user.id.decodeBase64Url() else {
-            throw ReachFiveError.TechnicalError(reason: "unreadable userID from public key: \(options.options.publicKey.user.id)")
-        }
-
-        let publicKeyCredentialProvider = ASAuthorizationPlatformPublicKeyCredentialProvider(relyingPartyIdentifier: options.options.publicKey.rp.id)
-        let registrationRequest = publicKeyCredentialProvider.createCredentialRegistrationRequest(challenge: challenge, name: request.friendlyName, userID: userID)
-
-        let authController = ASAuthorizationController(authorizationRequests: [registrationRequest])
-        authController.delegate = self
-        authController.presentationContextProvider = self
-        authController.performRequests()
-        self.authController = authController
-
-        return try await withCheckedThrowingContinuation { continuation in
-            self.continuationRegistration = continuation
+        try await awaitRegistration(requests: [registrationRequest], anchor: request.anchor, originR5: request.origin, passkeyCreationType: .AddPasskey(authToken: authToken)) {
+            $0.performRequests()
         }
     }
 
@@ -121,33 +145,14 @@ public class CredentialManager: NSObject {
     func resetPasskeys(withRequest request: ResetPasskeyRequest) async throws {
         // Here it is very important to cancel a running auto-fill request, otherwise it will fail like other modal requests
         // so can't separate this method from the rest of the class
-        authController?.cancel()
-        authenticationAnchor = request.anchor
-        self.originR5 = request.origin
+        cancelInFlightRequests()
 
         let resetOptions = ResetOptions(email: request.email, phoneNumber: request.phoneNumber, verificationCode: request.verificationCode, friendlyName: request.friendlyName, origin: request.originWebAuthn!, clientId: reachFiveApi.sdkConfig.clientId)
         let options = try await reachFiveApi.createWebAuthnResetOptions(resetOptions: resetOptions)
-        self.passkeyCreationType = .ResetPasskey(resetOptions: resetOptions)
+        let registrationRequest = try makeCredentialRegistrationRequest(from: options, friendlyName: request.friendlyName)
 
-        guard let challenge = options.options.publicKey.challenge.decodeBase64Url() else {
-            throw ReachFiveError.TechnicalError(reason: "unreadable challenge: \(options.options.publicKey.challenge)")
-        }
-
-        guard let userID = options.options.publicKey.user.id.decodeBase64Url() else {
-            throw ReachFiveError.TechnicalError(reason: "unreadable userID from public key: \(options.options.publicKey.user.id)")
-        }
-
-        let publicKeyCredentialProvider = ASAuthorizationPlatformPublicKeyCredentialProvider(relyingPartyIdentifier: options.options.publicKey.rp.id)
-        let registrationRequest = publicKeyCredentialProvider.createCredentialRegistrationRequest(challenge: challenge, name: request.friendlyName, userID: userID)
-
-        let authController = ASAuthorizationController(authorizationRequests: [registrationRequest])
-        authController.delegate = self
-        authController.presentationContextProvider = self
-        authController.performRequests()
-        self.authController = authController
-
-        return try await withCheckedThrowingContinuation { continuation in
-            self.continuationRegistration = continuation
+        try await awaitRegistration(requests: [registrationRequest], anchor: request.anchor, originR5: request.origin, passkeyCreationType: .ResetPasskey(resetOptions: resetOptions)) {
+            $0.performRequests()
         }
     }
 
@@ -155,12 +160,9 @@ public class CredentialManager: NSObject {
     @available(macCatalyst, unavailable)
     @available(iOS 16.0, *)
     func beginAutoFillAssistedPasskeySignIn(request: NativeLoginRequest) async throws -> AuthToken {
-        authController?.cancel()
-        authenticationAnchor = request.anchor
-        originR5 = request.origin
+        cancelInFlightRequests()
 
         let webAuthnLoginRequest = WebAuthnLoginRequest(clientId: reachFiveApi.sdkConfig.clientId, origin: request.originWebAuthn!, scope: request.scopes)
-        scope = webAuthnLoginRequest.scope
 
         let assertionRequestOptions = try await reachFiveApi.createWebAuthnAuthenticationOptions(webAuthnLoginRequest: webAuthnLoginRequest)
         // Cette garde semble redondante (la méthode est déjà @available(iOS 16.0, *)) mais elle est nécessaire
@@ -172,22 +174,14 @@ public class CredentialManager: NSObject {
         }
 
         // AutoFill-assisted requests only support ASAuthorizationPlatformPublicKeyCredentialAssertionRequest.
-        let authController = ASAuthorizationController(authorizationRequests: [authorizationRequest])
-        authController.delegate = self
-        authController.presentationContextProvider = self
-        authController.performAutoFillAssistedRequests()
-        self.authController = authController
-
-        return try await withCheckedThrowingContinuation { continuation in
-            self.continuationWithAuthToken = continuation
+        return try await awaitAuthToken(requests: [authorizationRequest], anchor: request.anchor, scope: webAuthnLoginRequest.scope, originR5: request.origin) {
+            $0.performAutoFillAssistedRequests()
         }
     }
 
     // MARK: - Modal
     func login(withNonDiscoverableUsername username: Username, forRequest request: NativeLoginRequest, usingModalAuthorizationFor requestTypes: [NonDiscoverableAuthorization], display mode: Mode) async throws -> AuthToken {
-        if #available(iOS 16.0, *) { authController?.cancel() }
-        authenticationAnchor = request.anchor
-        originR5 = request.origin
+        cancelInFlightRequests()
 
         let webAuthnLoginRequest = WebAuthnLoginRequest(clientId: reachFiveApi.sdkConfig.clientId, origin: request.originWebAuthn!, scope: request.scopes)
         switch username {
@@ -206,7 +200,7 @@ public class CredentialManager: NSObject {
 
         let authzs = requestTypes.compactMap { adaptAuthz($0) }
 
-        try await signInWith(webAuthnLoginRequest, withMode: mode, authorizing: authzs) { assertionRequestOptions in
+        let built = try await buildAuthorizationRequests(webAuthnLoginRequest, authorizing: authzs) { assertionRequestOptions in
             guard #available(iOS 16.0, *) else { // can't happen, because this is called from a >= iOS 16 context
                 throw ReachFiveError.TechnicalError(reason: "Must be iOS 16 or higher")
             }
@@ -221,34 +215,40 @@ public class CredentialManager: NSObject {
             return assertionRequest
         }
 
-        return try await withCheckedThrowingContinuation { continuation in
-            self.continuationWithAuthToken = continuation
+        return try await awaitAuthToken(requests: built.requests, anchor: request.anchor, scope: webAuthnLoginRequest.scope, originR5: request.origin) {
+            performRequests(on: $0, mode: mode)
         }
     }
 
     func login(withRequest request: NativeLoginRequest, usingModalAuthorizationFor requestTypes: [ModalAuthorization], display mode: Mode, appleProvider: ConfiguredAppleProvider?) async throws -> LoginFlow {
-        if #available(iOS 16.0, *) { authController?.cancel() }
-        authenticationAnchor = request.anchor
-        originR5 = request.origin
+        cancelInFlightRequests()
 
         let webAuthnLoginRequest = WebAuthnLoginRequest(clientId: reachFiveApi.sdkConfig.clientId, origin: request.originWebAuthn!, scope: request.scopes)
 
-        try await signInWith(webAuthnLoginRequest, withMode: mode, authorizing: requestTypes, appleProvider: appleProvider) { authenticationOptions in
+        let built = try await buildAuthorizationRequests(webAuthnLoginRequest, authorizing: requestTypes, appleProvider: appleProvider) { authenticationOptions in
             guard #available(iOS 16.0, *) else { // can't happen, because this is called from a >= iOS 16 context
                 throw ReachFiveError.TechnicalError(reason: "Must be iOS 16 or higher")
             }
             return try self.createCredentialAssertionRequest(authenticationOptions)
         }
 
-        return try await withCheckedThrowingContinuation { continuation in
-            self.continuationWithStepUp = continuation
+        return try await awaitLoginFlow(requests: built.requests, anchor: request.anchor, scope: webAuthnLoginRequest.scope, originR5: request.origin, nonce: built.nonce, appleProvider: built.appleProvider) {
+            performRequests(on: $0, mode: mode)
         }
     }
 
-    private func signInWith(_ webAuthnLoginRequest: WebAuthnLoginRequest, withMode mode: Mode, authorizing requestTypes: [ModalAuthorization], appleProvider: ConfiguredAppleProvider? = nil, makeAuthorization: @escaping (AuthenticationOptions) throws -> ASAuthorizationRequest) async throws {
-        scope = webAuthnLoginRequest.scope
+    private struct BuiltRequests {
+        let requests: [ASAuthorizationRequest]
+        // renseignés uniquement si une requête Sign In With Apple fait partie du lot
+        let nonce: Pkce?
+        let appleProvider: ConfiguredAppleProvider?
+    }
 
+    /// Construit les `ASAuthorizationRequest` pour les types demandés, sans toucher à l'état de la classe.
+    private func buildAuthorizationRequests(_ webAuthnLoginRequest: WebAuthnLoginRequest, authorizing requestTypes: [ModalAuthorization], appleProvider: ConfiguredAppleProvider? = nil, makeAuthorization: (AuthenticationOptions) throws -> ASAuthorizationRequest) async throws -> BuiltRequests {
         var requests: [ASAuthorizationRequest] = []
+        var nonce: Pkce?
+        var usedAppleProvider: ConfiguredAppleProvider?
 
         for type in requestTypes {
             switch type {
@@ -270,10 +270,10 @@ public class CredentialManager: NSObject {
                     }
                 }
                 appleIDRequest.requestedScopes = appleScopes
-                self.nonce = Pkce.generate()
-                appleIDRequest.nonce = self.nonce?.codeChallenge
-
-                self.appleProvider = appleProvider
+                let siwaNonce = Pkce.generate()
+                appleIDRequest.nonce = siwaNonce.codeChallenge
+                nonce = siwaNonce
+                usedAppleProvider = appleProvider
 
                 requests.append(appleIDRequest)
 
@@ -290,26 +290,25 @@ public class CredentialManager: NSObject {
             }
         }
 
-        let authController = ASAuthorizationController(authorizationRequests: requests)
-        authController.delegate = self
-        authController.presentationContextProvider = self
+        return BuiltRequests(requests: requests, nonce: nonce, appleProvider: usedAppleProvider)
+    }
+
+    private func performRequests(on controller: ASAuthorizationController, mode: Mode) {
         switch mode {
         case .Always:
             // If credentials are available, presents a modal sign-in sheet.
             // If there are no locally saved credentials, the system presents a QR code to allow signing in with a
             // passkey from a nearby device.
-            authController.performRequests()
+            controller.performRequests()
         case .IfImmediatelyAvailableCredentials:
             // If credentials are available, presents a modal sign-in sheet.
             // If there are no locally saved credentials, no UI appears and
             // the system passes ASAuthorizationError.Code.canceled to call
             // `AccountManager.authorizationController(controller:didCompleteWithError:)`.
             if #available(iOS 16.0, *) { // no need to have a fallback in case iOS < 16, because .IfImmediatelyAvailableCredentials is already requiring iOS 16
-                authController.performRequests(options: .preferImmediatelyAvailableCredentials)
+                controller.performRequests(options: .preferImmediatelyAvailableCredentials)
             }
         }
-
-        self.authController = authController
     }
 }
 
@@ -318,7 +317,7 @@ extension CredentialManager: ASAuthorizationControllerPresentationContextProvidi
     nonisolated public func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
         // AuthenticationServices délivre ce callback sur le main thread
         MainActor.assumeIsolated {
-            authenticationAnchor!
+            contexts[ObjectIdentifier(controller)]?.anchor ?? ASPresentationAnchor()
         }
     }
 }
@@ -340,156 +339,184 @@ extension CredentialManager: ASAuthorizationControllerDelegate {
         }
     }
 
+    // Retire le contexte à l'entrée du callback : garantit qu'une continuation est résolue exactement une fois,
+    // et qu'un cancelInFlightRequests() ultérieur ne peut plus toucher une requête dont la complétion est en cours.
+    private func takeContext(for controller: ASAuthorizationController) -> RequestContext? {
+        contexts.removeValue(forKey: ObjectIdentifier(controller))
+    }
+
     private func handleAuthorization(_ authorization: ASAuthorization, for controller: ASAuthorizationController) {
+        guard let context = takeContext(for: controller) else {
+            // controller inconnu ou requête déjà résolue : rien à faire
+            return
+        }
+
         Task { @MainActor in
-            defer {
-                continuationWithAuthToken = nil
-                continuationRegistration = nil
-                continuationWithStepUp = nil
-            }
-
             do {
-                if let passwordCredential = authorization.credential as? ASPasswordCredential {
-                    guard let scope else {
-                        throw ReachFiveError.TechnicalError(reason: "didCompleteWithAuthorization: no scope")
-                    }
-
-                    // a password was selected to sign in
-                    let email: String?
-                    let phoneNumber: String?
-                    if passwordCredential.user.contains("@") {
-                        email = passwordCredential.user
-                        phoneNumber = nil
-                    } else {
-                        email = nil
-                        phoneNumber = passwordCredential.user
-                    }
-
-                    let resp = try await reachFiveApi.loginWithPassword(loginRequest: LoginRequest(
-                        email: email,
-                        phoneNumber: phoneNumber,
-                        customIdentifier: nil, // No custom identifier for login because no custom identifier can be used for signup
-                        password: passwordCredential.password,
-                        grantType: "password",
-                        clientId: reachFiveApi.sdkConfig.clientId,
-                        scope: scope
-                    ))
-
-                    let loginFlow: LoginFlow
-                    if resp.mfaRequired == true {
-                        let pkce = Pkce.generate()
-                        self.storage.save(key: "PASSWORDLESS_PKCE", value: pkce)
-                        let stepUpResp = try await self.reachFiveApi.startMfaStepUp(StartMfaStepUpRequest(clientId: self.reachFiveApi.sdkConfig.clientId, redirectUri: self.reachFiveApi.sdkConfig.redirectUri, pkce: pkce, scope: scope, tkn: resp.tkn))
-                        loginFlow = .OngoingStepUp(token: stepUpResp.token, availableMfaCredentialItemTypes: stepUpResp.amr)
-                    } else {
-                        let token = try await self.loginCallback(tkn: resp.tkn, scope: scope, origin: self.originR5)
-                        loginFlow = .AchievedLogin(authToken: token)
-                    }
-
-                    continuationWithStepUp?.resume(returning: loginFlow)
-                } else if let appleIDCredential = authorization.credential as? ASAuthorizationAppleIDCredential {
-                    guard let nonce, let scope, let appleProvider else {
-                        throw ReachFiveError.TechnicalError(reason: "didCompleteWithAuthorization: no scope, no nonce, no apple provider")
-                    }
-
-                    guard let identityToken = appleIDCredential.identityToken else {
-                        throw ReachFiveError.TechnicalError(reason: "didCompleteWithAuthorization: no id token returned")
-                    }
-
-                    guard let idToken = String(data: identityToken, encoding: .utf8) else {
-                        throw ReachFiveError.TechnicalError(reason: "didCompleteWithAuthorization: unreadable id token \(identityToken)")
-                    }
-
-                    let pkce = Pkce.generate()
-                    let code = try await reachFiveApi.authorize(params: [
-                        "provider": appleProvider.providerConfig.providerWithVariant,
-                        "client_id": reachFiveApi.sdkConfig.clientId,
-                        "id_token": idToken,
-                        "response_type": "code",
-                        "redirect_uri": reachFiveApi.sdkConfig.redirectUri.absoluteString,
-                        "scope": scope,
-                        "code_challenge": pkce.codeChallenge,
-                        "code_challenge_method": pkce.codeChallengeMethod,
-                        "nonce": nonce.codeVerifier,
-                        "origin": originR5,
-                        "given_name": appleIDCredential.fullName?.givenName,
-                        "family_name": appleIDCredential.fullName?.familyName
-                    ])
-                    let token = try await self.authWithCode(code: code, pkce: pkce)
-                    continuationWithStepUp?.resume(returning: .AchievedLogin(authToken: token))
-                } else if #available(iOS 16.0, *), let credentialRegistration = authorization.credential as? ASAuthorizationPlatformPublicKeyCredentialRegistration {
-                    // A new passkey was registered
-                    guard let attestationObject = credentialRegistration.rawAttestationObject else {
-                        throw ReachFiveError.TechnicalError(reason: "didCompleteWithAuthorization: no attestationObject")
-                    }
-
-                    let clientDataJSON = credentialRegistration.rawClientDataJSON
-                    let r5AuthenticatorAttestationResponse = R5AuthenticatorAttestationResponse(attestationObject: attestationObject.toBase64Url(), clientDataJSON: clientDataJSON.toBase64Url())
-
-                    let id = credentialRegistration.credentialID.toBase64Url()
-                    let registrationPublicKeyCredential = RegistrationPublicKeyCredential(id: id, rawId: id, type: "public-key", response: r5AuthenticatorAttestationResponse)
-
-                    guard let passkeyCreationType else {
-                        throw ReachFiveError.TechnicalError(reason: "didCompleteWithAuthorization: no signupOptions")
-                    }
-
-                    switch passkeyCreationType {
-                    case let .AddPasskey(authToken):
-                        try await reachFiveApi.registerWithWebAuthn(authToken: authToken, publicKeyCredential: registrationPublicKeyCredential, originR5: self.originR5)
-                        continuationRegistration?.resume(returning: ())
-
-                    case let .Signup(signupOptions):
-                        guard let scope else {
-                            throw ReachFiveError.TechnicalError(reason: "didCompleteWithAuthorization: no scope")
-                        }
-
-                        let webauthnSignupCredential = WebauthnSignupCredential(webauthnId: signupOptions.options.publicKey.user.id, publicKeyCredential: registrationPublicKeyCredential)
-                        let authenticationToken = try await reachFiveApi.signupWithWebAuthn(webauthnSignupCredential: webauthnSignupCredential, originR5: self.originR5)
-                        let authToken = try await self.loginCallback(tkn: authenticationToken.tkn, scope: scope, origin: self.originR5)
-                        continuationWithAuthToken?.resume(returning: authToken)
-
-                    case let .ResetPasskey(resetOptions):
-                        let resetPublicKeyCredential = ResetPublicKeyCredential(resetOptions: resetOptions, publicKeyCredential: registrationPublicKeyCredential)
-                        try await reachFiveApi.resetWebAuthn(resetPublicKeyCredential: resetPublicKeyCredential, originR5: self.originR5)
-                        continuationRegistration?.resume(returning: ())
-                    }
-                } else if #available(iOS 16.0, *), let credentialAssertion = authorization.credential as? ASAuthorizationPlatformPublicKeyCredentialAssertion {
-                    // A passkey was selected to sign in
-
-                    guard let scope else {
-                        throw ReachFiveError.TechnicalError(reason: "didCompleteWithAuthorization: no scope")
-                    }
-
-                    let signature = credentialAssertion.signature.toBase64Url()
-                    let clientDataJSON = credentialAssertion.rawClientDataJSON.toBase64Url()
-                    let userID = credentialAssertion.userID.toBase64Url()
-
-                    let id = credentialAssertion.credentialID.toBase64Url()
-                    let authenticatorData = credentialAssertion.rawAuthenticatorData.toBase64Url()
-                    let response = R5AuthenticatorAssertionResponse(authenticatorData: authenticatorData, clientDataJSON: clientDataJSON, signature: signature, userHandle: userID)
-
-                    let authenticationToken = try await reachFiveApi.authenticateWithWebAuthn(authenticationPublicKeyCredential: AuthenticationPublicKeyCredential(id: id, rawId: id, type: "public-key", response: response))
-                    let authToken = try await self.loginCallback(tkn: authenticationToken.tkn, scope: scope, origin: self.originR5)
-
-                    continuationWithStepUp?.resume(returning: .AchievedLogin(authToken: authToken))
-                    continuationWithAuthToken?.resume(returning: authToken)
-                } else {
-                    throw ReachFiveError.TechnicalError(reason: "didCompleteWithAuthorization: Received unknown authorization type.")
-                }
+                try await complete(authorization, context: context)
             } catch {
-                continuationWithAuthToken?.resume(throwing: error)
-                continuationWithStepUp?.resume(throwing: error)
-                continuationRegistration?.resume(throwing: error)
+                context.fail(with: error)
             }
         }
     }
 
-    private func handleError(_ error: Error, for controller: ASAuthorizationController) {
-        defer {
-            continuationWithAuthToken = nil
-            continuationRegistration = nil
-            continuationWithStepUp = nil
+    private func complete(_ authorization: ASAuthorization, context: RequestContext) async throws {
+        if let passwordCredential = authorization.credential as? ASPasswordCredential {
+            // a password was selected to sign in
+            guard case let .loginFlow(continuation) = context.pending else {
+                throw ReachFiveError.TechnicalError(reason: "didCompleteWithAuthorization: unexpected password credential for this request")
+            }
+            guard let scope = context.scope else {
+                throw ReachFiveError.TechnicalError(reason: "didCompleteWithAuthorization: no scope")
+            }
+
+            let email: String?
+            let phoneNumber: String?
+            if passwordCredential.user.contains("@") {
+                email = passwordCredential.user
+                phoneNumber = nil
+            } else {
+                email = nil
+                phoneNumber = passwordCredential.user
+            }
+
+            let resp = try await reachFiveApi.loginWithPassword(loginRequest: LoginRequest(
+                email: email,
+                phoneNumber: phoneNumber,
+                customIdentifier: nil, // No custom identifier for login because no custom identifier can be used for signup
+                password: passwordCredential.password,
+                grantType: "password",
+                clientId: reachFiveApi.sdkConfig.clientId,
+                scope: scope
+            ))
+
+            let loginFlow: LoginFlow
+            if resp.mfaRequired == true {
+                let pkce = Pkce.generate()
+                storage.save(key: "PASSWORDLESS_PKCE", value: pkce)
+                let stepUpResp = try await reachFiveApi.startMfaStepUp(StartMfaStepUpRequest(clientId: reachFiveApi.sdkConfig.clientId, redirectUri: reachFiveApi.sdkConfig.redirectUri, pkce: pkce, scope: scope, tkn: resp.tkn))
+                loginFlow = .OngoingStepUp(token: stepUpResp.token, availableMfaCredentialItemTypes: stepUpResp.amr)
+            } else {
+                let token = try await loginCallback(tkn: resp.tkn, scope: scope, origin: context.originR5)
+                loginFlow = .AchievedLogin(authToken: token)
+            }
+
+            continuation.resume(returning: loginFlow)
+        } else if let appleIDCredential = authorization.credential as? ASAuthorizationAppleIDCredential {
+            guard case let .loginFlow(continuation) = context.pending else {
+                throw ReachFiveError.TechnicalError(reason: "didCompleteWithAuthorization: unexpected Sign In With Apple credential for this request")
+            }
+            guard let nonce = context.nonce, let scope = context.scope, let appleProvider = context.appleProvider else {
+                throw ReachFiveError.TechnicalError(reason: "didCompleteWithAuthorization: no scope, no nonce, no apple provider")
+            }
+
+            guard let identityToken = appleIDCredential.identityToken else {
+                throw ReachFiveError.TechnicalError(reason: "didCompleteWithAuthorization: no id token returned")
+            }
+
+            guard let idToken = String(data: identityToken, encoding: .utf8) else {
+                throw ReachFiveError.TechnicalError(reason: "didCompleteWithAuthorization: unreadable id token \(identityToken)")
+            }
+
+            let pkce = Pkce.generate()
+            let code = try await reachFiveApi.authorize(params: [
+                "provider": appleProvider.providerConfig.providerWithVariant,
+                "client_id": reachFiveApi.sdkConfig.clientId,
+                "id_token": idToken,
+                "response_type": "code",
+                "redirect_uri": reachFiveApi.sdkConfig.redirectUri.absoluteString,
+                "scope": scope,
+                "code_challenge": pkce.codeChallenge,
+                "code_challenge_method": pkce.codeChallengeMethod,
+                "nonce": nonce.codeVerifier,
+                "origin": context.originR5,
+                "given_name": appleIDCredential.fullName?.givenName,
+                "family_name": appleIDCredential.fullName?.familyName
+            ])
+            let token = try await authWithCode(code: code, pkce: pkce)
+            continuation.resume(returning: .AchievedLogin(authToken: token))
+        } else if #available(iOS 16.0, *), let credentialRegistration = authorization.credential as? ASAuthorizationPlatformPublicKeyCredentialRegistration {
+            // A new passkey was registered
+            guard let attestationObject = credentialRegistration.rawAttestationObject else {
+                throw ReachFiveError.TechnicalError(reason: "didCompleteWithAuthorization: no attestationObject")
+            }
+
+            let clientDataJSON = credentialRegistration.rawClientDataJSON
+            let r5AuthenticatorAttestationResponse = R5AuthenticatorAttestationResponse(attestationObject: attestationObject.toBase64Url(), clientDataJSON: clientDataJSON.toBase64Url())
+
+            let id = credentialRegistration.credentialID.toBase64Url()
+            let registrationPublicKeyCredential = RegistrationPublicKeyCredential(id: id, rawId: id, type: "public-key", response: r5AuthenticatorAttestationResponse)
+
+            guard let passkeyCreationType = context.passkeyCreationType else {
+                throw ReachFiveError.TechnicalError(reason: "didCompleteWithAuthorization: no signupOptions")
+            }
+
+            switch passkeyCreationType {
+            case let .AddPasskey(authToken):
+                guard case let .registration(continuation) = context.pending else {
+                    throw ReachFiveError.TechnicalError(reason: "didCompleteWithAuthorization: unexpected passkey registration for this request")
+                }
+                try await reachFiveApi.registerWithWebAuthn(authToken: authToken, publicKeyCredential: registrationPublicKeyCredential, originR5: context.originR5)
+                continuation.resume(returning: ())
+
+            case let .Signup(signupOptions):
+                guard case let .authToken(continuation) = context.pending else {
+                    throw ReachFiveError.TechnicalError(reason: "didCompleteWithAuthorization: unexpected passkey registration for this request")
+                }
+                guard let scope = context.scope else {
+                    throw ReachFiveError.TechnicalError(reason: "didCompleteWithAuthorization: no scope")
+                }
+
+                let webauthnSignupCredential = WebauthnSignupCredential(webauthnId: signupOptions.options.publicKey.user.id, publicKeyCredential: registrationPublicKeyCredential)
+                let authenticationToken = try await reachFiveApi.signupWithWebAuthn(webauthnSignupCredential: webauthnSignupCredential, originR5: context.originR5)
+                let authToken = try await loginCallback(tkn: authenticationToken.tkn, scope: scope, origin: context.originR5)
+                continuation.resume(returning: authToken)
+
+            case let .ResetPasskey(resetOptions):
+                guard case let .registration(continuation) = context.pending else {
+                    throw ReachFiveError.TechnicalError(reason: "didCompleteWithAuthorization: unexpected passkey registration for this request")
+                }
+                let resetPublicKeyCredential = ResetPublicKeyCredential(resetOptions: resetOptions, publicKeyCredential: registrationPublicKeyCredential)
+                try await reachFiveApi.resetWebAuthn(resetPublicKeyCredential: resetPublicKeyCredential, originR5: context.originR5)
+                continuation.resume(returning: ())
+            }
+        } else if #available(iOS 16.0, *), let credentialAssertion = authorization.credential as? ASAuthorizationPlatformPublicKeyCredentialAssertion {
+            // A passkey was selected to sign in
+
+            guard let scope = context.scope else {
+                throw ReachFiveError.TechnicalError(reason: "didCompleteWithAuthorization: no scope")
+            }
+
+            let signature = credentialAssertion.signature.toBase64Url()
+            let clientDataJSON = credentialAssertion.rawClientDataJSON.toBase64Url()
+            let userID = credentialAssertion.userID.toBase64Url()
+
+            let id = credentialAssertion.credentialID.toBase64Url()
+            let authenticatorData = credentialAssertion.rawAuthenticatorData.toBase64Url()
+            let response = R5AuthenticatorAssertionResponse(authenticatorData: authenticatorData, clientDataJSON: clientDataJSON, signature: signature, userHandle: userID)
+
+            let authenticationToken = try await reachFiveApi.authenticateWithWebAuthn(authenticationPublicKeyCredential: AuthenticationPublicKeyCredential(id: id, rawId: id, type: "public-key", response: response))
+            let authToken = try await loginCallback(tkn: authenticationToken.tkn, scope: scope, origin: context.originR5)
+
+            switch context.pending {
+            case let .authToken(continuation):
+                continuation.resume(returning: authToken)
+            case let .loginFlow(continuation):
+                continuation.resume(returning: .AchievedLogin(authToken: authToken))
+            case .registration:
+                throw ReachFiveError.TechnicalError(reason: "didCompleteWithAuthorization: unexpected passkey assertion for this request")
+            }
+        } else {
+            throw ReachFiveError.TechnicalError(reason: "didCompleteWithAuthorization: Received unknown authorization type.")
         }
+    }
+
+    private func handleError(_ error: Error, for controller: ASAuthorizationController) {
+        guard let context = takeContext(for: controller) else {
+            // controller inconnu ou requête déjà résolue : rien à faire
+            return
+        }
+
         let reachFiveError: ReachFiveError
 
         if let authorizationError = error as? ASAuthorizationError {
@@ -505,14 +532,28 @@ extension CredentialManager: ASAuthorizationControllerDelegate {
             reachFiveError = .TechnicalError(reason: "\(error.localizedDescription)")
         }
 
-        continuationWithStepUp?.resume(throwing: reachFiveError)
-        continuationRegistration?.resume(throwing: reachFiveError)
-        continuationWithAuthToken?.resume(throwing: reachFiveError)
+        context.fail(with: reachFiveError)
     }
 }
 
 // MARK: - utilities
 extension CredentialManager {
+    /// Construit une requête d'enregistrement de passkey à partir des options renvoyées par le serveur.
+    /// Pendant symétrique de ``createCredentialAssertionRequest(_:)``.
+    @available(iOS 16.0, *)
+    private func makeCredentialRegistrationRequest(from options: RegistrationOptions, friendlyName: String) throws -> ASAuthorizationRequest {
+        guard let challenge = options.options.publicKey.challenge.decodeBase64Url() else {
+            throw ReachFiveError.TechnicalError(reason: "unreadable challenge: \(options.options.publicKey.challenge)")
+        }
+
+        guard let userID = options.options.publicKey.user.id.decodeBase64Url() else {
+            throw ReachFiveError.TechnicalError(reason: "unreadable userID from public key: \(options.options.publicKey.user.id)")
+        }
+
+        let publicKeyCredentialProvider = ASAuthorizationPlatformPublicKeyCredentialProvider(relyingPartyIdentifier: options.options.publicKey.rp.id)
+        return publicKeyCredentialProvider.createCredentialRegistrationRequest(challenge: challenge, name: friendlyName, userID: userID)
+    }
+
     @available(iOS 16.0, *)
     private func createCredentialAssertionRequest(_ assertionRequestOptions: AuthenticationOptions) throws -> ASAuthorizationPlatformPublicKeyCredentialAssertionRequest {
         guard let challenge = assertionRequestOptions.publicKey.challenge.decodeBase64Url() else {

--- a/Sources/Core/Classes/CredentialManager.swift
+++ b/Sources/Core/Classes/CredentialManager.swift
@@ -189,24 +189,42 @@ class CredentialManager: NSObject {
         return try await authenticate(with: authorization, scopes: request.scopes, reachFive: reachFive, originR5: request.origin)
     }
 
-    // MARK: - Modal
+    // MARK: - Non-discoverable
 
+    /// La seule requête possible ici est une assertion restreinte aux credentials que le serveur associe
+    /// au username : il n'y a pas de lot à assembler, le flux construit sa requête lui-même.
+    ///
+    /// Volontairement sans annotation `@available`, contrairement aux autres flux passkey : `.Passkey` est
+    /// le seul cas de `NonDiscoverableAuthorization` aujourd'hui, mais une assertion de clé de sécurité
+    /// existe dès iOS 15 et serait un second cas ici — cette méthode et
+    /// ``authenticate(with:scopes:reachFive:originR5:)`` sont écrites pour que l'ajouter ne demande pas de
+    /// relever la version minimale de ce flux.
     func login(withNonDiscoverableUsername username: Username, forRequest request: ResolvedNativeLoginRequest, usingModalAuthorizationFor requestTypes: [NonDiscoverableAuthorization], display mode: Mode, reachFive: ReachFive) async throws -> AuthToken {
-        let webAuthnLoginRequest = makeWebAuthnLoginRequest(for: request, username: username, reachFive: reachFive)
-
-        let built = try await buildAuthorizationRequests(
-            webAuthnLoginRequest,
-            reachFive: reachFive,
-            authorizing: requestTypes.compactMap { adaptAuthz($0) },
-            restrictingPasskeysToAllowedCredentials: true
+        let options = try await reachFive.reachFiveApi.createWebAuthnAuthenticationOptions(
+            webAuthnLoginRequest: makeWebAuthnLoginRequest(for: request, username: username, reachFive: reachFive)
         )
 
-        let authorization = try await perform(requests: built.requests, anchor: request.anchor) {
-            performRequests(on: $0, mode: mode)
+        // Une requête par type demandé, toutes construites sur les mêmes options serveur. Le compte est
+        // connu ici, donc chaque requête est restreinte aux credentials que le serveur lui associe.
+        var requests: [ASAuthorizationRequest] = []
+        for type in requestTypes {
+            switch type {
+            case .Passkey:
+                // `.Passkey` n'est pas constructible sous iOS 16, donc cette branche ne s'exécute jamais
+                // ailleurs — la garde est pour le compilateur, qui ne peut pas le savoir.
+                if #available(iOS 16.0, *) {
+                    try requests.append(makePasskeyAssertionRequest(options, restrictedToAllowedCredentials: true))
+                }
+            }
         }
 
+        let authorization = try await perform(requests: requests, anchor: request.anchor) {
+            performRequests(on: $0, mode: mode)
+        }
         return try await authenticate(with: authorization, scopes: request.scopes, reachFive: reachFive, originR5: request.origin)
     }
+
+    // MARK: - Modal
 
     func login(withRequest request: ResolvedNativeLoginRequest, usingModalAuthorizationFor requestTypes: [ModalAuthorization], display mode: Mode, appleProvider: ConfiguredAppleProvider?, reachFive: ReachFive) async throws -> LoginFlow {
         let built = try await buildAuthorizationRequests(
@@ -238,7 +256,6 @@ class CredentialManager: NSObject {
         reachFive: ReachFive,
         authorizing requestTypes: [ModalAuthorization],
         appleProvider: ConfiguredAppleProvider? = nil,
-        restrictingPasskeysToAllowedCredentials restrictToAllowedCredentials: Bool = false,
         fetchAuthenticationOptions: (ReachFive, WebAuthnLoginRequest) async throws -> AuthenticationOptions = { try await $0.reachFiveApi.createWebAuthnAuthenticationOptions(webAuthnLoginRequest: $1) }
     ) async throws -> BuiltRequests {
         var requests: [ASAuthorizationRequest] = []
@@ -276,7 +293,7 @@ class CredentialManager: NSObject {
                 do {
                     // Allow the user to use a saved passkey, if they have one.
                     let authOptions = try await fetchAuthenticationOptions(reachFive, webAuthnLoginRequest)
-                    try requests.append(makePasskeyAssertionRequest(authOptions, restrictedToAllowedCredentials: restrictToAllowedCredentials))
+                    try requests.append(makePasskeyAssertionRequest(authOptions, restrictedToAllowedCredentials: false))
                 } catch let error where requestTypes.count > 1 {
                     // if there are other types of requests, do not block auth if only passkey fails. Just eat the error
                     Logger.shared.log("Passkey request error ignored in multi-type authorization: \(error)")
@@ -514,12 +531,5 @@ extension CredentialManager {
             .map(ASAuthorizationPlatformPublicKeyCredentialDescriptor.init(credentialID:))
 
         return assertionRequest
-    }
-
-    private func adaptAuthz(_ nda: NonDiscoverableAuthorization) -> ModalAuthorization? {
-        if #available(iOS 16.0, *), nda == .Passkey {
-            return ModalAuthorization.Passkey
-        }
-        return nil
     }
 }

--- a/Sources/Core/Classes/CredentialManager.swift
+++ b/Sources/Core/Classes/CredentialManager.swift
@@ -248,7 +248,13 @@ class CredentialManager: NSObject {
         let siwa: SignInWithApple?
     }
 
-    /// Construit les `ASAuthorizationRequest` pour les types demandés, sans toucher à l'état de la classe.
+    /// Construit les `ASAuthorizationRequest` pour les types demandés, dans l'ordre demandé — le système
+    /// présente les credentials dans cet ordre.
+    ///
+    /// Un type qu'on ne sait pas préparer (pas de provider Apple configuré, options passkey
+    /// inaccessibles) est écarté du lot plutôt que de bloquer la connexion quand un autre type peut
+    /// encore aboutir ; la raison du premier type écarté n'est remontée que si rien ne survit.
+    ///
     /// `fetchAuthenticationOptions` fait l'appel réseau par défaut ; un test peut le substituer pour
     /// construire les requêtes sans réseau.
     func buildAuthorizationRequests(
@@ -260,51 +266,59 @@ class CredentialManager: NSObject {
     ) async throws -> BuiltRequests {
         var requests: [ASAuthorizationRequest] = []
         var siwa: SignInWithApple? = nil
+        var firstDropped: Error? = nil
 
         for type in requestTypes {
-            switch type {
-            case .Password:
-                // Allow the user to use a saved password, if they have one.
-                let passwordRequest = ASAuthorizationPasswordProvider().createRequest()
-                requests.append(passwordRequest)
+            do {
+                switch type {
+                case .Password:
+                    // Allow the user to use a saved password, if they have one.
+                    requests.append(ASAuthorizationPasswordProvider().createRequest())
 
-            case .SignInWithApple:
-                // Allow the user to use a Sign In With Apple, if they have one.
-                let appleIDRequest = ASAuthorizationAppleIDProvider().createRequest()
-                var appleScopes: [ASAuthorization.Scope] = []
-                if let scope = appleProvider?.providerConfig.scope {
-                    if scope.contains(where: { s in s == "email" }) {
-                        appleScopes.append(.email)
+                case .SignInWithApple:
+                    // Sans provider Apple, la requête ne pourrait pas être complétée (cf.
+                    // completeModalLogin) : mieux vaut ne pas la proposer que d'authentifier
+                    // l'utilisateur pour échouer ensuite.
+                    guard let appleProvider else {
+                        throw ReachFiveError.TechnicalError(reason: "Sign In With Apple is not available: no Apple provider configured. Check that initialize() completed and that Apple is enabled for this client.")
                     }
-                    if scope.contains(where: { s in s == "name" }) {
-                        appleScopes.append(.fullName)
+
+                    // Allow the user to use a Sign In With Apple, if they have one.
+                    let appleIDRequest = ASAuthorizationAppleIDProvider().createRequest()
+                    var appleScopes: [ASAuthorization.Scope] = []
+                    if let scope = appleProvider.providerConfig.scope {
+                        if scope.contains(where: { s in s == "email" }) {
+                            appleScopes.append(.email)
+                        }
+                        if scope.contains(where: { s in s == "name" }) {
+                            appleScopes.append(.fullName)
+                        }
                     }
-                }
-                appleIDRequest.requestedScopes = appleScopes
-                let siwaNonce = Pkce.generate()
-                appleIDRequest.nonce = siwaNonce.codeChallenge
-                if let appleProvider {
+                    appleIDRequest.requestedScopes = appleScopes
+                    let siwaNonce = Pkce.generate()
+                    appleIDRequest.nonce = siwaNonce.codeChallenge
                     siwa = SignInWithApple(nonce: siwaNonce, provider: appleProvider)
-                }
 
-                requests.append(appleIDRequest)
+                    requests.append(appleIDRequest)
 
-            case .Passkey:
-                // `.Passkey` n'est pas constructible sous iOS 16, donc cette branche ne s'exécute jamais
-                // ailleurs — la garde est pour le compilateur, qui ne peut pas le savoir.
-                if #available(iOS 16.0, *) {
-                    do {
+                case .Passkey:
+                    // `.Passkey` n'est pas constructible sous iOS 16, donc cette branche ne s'exécute
+                    // jamais ailleurs — la garde est pour le compilateur, qui ne peut pas le savoir.
+                    if #available(iOS 16.0, *) {
                         // Allow the user to use a saved passkey, if they have one.
                         let authOptions = try await fetchAuthenticationOptions(reachFive, webAuthnLoginRequest)
                         try requests.append(makePasskeyAssertionRequest(authOptions, restrictedToAllowedCredentials: false))
-                    } catch let error where requestTypes.count > 1 {
-                        // if there are other types of requests, do not block auth if only passkey fails. Just eat the error
-                        Logger.shared.log("Passkey request error ignored in multi-type authorization: \(error)")
                     }
                 }
+            } catch {
+                Logger.shared.log("Authorization request dropped for \(type): \(error)")
+                firstDropped = firstDropped ?? error
             }
         }
 
+        if requests.isEmpty, let firstDropped {
+            throw firstDropped
+        }
         return BuiltRequests(requests: requests, siwa: siwa)
     }
 
@@ -441,6 +455,8 @@ extension CredentialManager {
             return try await reachFive.loginFlow(afterPasswordGrant: resp, scopes: scopes, origin: originR5)
         } else if let appleIDCredential = authorization.credential as? ASAuthorizationAppleIDCredential {
             guard let siwa else {
+                // Garanti par buildAuthorizationRequests : une requête Sign In With Apple n'entre dans le
+                // lot qu'accompagnée de son SignInWithApple.
                 throw ReachFiveError.TechnicalError(reason: "didCompleteWithAuthorization: no nonce, no apple provider")
             }
             guard let identityToken = appleIDCredential.identityToken else {

--- a/Sources/Core/Classes/CredentialManager.swift
+++ b/Sources/Core/Classes/CredentialManager.swift
@@ -13,7 +13,11 @@ class CredentialManager: NSObject {
     /// RequestContext indexed by its controller: each callback finds the context of its own request, and
     /// one request can never overwrite another's state.
     private struct RequestContext {
-        /// retained: keeps the system request alive until it completes
+        /// Identifies the request for a cancellation that has to hop back onto the main actor. An `Int` is
+        /// `Sendable` — the controller is not, and capturing it in the `@Sendable` `onCancel` closure is an
+        /// error in the Swift 6 language mode — and it is never recycled, unlike the controller's address.
+        let id: Int
+        /// kept to be able to `cancel()` the system request
         let controller: ASAuthorizationController
         /// anchor for the presentationContextProvider
         let anchor: ASPresentationAnchor
@@ -30,6 +34,18 @@ class CredentialManager: NSObject {
 
     /// requests in flight, indexed by their controller
     private var contexts: [ObjectIdentifier: RequestContext] = [:]
+
+    /// Monotonic, never reset: a fresh identity for each request, so a cancellation that lands late can
+    /// never resolve a request submitted since.
+    private var lastRequestId = 0
+
+    /// The caller's task was canceled. Deliberately not `.AuthCanceled`: apps react to that one by
+    /// restarting an auto-fill request, whereas here the calling screen is going away.
+    private static let callerCanceled = ReachFiveError.TechnicalError(reason: "The calling task was canceled")
+
+    /// `ASAuthorizationController` requires at least one request; without this the system would never call
+    /// the delegate back and the caller would hang forever.
+    private static let noRequest = ReachFiveError.TechnicalError(reason: "No authorization request to perform")
 
     /// nonisolated: called from ReachFive's synchronous init, outside the main actor
     override nonisolated init() {}
@@ -50,33 +66,32 @@ class CredentialManager: NSObject {
         anchor: ASPresentationAnchor,
         using submit: (ASAuthorizationController) -> Void
     ) async throws -> ASAuthorization {
-        guard !requests.isEmpty else {
-            // ASAuthorizationController requires at least one request. Without this guard, the system
-            // would never call the delegate back and the caller would hang forever.
-            throw ReachFiveError.TechnicalError(reason: "No authorization request to perform")
-        }
+        guard !requests.isEmpty else { throw Self.noRequest }
 
         let controller = ASAuthorizationController(authorizationRequests: requests)
         controller.delegate = self
         controller.presentationContextProvider = self
-        let key = ObjectIdentifier(controller)
+        lastRequestId += 1
+        let id = lastRequestId
 
         return try await withTaskCancellationHandler {
             // The caller's task may already be canceled by the time we get here: submit nothing.
-            try Task.checkCancellation()
+            guard !Task.isCancelled else { throw Self.callerCanceled }
 
             return try await withCheckedThrowingContinuation { continuation in
                 // Canceling requests in flight and submitting the new one in the same synchronous block:
                 // no other task can run on the main actor in between.
                 cancelInFlightRequests()
-                contexts[key] = RequestContext(controller: controller, anchor: anchor, continuation: continuation)
+                contexts[ObjectIdentifier(controller)] = RequestContext(id: id, controller: controller, anchor: anchor, continuation: continuation)
                 submit(controller)
             }
         } onCancel: {
             // onCancel runs off the main actor; hop back onto it to touch `contexts`. The task hop cannot
             // outrun registering the context: the block above only yields back to the main actor after
-            // submission.
-            Task { @MainActor in self.cancelBecauseCallerWasCancelled(key) }
+            // submission. The request is named by its `id` rather than by its controller: an `Int` crosses
+            // into this `@Sendable` closure, and it cannot designate a later request the way a reused
+            // address could.
+            Task { @MainActor in self.cancelBecauseCallerWasCancelled(id) }
         }
     }
 
@@ -105,31 +120,28 @@ class CredentialManager: NSObject {
         }
     }
 
-    /// Resumes the `key` request with `CancellationError` because the caller's task was canceled, and
-    /// stops the system request. Deliberately not `.AuthCanceled`: that error signals a user cancellation,
-    /// to which apps react by restarting an auto-fill request, whereas here it is the calling screen that
-    /// is going away.
-    private func cancelBecauseCallerWasCancelled(_ key: ObjectIdentifier) {
-        guard let context = contexts.removeValue(forKey: key) else {
+    /// Stops request `id` and resumes it with ``callerCanceled``, because the caller's task was canceled.
+    ///
+    /// Looked up by scanning rather than by key: the dictionary is indexed by controller, for the delegate
+    /// callbacks, and only ever holds the one or two requests that overlap.
+    private func cancelBecauseCallerWasCancelled(_ id: Int) {
+        guard let key = contexts.first(where: { $0.value.id == id })?.key,
+              let context = contexts.removeValue(forKey: key) else {
             // request already completed, or never registered: nothing to do
             return
         }
         if #available(iOS 16.0, *) {
             context.controller.cancel()
         }
-        context.continuation.resume(throwing: CancellationError())
+        context.continuation.resume(throwing: Self.callerCanceled)
     }
 
     // MARK: - Signup
 
     @available(iOS 16.0, *)
-    func signUp(withRequest request: SignupOptions, anchor: ASPresentationAnchor, originR5: String? = nil, reachFive: ReachFive) async throws -> AuthToken {
+    func signUp(withRequest request: SignupOptions, scopes: [String], anchor: ASPresentationAnchor, originR5: String? = nil, reachFive: ReachFive) async throws -> AuthToken {
         let options = try await reachFive.reachFiveApi.createWebAuthnSignupOptions(webAuthnSignupOptions: request)
         let registrationRequest = try makeCredentialRegistrationRequest(from: options, friendlyName: request.friendlyName)
-
-        // request.scope is already the space-joined list of scopes (see SignupOptions); we recover it
-        // here rather than duplicating the value as a parameter, an OAuth scope token cannot contain a space.
-        let scopes = request.scope.components(separatedBy: " ")
 
         let authorization = try await perform(requests: [registrationRequest], anchor: anchor) {
             $0.performRequests()
@@ -204,6 +216,9 @@ class CredentialManager: NSObject {
     /// ``authenticate(with:scopes:reachFive:originR5:)`` are written so that adding it will not require
     /// raising this flow's own minimum version.
     func login(withNonDiscoverableUsername username: Username, forRequest request: ResolvedNativeLoginRequest, usingModalAuthorizationFor requestTypes: [NonDiscoverableAuthorization], display mode: Mode, reachFive: ReachFive) async throws -> AuthToken {
+        // Checked before the round-trip: nothing to build means nothing to submit.
+        guard !requestTypes.isEmpty else { throw Self.noRequest }
+
         let options = try await reachFive.reachFiveApi.createWebAuthnAuthenticationOptions(
             webAuthnLoginRequest: makeWebAuthnLoginRequest(for: request, username: username, reachFive: reachFive)
         )

--- a/Sources/Core/Classes/CredentialManager.swift
+++ b/Sources/Core/Classes/CredentialManager.swift
@@ -1,58 +1,58 @@
 import AuthenticationServices
 import Foundation
 
-/// Les deux protocoles d'ASAuthorizationController (delegate et presentationContextProvider) sont annotés
-/// NS_SWIFT_UI_ACTOR : leurs callbacks arrivent donc sur le main actor, et l'isolation @MainActor de la
-/// classe protège l'état mutable partagé entre les points d'entrée async et ces callbacks.
+/// Both ASAuthorizationController protocols (delegate and presentationContextProvider) are annotated
+/// NS_SWIFT_UI_ACTOR: their callbacks are therefore delivered on the main actor, and the class's @MainActor
+/// isolation protects the mutable state shared between the async entry points and those callbacks.
 @MainActor
 class CredentialManager: NSObject {
-    // MARK: - Contexte de requête
+    // MARK: - Request context
 
-    /// Les requêtes peuvent se chevaucher : une nouvelle requête annule celles en cours, mais le callback
-    /// système d'une requête annulée peut encore arriver après. Tout l'état d'une requête vit donc dans un
-    /// RequestContext indexé par son controller : chaque callback retrouve le contexte de sa requête, et
-    /// une requête ne peut pas écraser l'état d'une autre.
+    /// Requests can overlap: a new request cancels the ones in flight, but the system callback of a
+    /// canceled request can still arrive afterwards. All of a request's state therefore lives in a
+    /// RequestContext indexed by its controller: each callback finds the context of its own request, and
+    /// one request can never overwrite another's state.
     private struct RequestContext {
-        /// retenu : maintient la requête système en vie jusqu'à sa complétion
+        /// retained: keeps the system request alive until it completes
         let controller: ASAuthorizationController
-        /// anchor pour le presentationContextProvider
+        /// anchor for the presentationContextProvider
         let anchor: ASPresentationAnchor
-        /// continuation de l'appelant, reprise exactement une fois : toute reprise passe par le retrait
-        /// du contexte du dictionnaire, et seul le retrait qui réussit reprend la continuation
+        /// the caller's continuation, resumed exactly once: every resumption goes through removing the
+        /// context from the dictionary, and only the removal that succeeds resumes the continuation
         let continuation: CheckedContinuation<ASAuthorization, Error>
     }
 
-    /// Données d'un Sign In With Apple, à conserver entre la construction de la requête et sa complétion.
+    /// Sign In With Apple data, kept between building the request and completing it.
     struct SignInWithApple {
         let nonce: Pkce
         let provider: ConfiguredAppleProvider
     }
 
-    /// les requêtes en cours, indexées par leur controller
+    /// requests in flight, indexed by their controller
     private var contexts: [ObjectIdentifier: RequestContext] = [:]
 
-    /// nonisolated : appelé depuis l'init synchrone de ReachFive, hors du main actor
+    /// nonisolated: called from ReachFive's synchronous init, outside the main actor
     override nonisolated init() {}
 
-    // MARK: - Cycle de vie des requêtes
+    // MARK: - Request lifecycle
 
-    /// Soumet une requête système et rend l'autorisation obtenue. Le post-traitement (validation serveur,
-    /// échange de jeton) reste dans la tâche de l'appelant, qui garde donc la main sur son annulation et
-    /// sur ses erreurs, et chaque flux se lit d'un seul tenant à son point d'entrée.
+    /// Submits a system request and returns the authorization obtained. Post-processing (server
+    /// validation, token exchange) stays in the caller's task, which therefore keeps control of its own
+    /// cancellation and errors, and each flow reads in one piece at its entry point.
     ///
-    /// Le contexte est enregistré avant la soumission : comme tout se passe sur le main actor, la
-    /// continuation est en place avant que le delegate puisse tirer.
+    /// The context is registered before submission: since everything runs on the main actor, the
+    /// continuation is in place before the delegate can be called.
     ///
-    /// Internal pour être testable : un test pilote la méthode avec un `submit` inerte (la requête n'est
-    /// jamais soumise au système) puis simule les callbacks du delegate.
+    /// Internal for testability: a test drives the method with an inert `submit` (the request is never
+    /// submitted to the system) then simulates the delegate callbacks.
     func perform(
         requests: [ASAuthorizationRequest],
         anchor: ASPresentationAnchor,
         using submit: (ASAuthorizationController) -> Void
     ) async throws -> ASAuthorization {
         guard !requests.isEmpty else {
-            // ASAuthorizationController exige au moins une requête. Sans cette garde, le système ne
-            // rappellerait jamais le delegate et l'appelant resterait suspendu indéfiniment.
+            // ASAuthorizationController requires at least one request. Without this guard, the system
+            // would never call the delegate back and the caller would hang forever.
             throw ReachFiveError.TechnicalError(reason: "No authorization request to perform")
         }
 
@@ -62,56 +62,56 @@ class CredentialManager: NSObject {
         let key = ObjectIdentifier(controller)
 
         return try await withTaskCancellationHandler {
-            // La tâche appelante peut avoir été annulée avant même d'arriver ici : ne rien soumettre.
+            // The caller's task may already be canceled by the time we get here: submit nothing.
             try Task.checkCancellation()
 
             return try await withCheckedThrowingContinuation { continuation in
-                // Annulation des requêtes en cours et soumission de la nouvelle dans le même bloc
-                // synchrone : aucune autre tâche du main actor ne peut s'exécuter entre les deux.
+                // Canceling requests in flight and submitting the new one in the same synchronous block:
+                // no other task can run on the main actor in between.
                 cancelInFlightRequests()
                 contexts[key] = RequestContext(controller: controller, anchor: anchor, continuation: continuation)
                 submit(controller)
             }
         } onCancel: {
-            // onCancel est appelé hors du main actor ; on y repasse pour toucher `contexts`. Le saut de
-            // tâche ne peut pas devancer l'enregistrement du contexte : le bloc ci-dessus ne rend la main
-            // au main actor qu'après la soumission.
+            // onCancel runs off the main actor; hop back onto it to touch `contexts`. The task hop cannot
+            // outrun registering the context: the block above only yields back to the main actor after
+            // submission.
             Task { @MainActor in self.cancelBecauseCallerWasCancelled(key) }
         }
     }
 
-    /// Annule les requêtes en cours, principalement pour annuler une requête auto-fill avant de démarrer
-    /// une requête modale (sinon cette dernière échouerait).
+    /// Cancels requests in flight, mainly to cancel an auto-fill request before starting a modal one
+    /// (otherwise the latter would fail).
     ///
-    /// La continuation de chaque requête annulée est reprise ici en `.AuthCanceled`, sans attendre le
-    /// `didCompleteWithError(.canceled)` du système : celui-ci n'est promis que si un flux tournait
-    /// effectivement (cf. la doc de `ASAuthorizationController.cancel()`), et une requête dont le système
-    /// ne rappelle jamais laisserait son appelant suspendu et son contexte en mémoire pour toujours. Le
-    /// callback tardif éventuel ne trouve plus de contexte et est ignoré.
+    /// Each canceled request's continuation is resumed here with `.AuthCanceled`, without waiting for the
+    /// system's `didCompleteWithError(.canceled)`: that callback is only promised if a flow was actually
+    /// running (see the doc of `ASAuthorizationController.cancel()`), and a request the system never calls
+    /// back on would leave its caller hanging and its context in memory forever. Any late callback then
+    /// finds no context left and is ignored.
     ///
-    /// Appelé par ``perform(requests:anchor:using:)`` dans le même bloc synchrone que la soumission de la
-    /// nouvelle requête : l'application ne peut donc pas relancer une requête auto-fill — sa réaction
-    /// habituelle à `.AuthCanceled` — avant que la nouvelle requête ne soit soumise.
+    /// Called by ``perform(requests:anchor:using:)`` in the same synchronous block as submitting the new
+    /// request: the app therefore cannot restart an auto-fill request — its usual reaction to
+    /// `.AuthCanceled` — before the new request has been submitted.
     ///
-    /// Internal pour être testable.
+    /// Internal for testability.
     func cancelInFlightRequests() {
         let inFlight = Array(contexts.values)
         contexts.removeAll()
         for context in inFlight {
-            if #available(iOS 16.0, *) { // cancel() n'existe qu'à partir d'iOS 16
+            if #available(iOS 16.0, *) { // cancel() only exists from iOS 16
                 context.controller.cancel()
             }
             context.continuation.resume(throwing: ReachFiveError.AuthCanceled)
         }
     }
 
-    /// Reprend la requête `key` en `CancellationError` parce que la tâche appelante a été annulée, et
-    /// arrête la requête système. Volontairement pas `.AuthCanceled` : cette erreur signale une annulation
-    /// par l'utilisateur, à laquelle les applications réagissent en relançant une requête auto-fill, alors
-    /// qu'ici c'est l'écran appelant qui disparaît.
+    /// Resumes the `key` request with `CancellationError` because the caller's task was canceled, and
+    /// stops the system request. Deliberately not `.AuthCanceled`: that error signals a user cancellation,
+    /// to which apps react by restarting an auto-fill request, whereas here it is the calling screen that
+    /// is going away.
     private func cancelBecauseCallerWasCancelled(_ key: ObjectIdentifier) {
         guard let context = contexts.removeValue(forKey: key) else {
-            // requête déjà complétée ou jamais enregistrée : rien à faire
+            // request already completed, or never registered: nothing to do
             return
         }
         if #available(iOS 16.0, *) {
@@ -127,8 +127,8 @@ class CredentialManager: NSObject {
         let options = try await reachFive.reachFiveApi.createWebAuthnSignupOptions(webAuthnSignupOptions: request)
         let registrationRequest = try makeCredentialRegistrationRequest(from: options, friendlyName: request.friendlyName)
 
-        // request.scope est déjà le join espace de la liste de scopes (cf. SignupOptions) ; on la retrouve
-        // sans dupliquer la valeur en paramètre, un token de scope OAuth ne pouvant pas contenir d'espace.
+        // request.scope is already the space-joined list of scopes (see SignupOptions); we recover it
+        // here rather than duplicating the value as a parameter, an OAuth scope token cannot contain a space.
         let scopes = request.scope.components(separatedBy: " ")
 
         let authorization = try await perform(requests: [registrationRequest], anchor: anchor) {
@@ -191,27 +191,27 @@ class CredentialManager: NSObject {
 
     // MARK: - Non-discoverable
 
-    /// La seule requête possible ici est une assertion restreinte aux credentials que le serveur associe
-    /// au username : il n'y a pas de lot à assembler, le flux construit sa requête lui-même.
+    /// The only possible request here is an assertion restricted to the credentials the server associates
+    /// with the username: there is no batch to assemble, the flow builds its own request.
     ///
-    /// Volontairement sans annotation `@available`, contrairement aux autres flux passkey : `.Passkey` est
-    /// le seul cas de `NonDiscoverableAuthorization` aujourd'hui, mais une assertion de clé de sécurité
-    /// existe dès iOS 15 et serait un second cas ici — cette méthode et
-    /// ``authenticate(with:scopes:reachFive:originR5:)`` sont écrites pour que l'ajouter ne demande pas de
-    /// relever la version minimale de ce flux.
+    /// Deliberately without an `@available` annotation, unlike the other passkey flows: `.Passkey` is the
+    /// only case of `NonDiscoverableAuthorization` today, but a security key assertion exists from iOS 15
+    /// already and would be a second case here — this method and
+    /// ``authenticate(with:scopes:reachFive:originR5:)`` are written so that adding it will not require
+    /// raising this flow's own minimum version.
     func login(withNonDiscoverableUsername username: Username, forRequest request: ResolvedNativeLoginRequest, usingModalAuthorizationFor requestTypes: [NonDiscoverableAuthorization], display mode: Mode, reachFive: ReachFive) async throws -> AuthToken {
         let options = try await reachFive.reachFiveApi.createWebAuthnAuthenticationOptions(
             webAuthnLoginRequest: makeWebAuthnLoginRequest(for: request, username: username, reachFive: reachFive)
         )
 
-        // Une requête par type demandé, toutes construites sur les mêmes options serveur. Le compte est
-        // connu ici, donc chaque requête est restreinte aux credentials que le serveur lui associe.
+        // One request per requested type, all built from the same server options. The account is known
+        // here, so every request is restricted to the credentials the server associates with it.
         var requests: [ASAuthorizationRequest] = []
         for type in requestTypes {
             switch type {
             case .Passkey:
-                // `.Passkey` n'est pas constructible sous iOS 16, donc cette branche ne s'exécute jamais
-                // ailleurs — la garde est pour le compilateur, qui ne peut pas le savoir.
+                // `.Passkey` cannot be constructed below iOS 16, so this branch only ever runs there —
+                // the guard is for the compiler, which cannot know it.
                 if #available(iOS 16.0, *) {
                     try requests.append(makePasskeyAssertionRequest(options, restrictedToAllowedCredentials: true))
                 }
@@ -241,22 +241,22 @@ class CredentialManager: NSObject {
         return try await completeModalLogin(authorization, scopes: request.scopes, siwa: built.siwa, reachFive: reachFive, originR5: request.origin)
     }
 
-    /// Internal pour être testable
+    /// Internal for testability
     struct BuiltRequests {
         let requests: [ASAuthorizationRequest]
-        /// renseigné si une requête Sign In With Apple fait partie du lot
+        /// set when a Sign In With Apple request is part of the batch
         let siwa: SignInWithApple?
     }
 
-    /// Construit les `ASAuthorizationRequest` pour les types demandés, dans l'ordre demandé — le système
-    /// présente les credentials dans cet ordre.
+    /// Builds the `ASAuthorizationRequest`s for the requested types, in the requested order — the system
+    /// presents the credentials in that order.
     ///
-    /// Un type qu'on ne sait pas préparer (pas de provider Apple configuré, options passkey
-    /// inaccessibles) est écarté du lot plutôt que de bloquer la connexion quand un autre type peut
-    /// encore aboutir ; la raison du premier type écarté n'est remontée que si rien ne survit.
+    /// A type this function cannot prepare (no Apple provider configured, passkey options unreachable) is
+    /// dropped from the batch rather than blocking sign-in when another type can still succeed; the first
+    /// dropped reason only surfaces if nothing survives.
     ///
-    /// `fetchAuthenticationOptions` fait l'appel réseau par défaut ; un test peut le substituer pour
-    /// construire les requêtes sans réseau.
+    /// `fetchAuthenticationOptions` makes the network call by default; a test can substitute it to build
+    /// the requests without network.
     func buildAuthorizationRequests(
         _ webAuthnLoginRequest: WebAuthnLoginRequest,
         reachFive: ReachFive,
@@ -276,9 +276,9 @@ class CredentialManager: NSObject {
                     requests.append(ASAuthorizationPasswordProvider().createRequest())
 
                 case .SignInWithApple:
-                    // Sans provider Apple, la requête ne pourrait pas être complétée (cf.
-                    // completeModalLogin) : mieux vaut ne pas la proposer que d'authentifier
-                    // l'utilisateur pour échouer ensuite.
+                    // Without an Apple provider the request could not be completed (see
+                    // completeModalLogin): better not to offer it than to authenticate the user and fail
+                    // afterwards.
                     guard let appleProvider else {
                         throw ReachFiveError.TechnicalError(reason: "Sign In With Apple is not available: no Apple provider configured. Check that initialize() completed and that Apple is enabled for this client.")
                     }
@@ -302,8 +302,8 @@ class CredentialManager: NSObject {
                     requests.append(appleIDRequest)
 
                 case .Passkey:
-                    // `.Passkey` n'est pas constructible sous iOS 16, donc cette branche ne s'exécute
-                    // jamais ailleurs — la garde est pour le compilateur, qui ne peut pas le savoir.
+                    // `.Passkey` cannot be constructed below iOS 16, so this branch only ever runs there —
+                    // the guard is for the compiler, which cannot know it.
                     if #available(iOS 16.0, *) {
                         // Allow the user to use a saved passkey, if they have one.
                         let authOptions = try await fetchAuthenticationOptions(reachFive, webAuthnLoginRequest)
@@ -346,9 +346,9 @@ class CredentialManager: NSObject {
 extension CredentialManager: ASAuthorizationControllerPresentationContextProviding {
     func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
         guard let anchor = contexts[ObjectIdentifier(controller)]?.anchor else {
-            // Ne devrait pas arriver : le contexte est enregistré avant la soumission de la requête et
-            // retiré à sa complétion. Une fenêtre détachée vaut mieux qu'un crash, mais elle serait
-            // invisible à l'écran : on la signale.
+            // Should not happen: the context is registered before the request is submitted and removed
+            // only once it completes. A detached window is better than a crash, but it would be invisible
+            // on screen: log it.
             Logger.shared.log("presentationAnchor: no in-flight request for this controller, falling back to a detached window")
             return ASPresentationAnchor()
         }
@@ -367,14 +367,14 @@ extension CredentialManager: ASAuthorizationControllerDelegate {
         takeContext(for: controller)?.continuation.resume(throwing: Self.adapt(error))
     }
 
-    /// Retire le contexte à l'entrée du callback : garantit qu'une continuation est résolue exactement une
-    /// fois (un second callback pour le même controller ne trouve plus rien), et qu'une annulation
-    /// ultérieure ne peut plus toucher une requête déjà complétée.
+    /// Removes the context as soon as the callback arrives: guarantees a continuation is resumed exactly
+    /// once (a second callback for the same controller finds nothing left), and that a later cancellation
+    /// can no longer touch a request that already completed.
     private func takeContext(for controller: ASAuthorizationController) -> RequestContext? {
         contexts.removeValue(forKey: ObjectIdentifier(controller))
     }
 
-    /// Fonction pure, extraite pour être testable unitairement
+    /// Pure function, extracted to be unit-testable
     nonisolated static func adapt(_ error: Error) -> ReachFiveError {
         if let authorizationError = error as? ASAuthorizationError {
             if authorizationError.code == .canceled {
@@ -389,11 +389,11 @@ extension CredentialManager: ASAuthorizationControllerDelegate {
     }
 }
 
-// MARK: - exploitation des credentials reçus
+// MARK: - Extracting received credentials
 
 extension CredentialManager {
-    /// Extrait le credential d'enregistrement de passkey d'une autorisation (signup / add / reset)
-    /// et le convertit dans notre format. Lève une erreur technique si l'autorisation n'en contient pas.
+    /// Extracts a passkey registration credential from an authorization (signup / add / reset) and
+    /// converts it to our format. Throws a technical error if the authorization does not carry one.
     private func registrationCredential(from authorization: ASAuthorization) throws -> RegistrationPublicKeyCredential {
         guard #available(iOS 16.0, *), let credentialRegistration = authorization.credential as? ASAuthorizationPlatformPublicKeyCredentialRegistration else {
             throw ReachFiveError.TechnicalError(reason: "didCompleteWithAuthorization: expected a passkey registration")
@@ -407,13 +407,13 @@ extension CredentialManager {
         return RegistrationPublicKeyCredential(id: id, rawId: id, type: "public-key", response: response)
     }
 
-    /// Extrait l'assertion WebAuthn d'une autorisation, la valide auprès du serveur et rend le jeton.
-    /// Partagé par la connexion par passkey (auto-fill / non-discoverable) et la branche passkey de la
-    /// connexion modale. Lève une erreur technique si l'autorisation n'est pas une assertion WebAuthn.
+    /// Extracts a WebAuthn assertion from an authorization, validates it against the server and returns
+    /// the token. Shared by passkey sign-in (auto-fill / non-discoverable) and by the passkey branch of
+    /// the modal sign-in. Throws a technical error if the authorization is not a WebAuthn assertion.
     ///
-    /// Typée sur ``ASAuthorizationPublicKeyCredentialAssertion`` et non sur le credential de plateforme :
-    /// le protocole déclare tous les champs qu'on lit, et une assertion de clé de sécurité s'y conforme
-    /// aussi, donc supporter les clés de sécurité ne touchera pas cette méthode.
+    /// Typed on ``ASAuthorizationPublicKeyCredentialAssertion`` rather than on the platform credential:
+    /// the protocol declares every field we read, and a security key assertion conforms to it too, so
+    /// supporting security keys will not touch this method.
     private func authenticate(with authorization: ASAuthorization, scopes: [String], reachFive: ReachFive, originR5: String?) async throws -> AuthToken {
         guard #available(iOS 15.0, *), let assertion = authorization.credential as? any ASAuthorizationPublicKeyCredentialAssertion else {
             throw ReachFiveError.TechnicalError(reason: "didCompleteWithAuthorization: expected a WebAuthn assertion")
@@ -430,8 +430,8 @@ extension CredentialManager {
         return try await reachFive.loginCallback(tkn: authenticationToken.tkn, scopes: scopes, origin: originR5)
     }
 
-    /// Complète une connexion modale, seul flux à pouvoir recevoir plusieurs types de credential
-    /// (mot de passe, Sign In With Apple ou passkey).
+    /// Completes a modal sign-in, the only flow that can receive several kinds of credential (password,
+    /// Sign In With Apple, or passkey).
     private func completeModalLogin(_ authorization: ASAuthorization, scopes: [String], siwa: SignInWithApple?, reachFive: ReachFive, originR5: String?) async throws -> LoginFlow {
         let reachFiveApi = reachFive.reachFiveApi
         let sdkConfig = reachFive.sdkConfig
@@ -455,8 +455,8 @@ extension CredentialManager {
             return try await reachFive.loginFlow(afterPasswordGrant: resp, scopes: scopes, origin: originR5)
         } else if let appleIDCredential = authorization.credential as? ASAuthorizationAppleIDCredential {
             guard let siwa else {
-                // Garanti par buildAuthorizationRequests : une requête Sign In With Apple n'entre dans le
-                // lot qu'accompagnée de son SignInWithApple.
+                // Guaranteed by buildAuthorizationRequests: a Sign In With Apple request only ever makes
+                // it into the batch together with its SignInWithApple.
                 throw ReachFiveError.TechnicalError(reason: "didCompleteWithAuthorization: no nonce, no apple provider")
             }
             guard let identityToken = appleIDCredential.identityToken else {
@@ -491,22 +491,22 @@ extension CredentialManager {
     }
 }
 
-// MARK: - construction des requêtes
+// MARK: - Request construction
 
 extension CredentialManager {
-    /// Le socle commun aux trois flux de connexion WebAuthn.
+    /// The shared basis of the three WebAuthn login flows.
     private func makeWebAuthnLoginRequest(for request: ResolvedNativeLoginRequest, username: Username? = nil, reachFive: ReachFive) -> WebAuthnLoginRequest {
         WebAuthnLoginRequest(clientId: reachFive.sdkConfig.clientId, origin: request.originWebAuthn, username: username, scope: request.scopes)
     }
 
-    /// Construit une requête d'enregistrement de passkey à partir des options renvoyées par le serveur.
-    /// Pendant symétrique de ``makePasskeyAssertionRequest(_:restrictedToAllowedCredentials:)``.
+    /// Builds a passkey registration request from the options returned by the server. Counterpart of
+    /// ``makePasskeyAssertionRequest(_:restrictedToAllowedCredentials:)``.
     ///
-    /// `friendlyName` est celui demandé par l'application, et non `options.friendlyName` : rien ne garantit
-    /// que le serveur renvoie la valeur qu'on lui a passée, et c'est bien l'intention de l'application qui
-    /// doit nommer la passkey dans le trousseau.
+    /// `friendlyName` is the one the app asked for, not `options.friendlyName`: nothing guarantees the
+    /// server echoes back the value it was given, and it is the app's intent that should name the passkey
+    /// in the keychain.
     ///
-    /// Internal pour être testable.
+    /// Internal for testability.
     @available(iOS 16.0, *)
     func makeCredentialRegistrationRequest(from options: RegistrationOptions, friendlyName: String) throws -> ASAuthorizationRequest {
         guard let challenge = options.options.publicKey.challenge.decodeBase64Url() else {
@@ -521,16 +521,16 @@ extension CredentialManager {
         return publicKeyCredentialProvider.createCredentialRegistrationRequest(challenge: challenge, name: friendlyName, userID: userID)
     }
 
-    /// Construit une requête d'assertion de passkey à partir des options renvoyées par le serveur.
+    /// Builds a passkey assertion request from the options returned by the server.
     ///
-    /// - Parameter restrictedToAllowedCredentials: restreint la requête aux credentials listés par le
-    ///   serveur — ce que fait la connexion non-discoverable, qui sait de quel compte il s'agit. L'auto-fill
-    ///   et la connexion modale laissent au contraire l'utilisateur choisir parmi ses passkeys.
+    /// - Parameter restrictedToAllowedCredentials: restricts the request to the credentials listed by the
+    ///   server — what the non-discoverable sign-in does, since it already knows the account. Auto-fill
+    ///   and the modal sign-in instead let the user choose among their own passkeys.
     ///
-    /// Ce sont les appelants qui portent la garde de disponibilité : `.Passkey` n'étant pas constructible
-    /// sous iOS 16, sa présence dans une demande implique déjà iOS 16 à l'exécution.
+    /// The callers carry the availability guard: `.Passkey` cannot be constructed below iOS 16, so its
+    /// presence in a request already implies iOS 16 at runtime.
     ///
-    /// Internal pour être testable.
+    /// Internal for testability.
     @available(iOS 16.0, *)
     func makePasskeyAssertionRequest(_ options: AuthenticationOptions, restrictedToAllowedCredentials: Bool) throws -> ASAuthorizationRequest {
         guard let challenge = options.publicKey.challenge.decodeBase64Url() else {

--- a/Sources/Core/Classes/CredentialManager.swift
+++ b/Sources/Core/Classes/CredentialManager.swift
@@ -5,10 +5,6 @@ import AuthenticationServices
 // protège l'état mutable partagé entre les points d'entrée async et le delegate.
 @MainActor
 public class CredentialManager: NSObject {
-    // nonisolated(unsafe) : affecté une seule fois depuis l'init nonisolated (appelé par ReachFive.init,
-    // synchrone et hors main actor), jamais modifié ensuite. Lecture sans risque depuis le main actor.
-    nonisolated(unsafe) let reachFiveApi: ReachFiveApi
-
     // MARK: - Contexte de requête
 
     // Les requêtes peuvent s'entrelacer (une requête modale peut démarrer pendant une requête auto-fill).
@@ -62,12 +58,8 @@ public class CredentialManager: NSObject {
         case ResetPasskey(resetOptions: ResetOptions)
     }
 
-    // MARK: -
-
     // nonisolated : appelé depuis l'init synchrone de ReachFive, hors du main actor
-    nonisolated init(reachFiveApi: ReachFiveApi) {
-        self.reachFiveApi = reachFiveApi
-    }
+    nonisolated override init() {}
 
     // MARK: - Cycle de vie des requêtes
 
@@ -120,11 +112,15 @@ public class CredentialManager: NSObject {
 
     // MARK: - Signup
     @available(iOS 16.0, *)
-    func signUp(withRequest request: SignupOptions, scopes: [String], anchor: ASPresentationAnchor, originR5: String? = nil, reachFive: ReachFive) async throws -> AuthToken {
+    func signUp(withRequest request: SignupOptions, anchor: ASPresentationAnchor, originR5: String? = nil, reachFive: ReachFive) async throws -> AuthToken {
         cancelInFlightRequests()
 
-        let options = try await reachFiveApi.createWebAuthnSignupOptions(webAuthnSignupOptions: request)
+        let options = try await reachFive.reachFiveApi.createWebAuthnSignupOptions(webAuthnSignupOptions: request)
         let registrationRequest = try makeCredentialRegistrationRequest(from: options, friendlyName: request.friendlyName)
+
+        // request.scope est déjà le join espace de la liste de scopes (cf. SignupOptions) ; on la retrouve
+        // sans dupliquer la valeur en paramètre, un token de scope OAuth ne pouvant pas contenir d'espace.
+        let scopes = request.scope.components(separatedBy: " ")
 
         return try await awaitAuthToken(requests: [registrationRequest], reachFive: reachFive, anchor: anchor, scopes: scopes, originR5: originR5, passkeyCreationType: .Signup(signupOptions: options)) {
             $0.performRequests()
@@ -138,7 +134,7 @@ public class CredentialManager: NSObject {
         // so can't separate this method from the rest of the class
         cancelInFlightRequests()
 
-        let options = try await reachFiveApi.createWebAuthnRegistrationOptions(authToken: authToken, registrationRequest: RegistrationRequest(origin: request.originWebAuthn!, friendlyName: request.friendlyName))
+        let options = try await reachFive.reachFiveApi.createWebAuthnRegistrationOptions(authToken: authToken, registrationRequest: RegistrationRequest(origin: request.originWebAuthn!, friendlyName: request.friendlyName))
         let registrationRequest = try makeCredentialRegistrationRequest(from: options, friendlyName: request.friendlyName)
 
         try await awaitRegistration(requests: [registrationRequest], reachFive: reachFive, anchor: request.anchor, originR5: request.origin, passkeyCreationType: .AddPasskey(authToken: authToken)) {
@@ -153,8 +149,8 @@ public class CredentialManager: NSObject {
         // so can't separate this method from the rest of the class
         cancelInFlightRequests()
 
-        let resetOptions = ResetOptions(email: request.email, phoneNumber: request.phoneNumber, verificationCode: request.verificationCode, friendlyName: request.friendlyName, origin: request.originWebAuthn!, clientId: reachFiveApi.sdkConfig.clientId)
-        let options = try await reachFiveApi.createWebAuthnResetOptions(resetOptions: resetOptions)
+        let resetOptions = ResetOptions(email: request.email, phoneNumber: request.phoneNumber, verificationCode: request.verificationCode, friendlyName: request.friendlyName, origin: request.originWebAuthn!, clientId: reachFive.sdkConfig.clientId)
+        let options = try await reachFive.reachFiveApi.createWebAuthnResetOptions(resetOptions: resetOptions)
         let registrationRequest = try makeCredentialRegistrationRequest(from: options, friendlyName: request.friendlyName)
 
         try await awaitRegistration(requests: [registrationRequest], reachFive: reachFive, anchor: request.anchor, originR5: request.origin, passkeyCreationType: .ResetPasskey(resetOptions: resetOptions)) {
@@ -168,9 +164,9 @@ public class CredentialManager: NSObject {
     func beginAutoFillAssistedPasskeySignIn(request: NativeLoginRequest, reachFive: ReachFive) async throws -> AuthToken {
         cancelInFlightRequests()
 
-        let webAuthnLoginRequest = WebAuthnLoginRequest(clientId: reachFiveApi.sdkConfig.clientId, origin: request.originWebAuthn!, scope: request.scopes)
+        let webAuthnLoginRequest = WebAuthnLoginRequest(clientId: reachFive.sdkConfig.clientId, origin: request.originWebAuthn!, scope: request.scopes)
 
-        let assertionRequestOptions = try await reachFiveApi.createWebAuthnAuthenticationOptions(webAuthnLoginRequest: webAuthnLoginRequest)
+        let assertionRequestOptions = try await reachFive.reachFiveApi.createWebAuthnAuthenticationOptions(webAuthnLoginRequest: webAuthnLoginRequest)
         // Cette garde semble redondante (la méthode est déjà @available(iOS 16.0, *)) mais elle est nécessaire
         // pour compiler sous Xcode 26 (peut-être un bug Xcode). Ne pas la supprimer. Cf. commit 6a65a83.
         let authorizationRequest = if #available(iOS 16.0, *) {
@@ -189,7 +185,7 @@ public class CredentialManager: NSObject {
     func login(withNonDiscoverableUsername username: Username, forRequest request: NativeLoginRequest, usingModalAuthorizationFor requestTypes: [NonDiscoverableAuthorization], display mode: Mode, reachFive: ReachFive) async throws -> AuthToken {
         cancelInFlightRequests()
 
-        let webAuthnLoginRequest = WebAuthnLoginRequest(clientId: reachFiveApi.sdkConfig.clientId, origin: request.originWebAuthn!, scope: request.scopes)
+        let webAuthnLoginRequest = WebAuthnLoginRequest(clientId: reachFive.sdkConfig.clientId, origin: request.originWebAuthn!, scope: request.scopes)
         switch username {
 
         case .Unspecified(username: let username):
@@ -206,7 +202,7 @@ public class CredentialManager: NSObject {
 
         let authzs = requestTypes.compactMap { adaptAuthz($0) }
 
-        let built = try await buildAuthorizationRequests(webAuthnLoginRequest, authorizing: authzs) { assertionRequestOptions in
+        let built = try await buildAuthorizationRequests(webAuthnLoginRequest, reachFive: reachFive, authorizing: authzs) { assertionRequestOptions in
             guard #available(iOS 16.0, *) else { // can't happen, because this is called from a >= iOS 16 context
                 throw ReachFiveError.TechnicalError(reason: "Must be iOS 16 or higher")
             }
@@ -229,9 +225,9 @@ public class CredentialManager: NSObject {
     func login(withRequest request: NativeLoginRequest, usingModalAuthorizationFor requestTypes: [ModalAuthorization], display mode: Mode, appleProvider: ConfiguredAppleProvider?, reachFive: ReachFive) async throws -> LoginFlow {
         cancelInFlightRequests()
 
-        let webAuthnLoginRequest = WebAuthnLoginRequest(clientId: reachFiveApi.sdkConfig.clientId, origin: request.originWebAuthn!, scope: request.scopes)
+        let webAuthnLoginRequest = WebAuthnLoginRequest(clientId: reachFive.sdkConfig.clientId, origin: request.originWebAuthn!, scope: request.scopes)
 
-        let built = try await buildAuthorizationRequests(webAuthnLoginRequest, authorizing: requestTypes, appleProvider: appleProvider) { authenticationOptions in
+        let built = try await buildAuthorizationRequests(webAuthnLoginRequest, reachFive: reachFive, authorizing: requestTypes, appleProvider: appleProvider) { authenticationOptions in
             guard #available(iOS 16.0, *) else { // can't happen, because this is called from a >= iOS 16 context
                 throw ReachFiveError.TechnicalError(reason: "Must be iOS 16 or higher")
             }
@@ -251,7 +247,7 @@ public class CredentialManager: NSObject {
     }
 
     /// Construit les `ASAuthorizationRequest` pour les types demandés, sans toucher à l'état de la classe.
-    private func buildAuthorizationRequests(_ webAuthnLoginRequest: WebAuthnLoginRequest, authorizing requestTypes: [ModalAuthorization], appleProvider: ConfiguredAppleProvider? = nil, makeAuthorization: (AuthenticationOptions) throws -> ASAuthorizationRequest) async throws -> BuiltRequests {
+    private func buildAuthorizationRequests(_ webAuthnLoginRequest: WebAuthnLoginRequest, reachFive: ReachFive, authorizing requestTypes: [ModalAuthorization], appleProvider: ConfiguredAppleProvider? = nil, makeAuthorization: (AuthenticationOptions) throws -> ASAuthorizationRequest) async throws -> BuiltRequests {
         var requests: [ASAuthorizationRequest] = []
         var nonce: Pkce?
         var usedAppleProvider: ConfiguredAppleProvider?
@@ -286,7 +282,7 @@ public class CredentialManager: NSObject {
             case .Passkey:
                 do {
                     // Allow the user to use a saved passkey, if they have one.
-                    let authOptions = try await self.reachFiveApi.createWebAuthnAuthenticationOptions(webAuthnLoginRequest: webAuthnLoginRequest)
+                    let authOptions = try await reachFive.reachFiveApi.createWebAuthnAuthenticationOptions(webAuthnLoginRequest: webAuthnLoginRequest)
                     let passkeyRequest = try makeAuthorization(authOptions)
                     requests.append(passkeyRequest)
                 } catch let error where requestTypes.count > 1 {
@@ -367,6 +363,9 @@ extension CredentialManager: ASAuthorizationControllerDelegate {
     }
 
     private func complete(_ authorization: ASAuthorization, context: RequestContext) async throws {
+        let reachFiveApi = context.reachFive.reachFiveApi
+        let sdkConfig = context.reachFive.sdkConfig
+
         if let passwordCredential = authorization.credential as? ASPasswordCredential {
             // a password was selected to sign in
             guard case let .loginFlow(continuation) = context.pending else {
@@ -386,16 +385,15 @@ extension CredentialManager: ASAuthorizationControllerDelegate {
                 phoneNumber = passwordCredential.user
             }
 
-            // Contrairement à ReachFive.loginWithPassword, origin n'est pas envoyé dans le LoginRequest
-            // (divergence historique conservée telle quelle)
             let resp = try await reachFiveApi.loginWithPassword(loginRequest: LoginRequest(
                 email: email,
                 phoneNumber: phoneNumber,
                 customIdentifier: nil, // No custom identifier for login because no custom identifier can be used for signup
                 password: passwordCredential.password,
                 grantType: "password",
-                clientId: reachFiveApi.sdkConfig.clientId,
-                scope: scope
+                clientId: sdkConfig.clientId,
+                scope: scope,
+                origin: context.originR5
             ))
 
             let loginFlow = try await context.reachFive.loginFlow(afterPasswordGrant: resp, scopes: context.scopes, origin: context.originR5)
@@ -419,10 +417,10 @@ extension CredentialManager: ASAuthorizationControllerDelegate {
             let pkce = Pkce.generate()
             let code = try await reachFiveApi.authorize(params: [
                 "provider": appleProvider.providerConfig.providerWithVariant,
-                "client_id": reachFiveApi.sdkConfig.clientId,
+                "client_id": sdkConfig.clientId,
                 "id_token": idToken,
                 "response_type": "code",
-                "redirect_uri": reachFiveApi.sdkConfig.redirectUri.absoluteString,
+                "redirect_uri": sdkConfig.redirectUri.absoluteString,
                 "scope": scope,
                 "code_challenge": pkce.codeChallenge,
                 "code_challenge_method": pkce.codeChallengeMethod,

--- a/Sources/Core/Classes/CredentialManager.swift
+++ b/Sources/Core/Classes/CredentialManager.swift
@@ -6,7 +6,6 @@ import AuthenticationServices
 @MainActor
 public class CredentialManager: NSObject {
     let reachFiveApi: ReachFiveApi
-    let storage: Storage
 
     // MARK: - Contexte de requête
 
@@ -25,11 +24,16 @@ public class CredentialManager: NSObject {
 
         // retenu : maintient la requête système en vie jusqu'à sa complétion
         let controller: ASAuthorizationController
+        // retenu fort pendant la durée de la requête : pas de cycle permanent, et le SDK
+        // reste vivant jusqu'à la complétion (pas de back-pointer weak à dénuller)
+        let reachFive: ReachFive
         let pending: Pending
         // anchor pour le presentationContextProvider
         let anchor: ASPresentationAnchor
-        // le scope de la requête, tel qu'envoyé au serveur
-        let scope: String?
+        // le scope de la requête
+        let scopes: [String]?
+        // le scope tel qu'envoyé au serveur
+        var scope: String? { scopes?.joined(separator: " ") }
         // origin optionnel pour les événements utilisateur
         let originR5: String?
         // données pour signup/register
@@ -59,9 +63,8 @@ public class CredentialManager: NSObject {
     // MARK: -
 
     // nonisolated : appelé depuis l'init synchrone de ReachFive, hors du main actor
-    nonisolated init(reachFiveApi: ReachFiveApi, storage: Storage) {
+    nonisolated init(reachFiveApi: ReachFiveApi) {
         self.reachFiveApi = reachFiveApi
-        self.storage = storage
     }
 
     // MARK: - Cycle de vie des requêtes
@@ -80,8 +83,9 @@ public class CredentialManager: NSObject {
     /// comme tout se passe sur le main actor, la continuation est en place avant que le delegate puisse tirer.
     private func start(_ pending: RequestContext.Pending,
                        requests: [ASAuthorizationRequest],
+                       reachFive: ReachFive,
                        anchor: ASPresentationAnchor,
-                       scope: String?,
+                       scopes: [String]?,
                        originR5: String?,
                        passkeyCreationType: PasskeyCreationType? = nil,
                        nonce: Pkce? = nil,
@@ -90,44 +94,44 @@ public class CredentialManager: NSObject {
         let controller = ASAuthorizationController(authorizationRequests: requests)
         controller.delegate = self
         controller.presentationContextProvider = self
-        contexts[ObjectIdentifier(controller)] = RequestContext(controller: controller, pending: pending, anchor: anchor, scope: scope, originR5: originR5, passkeyCreationType: passkeyCreationType, nonce: nonce, appleProvider: appleProvider)
+        contexts[ObjectIdentifier(controller)] = RequestContext(controller: controller, reachFive: reachFive, pending: pending, anchor: anchor, scopes: scopes, originR5: originR5, passkeyCreationType: passkeyCreationType, nonce: nonce, appleProvider: appleProvider)
         perform(controller)
     }
 
-    private func awaitAuthToken(requests: [ASAuthorizationRequest], anchor: ASPresentationAnchor, scope: String?, originR5: String?, passkeyCreationType: PasskeyCreationType? = nil, perform: (ASAuthorizationController) -> Void) async throws -> AuthToken {
+    private func awaitAuthToken(requests: [ASAuthorizationRequest], reachFive: ReachFive, anchor: ASPresentationAnchor, scopes: [String]?, originR5: String?, passkeyCreationType: PasskeyCreationType? = nil, perform: (ASAuthorizationController) -> Void) async throws -> AuthToken {
         try await withCheckedThrowingContinuation { continuation in
-            start(.authToken(continuation), requests: requests, anchor: anchor, scope: scope, originR5: originR5, passkeyCreationType: passkeyCreationType, perform: perform)
+            start(.authToken(continuation), requests: requests, reachFive: reachFive, anchor: anchor, scopes: scopes, originR5: originR5, passkeyCreationType: passkeyCreationType, perform: perform)
         }
     }
 
-    private func awaitLoginFlow(requests: [ASAuthorizationRequest], anchor: ASPresentationAnchor, scope: String?, originR5: String?, nonce: Pkce? = nil, appleProvider: ConfiguredAppleProvider? = nil, perform: (ASAuthorizationController) -> Void) async throws -> LoginFlow {
+    private func awaitLoginFlow(requests: [ASAuthorizationRequest], reachFive: ReachFive, anchor: ASPresentationAnchor, scopes: [String]?, originR5: String?, nonce: Pkce? = nil, appleProvider: ConfiguredAppleProvider? = nil, perform: (ASAuthorizationController) -> Void) async throws -> LoginFlow {
         try await withCheckedThrowingContinuation { continuation in
-            start(.loginFlow(continuation), requests: requests, anchor: anchor, scope: scope, originR5: originR5, nonce: nonce, appleProvider: appleProvider, perform: perform)
+            start(.loginFlow(continuation), requests: requests, reachFive: reachFive, anchor: anchor, scopes: scopes, originR5: originR5, nonce: nonce, appleProvider: appleProvider, perform: perform)
         }
     }
 
-    private func awaitRegistration(requests: [ASAuthorizationRequest], anchor: ASPresentationAnchor, originR5: String?, passkeyCreationType: PasskeyCreationType, perform: (ASAuthorizationController) -> Void) async throws {
+    private func awaitRegistration(requests: [ASAuthorizationRequest], reachFive: ReachFive, anchor: ASPresentationAnchor, originR5: String?, passkeyCreationType: PasskeyCreationType, perform: (ASAuthorizationController) -> Void) async throws {
         try await withCheckedThrowingContinuation { continuation in
-            start(.registration(continuation), requests: requests, anchor: anchor, scope: nil, originR5: originR5, passkeyCreationType: passkeyCreationType, perform: perform)
+            start(.registration(continuation), requests: requests, reachFive: reachFive, anchor: anchor, scopes: nil, originR5: originR5, passkeyCreationType: passkeyCreationType, perform: perform)
         }
     }
 
     // MARK: - Signup
     @available(iOS 16.0, *)
-    func signUp(withRequest request: SignupOptions, anchor: ASPresentationAnchor, originR5: String? = nil) async throws -> AuthToken {
+    func signUp(withRequest request: SignupOptions, scopes: [String], anchor: ASPresentationAnchor, originR5: String? = nil, reachFive: ReachFive) async throws -> AuthToken {
         cancelInFlightRequests()
 
         let options = try await reachFiveApi.createWebAuthnSignupOptions(webAuthnSignupOptions: request)
         let registrationRequest = try makeCredentialRegistrationRequest(from: options, friendlyName: request.friendlyName)
 
-        return try await awaitAuthToken(requests: [registrationRequest], anchor: anchor, scope: request.scope, originR5: originR5, passkeyCreationType: .Signup(signupOptions: options)) {
+        return try await awaitAuthToken(requests: [registrationRequest], reachFive: reachFive, anchor: anchor, scopes: scopes, originR5: originR5, passkeyCreationType: .Signup(signupOptions: options)) {
             $0.performRequests()
         }
     }
 
     // MARK: - Register
     @available(iOS 16.0, *)
-    func registerNewPasskey(withRequest request: NewPasskeyRequest, authToken: AuthToken) async throws {
+    func registerNewPasskey(withRequest request: NewPasskeyRequest, authToken: AuthToken, reachFive: ReachFive) async throws {
         // Here it is very important to cancel a running auto-fill request, otherwise it will fail like other modal requests
         // so can't separate this method from the rest of the class
         cancelInFlightRequests()
@@ -135,14 +139,14 @@ public class CredentialManager: NSObject {
         let options = try await reachFiveApi.createWebAuthnRegistrationOptions(authToken: authToken, registrationRequest: RegistrationRequest(origin: request.originWebAuthn!, friendlyName: request.friendlyName))
         let registrationRequest = try makeCredentialRegistrationRequest(from: options, friendlyName: request.friendlyName)
 
-        try await awaitRegistration(requests: [registrationRequest], anchor: request.anchor, originR5: request.origin, passkeyCreationType: .AddPasskey(authToken: authToken)) {
+        try await awaitRegistration(requests: [registrationRequest], reachFive: reachFive, anchor: request.anchor, originR5: request.origin, passkeyCreationType: .AddPasskey(authToken: authToken)) {
             $0.performRequests()
         }
     }
 
     // MARK: - Reset
     @available(iOS 16.0, *)
-    func resetPasskeys(withRequest request: ResetPasskeyRequest) async throws {
+    func resetPasskeys(withRequest request: ResetPasskeyRequest, reachFive: ReachFive) async throws {
         // Here it is very important to cancel a running auto-fill request, otherwise it will fail like other modal requests
         // so can't separate this method from the rest of the class
         cancelInFlightRequests()
@@ -151,7 +155,7 @@ public class CredentialManager: NSObject {
         let options = try await reachFiveApi.createWebAuthnResetOptions(resetOptions: resetOptions)
         let registrationRequest = try makeCredentialRegistrationRequest(from: options, friendlyName: request.friendlyName)
 
-        try await awaitRegistration(requests: [registrationRequest], anchor: request.anchor, originR5: request.origin, passkeyCreationType: .ResetPasskey(resetOptions: resetOptions)) {
+        try await awaitRegistration(requests: [registrationRequest], reachFive: reachFive, anchor: request.anchor, originR5: request.origin, passkeyCreationType: .ResetPasskey(resetOptions: resetOptions)) {
             $0.performRequests()
         }
     }
@@ -159,7 +163,7 @@ public class CredentialManager: NSObject {
     // MARK: - Auto-fill
     @available(macCatalyst, unavailable)
     @available(iOS 16.0, *)
-    func beginAutoFillAssistedPasskeySignIn(request: NativeLoginRequest) async throws -> AuthToken {
+    func beginAutoFillAssistedPasskeySignIn(request: NativeLoginRequest, reachFive: ReachFive) async throws -> AuthToken {
         cancelInFlightRequests()
 
         let webAuthnLoginRequest = WebAuthnLoginRequest(clientId: reachFiveApi.sdkConfig.clientId, origin: request.originWebAuthn!, scope: request.scopes)
@@ -174,13 +178,13 @@ public class CredentialManager: NSObject {
         }
 
         // AutoFill-assisted requests only support ASAuthorizationPlatformPublicKeyCredentialAssertionRequest.
-        return try await awaitAuthToken(requests: [authorizationRequest], anchor: request.anchor, scope: webAuthnLoginRequest.scope, originR5: request.origin) {
+        return try await awaitAuthToken(requests: [authorizationRequest], reachFive: reachFive, anchor: request.anchor, scopes: request.scopes, originR5: request.origin) {
             $0.performAutoFillAssistedRequests()
         }
     }
 
     // MARK: - Modal
-    func login(withNonDiscoverableUsername username: Username, forRequest request: NativeLoginRequest, usingModalAuthorizationFor requestTypes: [NonDiscoverableAuthorization], display mode: Mode) async throws -> AuthToken {
+    func login(withNonDiscoverableUsername username: Username, forRequest request: NativeLoginRequest, usingModalAuthorizationFor requestTypes: [NonDiscoverableAuthorization], display mode: Mode, reachFive: ReachFive) async throws -> AuthToken {
         cancelInFlightRequests()
 
         let webAuthnLoginRequest = WebAuthnLoginRequest(clientId: reachFiveApi.sdkConfig.clientId, origin: request.originWebAuthn!, scope: request.scopes)
@@ -215,12 +219,12 @@ public class CredentialManager: NSObject {
             return assertionRequest
         }
 
-        return try await awaitAuthToken(requests: built.requests, anchor: request.anchor, scope: webAuthnLoginRequest.scope, originR5: request.origin) {
+        return try await awaitAuthToken(requests: built.requests, reachFive: reachFive, anchor: request.anchor, scopes: request.scopes, originR5: request.origin) {
             performRequests(on: $0, mode: mode)
         }
     }
 
-    func login(withRequest request: NativeLoginRequest, usingModalAuthorizationFor requestTypes: [ModalAuthorization], display mode: Mode, appleProvider: ConfiguredAppleProvider?) async throws -> LoginFlow {
+    func login(withRequest request: NativeLoginRequest, usingModalAuthorizationFor requestTypes: [ModalAuthorization], display mode: Mode, appleProvider: ConfiguredAppleProvider?, reachFive: ReachFive) async throws -> LoginFlow {
         cancelInFlightRequests()
 
         let webAuthnLoginRequest = WebAuthnLoginRequest(clientId: reachFiveApi.sdkConfig.clientId, origin: request.originWebAuthn!, scope: request.scopes)
@@ -232,7 +236,7 @@ public class CredentialManager: NSObject {
             return try self.createCredentialAssertionRequest(authenticationOptions)
         }
 
-        return try await awaitLoginFlow(requests: built.requests, anchor: request.anchor, scope: webAuthnLoginRequest.scope, originR5: request.origin, nonce: built.nonce, appleProvider: built.appleProvider) {
+        return try await awaitLoginFlow(requests: built.requests, reachFive: reachFive, anchor: request.anchor, scopes: request.scopes, originR5: request.origin, nonce: built.nonce, appleProvider: built.appleProvider) {
             performRequests(on: $0, mode: mode)
         }
     }
@@ -380,6 +384,8 @@ extension CredentialManager: ASAuthorizationControllerDelegate {
                 phoneNumber = passwordCredential.user
             }
 
+            // Contrairement à ReachFive.loginWithPassword, origin n'est pas envoyé dans le LoginRequest
+            // (divergence historique conservée telle quelle)
             let resp = try await reachFiveApi.loginWithPassword(loginRequest: LoginRequest(
                 email: email,
                 phoneNumber: phoneNumber,
@@ -390,17 +396,7 @@ extension CredentialManager: ASAuthorizationControllerDelegate {
                 scope: scope
             ))
 
-            let loginFlow: LoginFlow
-            if resp.mfaRequired == true {
-                let pkce = Pkce.generate()
-                storage.save(key: "PASSWORDLESS_PKCE", value: pkce)
-                let stepUpResp = try await reachFiveApi.startMfaStepUp(StartMfaStepUpRequest(clientId: reachFiveApi.sdkConfig.clientId, redirectUri: reachFiveApi.sdkConfig.redirectUri, pkce: pkce, scope: scope, tkn: resp.tkn))
-                loginFlow = .OngoingStepUp(token: stepUpResp.token, availableMfaCredentialItemTypes: stepUpResp.amr)
-            } else {
-                let token = try await loginCallback(tkn: resp.tkn, scope: scope, origin: context.originR5)
-                loginFlow = .AchievedLogin(authToken: token)
-            }
-
+            let loginFlow = try await context.reachFive.loginFlow(afterPasswordGrant: resp, scopes: context.scopes, origin: context.originR5)
             continuation.resume(returning: loginFlow)
         } else if let appleIDCredential = authorization.credential as? ASAuthorizationAppleIDCredential {
             guard case let .loginFlow(continuation) = context.pending else {
@@ -433,7 +429,7 @@ extension CredentialManager: ASAuthorizationControllerDelegate {
                 "given_name": appleIDCredential.fullName?.givenName,
                 "family_name": appleIDCredential.fullName?.familyName
             ])
-            let token = try await authWithCode(code: code, pkce: pkce)
+            let token = try await context.reachFive.authWithCode(code: code, pkce: pkce)
             continuation.resume(returning: .AchievedLogin(authToken: token))
         } else if #available(iOS 16.0, *), let credentialRegistration = authorization.credential as? ASAuthorizationPlatformPublicKeyCredentialRegistration {
             // A new passkey was registered
@@ -463,13 +459,13 @@ extension CredentialManager: ASAuthorizationControllerDelegate {
                 guard case let .authToken(continuation) = context.pending else {
                     throw ReachFiveError.TechnicalError(reason: "didCompleteWithAuthorization: unexpected passkey registration for this request")
                 }
-                guard let scope = context.scope else {
+                guard context.scopes != nil else {
                     throw ReachFiveError.TechnicalError(reason: "didCompleteWithAuthorization: no scope")
                 }
 
                 let webauthnSignupCredential = WebauthnSignupCredential(webauthnId: signupOptions.options.publicKey.user.id, publicKeyCredential: registrationPublicKeyCredential)
                 let authenticationToken = try await reachFiveApi.signupWithWebAuthn(webauthnSignupCredential: webauthnSignupCredential, originR5: context.originR5)
-                let authToken = try await loginCallback(tkn: authenticationToken.tkn, scope: scope, origin: context.originR5)
+                let authToken = try await context.reachFive.loginCallback(tkn: authenticationToken.tkn, scopes: context.scopes, origin: context.originR5)
                 continuation.resume(returning: authToken)
 
             case let .ResetPasskey(resetOptions):
@@ -483,7 +479,7 @@ extension CredentialManager: ASAuthorizationControllerDelegate {
         } else if #available(iOS 16.0, *), let credentialAssertion = authorization.credential as? ASAuthorizationPlatformPublicKeyCredentialAssertion {
             // A passkey was selected to sign in
 
-            guard let scope = context.scope else {
+            guard context.scopes != nil else {
                 throw ReachFiveError.TechnicalError(reason: "didCompleteWithAuthorization: no scope")
             }
 
@@ -496,7 +492,7 @@ extension CredentialManager: ASAuthorizationControllerDelegate {
             let response = R5AuthenticatorAssertionResponse(authenticatorData: authenticatorData, clientDataJSON: clientDataJSON, signature: signature, userHandle: userID)
 
             let authenticationToken = try await reachFiveApi.authenticateWithWebAuthn(authenticationPublicKeyCredential: AuthenticationPublicKeyCredential(id: id, rawId: id, type: "public-key", response: response))
-            let authToken = try await loginCallback(tkn: authenticationToken.tkn, scope: scope, origin: context.originR5)
+            let authToken = try await context.reachFive.loginCallback(tkn: authenticationToken.tkn, scopes: context.scopes, origin: context.originR5)
 
             switch context.pending {
             case let .authToken(continuation):
@@ -569,23 +565,5 @@ extension CredentialManager {
             return ModalAuthorization.Passkey
         }
         return nil
-    }
-
-    func loginCallback(tkn: String, scope: String, origin: String? = nil) async throws -> AuthToken {
-        let pkce = Pkce.generate()
-
-        let code = try await reachFiveApi.loginCallback(loginCallback: LoginCallback(sdkConfig: reachFiveApi.sdkConfig, scope: scope, pkce: pkce, tkn: tkn, origin: origin))
-        return try await self.authWithCode(code: code, pkce: pkce)
-    }
-
-    func authWithCode(code: String, pkce: Pkce? = nil) async throws -> AuthToken {
-        let authCodeRequest = AuthCodeRequest(
-            clientId: reachFiveApi.sdkConfig.clientId,
-            code: code,
-            redirectUri: reachFiveApi.sdkConfig.redirectUri,
-            pkce: pkce
-        )
-        let token = try await reachFiveApi.authWithCode(authCodeRequest: authCodeRequest)
-        return try AuthToken.fromOpenIdTokenResponse(token)
     }
 }

--- a/Sources/Core/Classes/CredentialManager.swift
+++ b/Sources/Core/Classes/CredentialManager.swift
@@ -5,7 +5,9 @@ import AuthenticationServices
 // protège l'état mutable partagé entre les points d'entrée async et le delegate.
 @MainActor
 public class CredentialManager: NSObject {
-    let reachFiveApi: ReachFiveApi
+    // nonisolated(unsafe) : affecté une seule fois depuis l'init nonisolated (appelé par ReachFive.init,
+    // synchrone et hors main actor), jamais modifié ensuite. Lecture sans risque depuis le main actor.
+    nonisolated(unsafe) let reachFiveApi: ReachFiveApi
 
     // MARK: - Contexte de requête
 
@@ -513,31 +515,30 @@ extension CredentialManager: ASAuthorizationControllerDelegate {
             return
         }
 
-        let reachFiveError: ReachFiveError
+        context.fail(with: Self.adapt(error))
+    }
 
+    // Fonction pure, extraite pour être testable unitairement
+    nonisolated static func adapt(_ error: Error) -> ReachFiveError {
         if let authorizationError = error as? ASAuthorizationError {
             if authorizationError.code == .canceled {
                 // Either the system doesn't find any credentials and the request ends silently, or the user cancels the request.
                 // This is a good time to show a traditional login form, or ask the user to create an account.
-                reachFiveError = .AuthCanceled
-            } else {
-                // Another ASAuthorization error.
-                reachFiveError = .TechnicalError(reason: "ASAuthorizationError \(authorizationError.code.rawValue): \(error)")
+                return .AuthCanceled
             }
-        } else {
-            reachFiveError = .TechnicalError(reason: "\(error.localizedDescription)")
+            // Another ASAuthorization error.
+            return .TechnicalError(reason: "ASAuthorizationError \(authorizationError.code.rawValue): \(error)")
         }
-
-        context.fail(with: reachFiveError)
+        return .TechnicalError(reason: "\(error.localizedDescription)")
     }
 }
 
 // MARK: - utilities
 extension CredentialManager {
     /// Construit une requête d'enregistrement de passkey à partir des options renvoyées par le serveur.
-    /// Pendant symétrique de ``createCredentialAssertionRequest(_:)``.
+    /// Pendant symétrique de ``createCredentialAssertionRequest(_:)``. Internal pour être testable.
     @available(iOS 16.0, *)
-    private func makeCredentialRegistrationRequest(from options: RegistrationOptions, friendlyName: String) throws -> ASAuthorizationRequest {
+    func makeCredentialRegistrationRequest(from options: RegistrationOptions, friendlyName: String) throws -> ASAuthorizationRequest {
         guard let challenge = options.options.publicKey.challenge.decodeBase64Url() else {
             throw ReachFiveError.TechnicalError(reason: "unreadable challenge: \(options.options.publicKey.challenge)")
         }

--- a/Sources/Core/Classes/CredentialManager.swift
+++ b/Sources/Core/Classes/CredentialManager.swift
@@ -12,57 +12,55 @@ public class CredentialManager: NSObject {
     // du delegate retrouve le contexte de SA requête, et une requête ne peut pas écraser l'état d'une autre.
     // Internal (et non private) pour que les tests puissent piloter perform(_:requests:...).
     struct RequestContext {
-        enum Pending {
-            // signup, auto-fill, login non-discoverable
-            case authToken(CheckedContinuation<AuthToken, Error>)
-            // login modal (password/SIWA/passkey), qui peut déboucher sur un step-up MFA
-            case loginFlow(CheckedContinuation<LoginFlow, Error>)
-            // enregistrement d'une nouvelle clé (add/reset)
-            case registration(CheckedContinuation<Void, Error>)
-        }
-
-        // Données propres à un flux : une création de passkey (signup/add/reset) et un Sign In With Apple
-        // ne coexistent jamais dans une même requête.
-        enum Extra {
-            case passkeyCreation(PasskeyCreationType)
-            case signInWithApple(nonce: Pkce, provider: ConfiguredAppleProvider)
-            case none
-        }
-
         // retenu : maintient la requête système en vie jusqu'à sa complétion
         let controller: ASAuthorizationController
         // retenu fort pendant la durée de la requête : pas de cycle permanent, et le SDK
         // reste vivant jusqu'à la complétion (pas de back-pointer weak à dénuller)
         let reachFive: ReachFive
-        let pending: Pending
         // anchor pour le presentationContextProvider
         let anchor: ASPresentationAnchor
-        // le scope de la requête
-        let scopes: [String]?
-        // le scope tel qu'envoyé au serveur
-        var scope: String? { scopes?.joined(separator: " ") }
         // origin optionnel pour les événements utilisateur
         let originR5: String?
-        // données propres au flux (création de passkey ou Sign In With Apple)
-        let extra: Extra
+        // l'opération demandée : continuation typée + données propres au flux
+        let operation: Operation
+    }
+
+    /// L'opération portée par une requête. Chaque cas fixe d'un bloc le type de credential attendu, le
+    /// traitement à appliquer et le type de valeur rendu par sa continuation : la nature de la requête
+    /// est donc connue de façon univoque, sans avoir à recouper à la main un `Pending` et un `Extra` dans
+    /// chaque branche de complétion. La continuation est le dernier associé, non étiqueté.
+    enum Operation {
+        /// Création de passkey à l'inscription → jeton d'authentification.
+        case signup(options: RegistrationOptions, scopes: [String], CheckedContinuation<AuthToken, Error>)
+        /// Enregistrement d'une passkey pour un compte déjà connecté (add) → rien.
+        case addPasskey(authToken: AuthToken, CheckedContinuation<Void, Error>)
+        /// Réinitialisation des passkeys → rien.
+        case resetPasskey(options: ResetOptions, CheckedContinuation<Void, Error>)
+        /// Connexion par assertion de passkey (auto-fill ou non-discoverable) → jeton d'authentification.
+        case passkeyLogin(scopes: [String]?, CheckedContinuation<AuthToken, Error>)
+        /// Connexion modale (mot de passe, Sign In With Apple ou passkey), pouvant déboucher sur un
+        /// step-up MFA → LoginFlow. Seul flux à pouvoir recevoir plusieurs types de credential.
+        case modalLogin(scopes: [String]?, siwa: SignInWithApple?, CheckedContinuation<LoginFlow, Error>)
 
         func fail(with error: Error) {
-            switch pending {
-            case let .authToken(continuation): continuation.resume(throwing: error)
-            case let .loginFlow(continuation): continuation.resume(throwing: error)
-            case let .registration(continuation): continuation.resume(throwing: error)
+            switch self {
+            case let .signup(_, _, continuation): continuation.resume(throwing: error)
+            case let .addPasskey(_, continuation): continuation.resume(throwing: error)
+            case let .resetPasskey(_, continuation): continuation.resume(throwing: error)
+            case let .passkeyLogin(_, continuation): continuation.resume(throwing: error)
+            case let .modalLogin(_, _, continuation): continuation.resume(throwing: error)
             }
         }
     }
 
+    // Données d'un Sign In With Apple, à conserver entre la construction de la requête et sa complétion.
+    struct SignInWithApple {
+        let nonce: Pkce
+        let provider: ConfiguredAppleProvider
+    }
+
     // les requêtes en cours, indexées par leur controller
     private var contexts: [ObjectIdentifier: RequestContext] = [:]
-
-    enum PasskeyCreationType {
-        case Signup(signupOptions: RegistrationOptions)
-        case AddPasskey(authToken: AuthToken)
-        case ResetPasskey(resetOptions: ResetOptions)
-    }
 
     // nonisolated : appelé depuis l'init synchrone de ReachFive, hors du main actor
     nonisolated override init() {}
@@ -82,24 +80,22 @@ public class CredentialManager: NSObject {
     /// Crée le controller, enregistre le contexte de la requête PUIS lance la requête système via `perform` :
     /// comme tout se passe sur le main actor, la continuation est en place avant que le delegate puisse tirer.
     ///
-    /// Le case de `Pending` à construire est passé comme fonction (`RequestContext.Pending.authToken`, etc.),
+    /// L'`Operation` à construire est passée comme closure recevant la continuation (`{ .signup(…, $0) }`),
     /// ce qui fixe le type de retour `T` de la requête. Internal pour être testable : un test pilote la méthode
     /// avec un `perform` inerte puis simule les callbacks du delegate.
     func perform<T>(
-        _ makePending: (CheckedContinuation<T, Error>) -> RequestContext.Pending,
+        _ makeOperation: (CheckedContinuation<T, Error>) -> Operation,
         requests: [ASAuthorizationRequest],
         reachFive: ReachFive,
         anchor: ASPresentationAnchor,
-        scopes: [String]?,
         originR5: String?,
-        extra: RequestContext.Extra = .none,
         using perform: (ASAuthorizationController) -> Void
     ) async throws -> T {
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<T, Error>) in
             let controller = ASAuthorizationController(authorizationRequests: requests)
             controller.delegate = self
             controller.presentationContextProvider = self
-            contexts[ObjectIdentifier(controller)] = RequestContext(controller: controller, reachFive: reachFive, pending: makePending(continuation), anchor: anchor, scopes: scopes, originR5: originR5, extra: extra)
+            contexts[ObjectIdentifier(controller)] = RequestContext(controller: controller, reachFive: reachFive, anchor: anchor, originR5: originR5, operation: makeOperation(continuation))
             perform(controller)
         }
     }
@@ -116,7 +112,7 @@ public class CredentialManager: NSObject {
         // sans dupliquer la valeur en paramètre, un token de scope OAuth ne pouvant pas contenir d'espace.
         let scopes = request.scope.components(separatedBy: " ")
 
-        return try await perform(RequestContext.Pending.authToken, requests: [registrationRequest], reachFive: reachFive, anchor: anchor, scopes: scopes, originR5: originR5, extra: .passkeyCreation(.Signup(signupOptions: options))) {
+        return try await perform({ .signup(options: options, scopes: scopes, $0) }, requests: [registrationRequest], reachFive: reachFive, anchor: anchor, originR5: originR5) {
             $0.performRequests()
         }
     }
@@ -131,7 +127,7 @@ public class CredentialManager: NSObject {
         let options = try await reachFive.reachFiveApi.createWebAuthnRegistrationOptions(authToken: authToken, registrationRequest: RegistrationRequest(origin: request.originWebAuthn!, friendlyName: request.friendlyName))
         let registrationRequest = try makeCredentialRegistrationRequest(from: options, friendlyName: request.friendlyName)
 
-        try await perform(RequestContext.Pending.registration, requests: [registrationRequest], reachFive: reachFive, anchor: request.anchor, scopes: nil, originR5: request.origin, extra: .passkeyCreation(.AddPasskey(authToken: authToken))) {
+        try await perform({ .addPasskey(authToken: authToken, $0) }, requests: [registrationRequest], reachFive: reachFive, anchor: request.anchor, originR5: request.origin) {
             $0.performRequests()
         }
     }
@@ -147,7 +143,7 @@ public class CredentialManager: NSObject {
         let options = try await reachFive.reachFiveApi.createWebAuthnResetOptions(resetOptions: resetOptions)
         let registrationRequest = try makeCredentialRegistrationRequest(from: options, friendlyName: request.friendlyName)
 
-        try await perform(RequestContext.Pending.registration, requests: [registrationRequest], reachFive: reachFive, anchor: request.anchor, scopes: nil, originR5: request.origin, extra: .passkeyCreation(.ResetPasskey(resetOptions: resetOptions))) {
+        try await perform({ .resetPasskey(options: resetOptions, $0) }, requests: [registrationRequest], reachFive: reachFive, anchor: request.anchor, originR5: request.origin) {
             $0.performRequests()
         }
     }
@@ -170,7 +166,7 @@ public class CredentialManager: NSObject {
         }
 
         // AutoFill-assisted requests only support ASAuthorizationPlatformPublicKeyCredentialAssertionRequest.
-        return try await perform(RequestContext.Pending.authToken, requests: [authorizationRequest], reachFive: reachFive, anchor: request.anchor, scopes: request.scopes, originR5: request.origin) {
+        return try await perform({ .passkeyLogin(scopes: request.scopes, $0) }, requests: [authorizationRequest], reachFive: reachFive, anchor: request.anchor, originR5: request.origin) {
             $0.performAutoFillAssistedRequests()
         }
     }
@@ -211,7 +207,7 @@ public class CredentialManager: NSObject {
             return assertionRequest
         }
 
-        return try await perform(RequestContext.Pending.authToken, requests: built.requests, reachFive: reachFive, anchor: request.anchor, scopes: request.scopes, originR5: request.origin, extra: built.extra) {
+        return try await perform({ .passkeyLogin(scopes: request.scopes, $0) }, requests: built.requests, reachFive: reachFive, anchor: request.anchor, originR5: request.origin) {
             performRequests(on: $0, mode: mode)
         }
     }
@@ -228,7 +224,7 @@ public class CredentialManager: NSObject {
             return try self.createCredentialAssertionRequest(authenticationOptions)
         }
 
-        return try await perform(RequestContext.Pending.loginFlow, requests: built.requests, reachFive: reachFive, anchor: request.anchor, scopes: request.scopes, originR5: request.origin, extra: built.extra) {
+        return try await perform({ .modalLogin(scopes: request.scopes, siwa: built.siwa, $0) }, requests: built.requests, reachFive: reachFive, anchor: request.anchor, originR5: request.origin) {
             performRequests(on: $0, mode: mode)
         }
     }
@@ -236,8 +232,8 @@ public class CredentialManager: NSObject {
     // Internal pour être testable
     struct BuiltRequests {
         let requests: [ASAuthorizationRequest]
-        // .signInWithApple si une requête Sign In With Apple fait partie du lot, sinon .none
-        let extra: RequestContext.Extra
+        // renseigné si une requête Sign In With Apple fait partie du lot
+        let siwa: SignInWithApple?
     }
 
     /// Construit les `ASAuthorizationRequest` pour les types demandés, sans toucher à l'état de la classe.
@@ -245,7 +241,7 @@ public class CredentialManager: NSObject {
     /// construire les requêtes sans réseau.
     func buildAuthorizationRequests(_ webAuthnLoginRequest: WebAuthnLoginRequest, reachFive: ReachFive,authorizing requestTypes: [ModalAuthorization], appleProvider: ConfiguredAppleProvider? = nil, fetchAuthenticationOptions: (ReachFive, WebAuthnLoginRequest) async throws -> AuthenticationOptions = { try await $0.reachFiveApi.createWebAuthnAuthenticationOptions(webAuthnLoginRequest: $1) }, makeAuthorization: (AuthenticationOptions) throws -> ASAuthorizationRequest) async throws -> BuiltRequests {
         var requests: [ASAuthorizationRequest] = []
-        var extra: RequestContext.Extra = .none
+        var siwa: SignInWithApple? = nil
 
         for type in requestTypes {
             switch type {
@@ -270,7 +266,7 @@ public class CredentialManager: NSObject {
                 let siwaNonce = Pkce.generate()
                 appleIDRequest.nonce = siwaNonce.codeChallenge
                 if let appleProvider {
-                    extra = .signInWithApple(nonce: siwaNonce, provider: appleProvider)
+                    siwa = SignInWithApple(nonce: siwaNonce, provider: appleProvider)
                 }
 
                 requests.append(appleIDRequest)
@@ -288,7 +284,7 @@ public class CredentialManager: NSObject {
             }
         }
 
-        return BuiltRequests(requests: requests, extra: extra)
+        return BuiltRequests(requests: requests, siwa: siwa)
     }
 
     private func performRequests(on controller: ASAuthorizationController, mode: Mode) {
@@ -353,24 +349,59 @@ extension CredentialManager: ASAuthorizationControllerDelegate {
             do {
                 try await complete(authorization, context: context)
             } catch {
-                context.fail(with: error)
+                context.operation.fail(with: error)
             }
         }
     }
 
+    /// Un seul `switch` sur l'opération : chaque branche sait quel credential elle attend et le récupère
+    /// via un helper d'extraction. Plus aucun recoupement pending/extra/credential à faire à la main.
     private func complete(_ authorization: ASAuthorization, context: RequestContext) async throws {
-        let reachFiveApi = context.reachFive.reachFiveApi
-        let sdkConfig = context.reachFive.sdkConfig
+        let reachFive = context.reachFive
+        let reachFiveApi = reachFive.reachFiveApi
+
+        switch context.operation {
+        case let .signup(options, scopes, continuation):
+            let credential = try registrationCredential(from: authorization)
+            let webauthnSignupCredential = WebauthnSignupCredential(webauthnId: options.options.publicKey.user.id, publicKeyCredential: credential)
+            let authenticationToken = try await reachFiveApi.signupWithWebAuthn(webauthnSignupCredential: webauthnSignupCredential, originR5: context.originR5)
+            let authToken = try await reachFive.loginCallback(tkn: authenticationToken.tkn, scopes: scopes, origin: context.originR5)
+            continuation.resume(returning: authToken)
+
+        case let .addPasskey(authToken, continuation):
+            let credential = try registrationCredential(from: authorization)
+            try await reachFiveApi.registerWithWebAuthn(authToken: authToken, publicKeyCredential: credential, originR5: context.originR5)
+            continuation.resume(returning: ())
+
+        case let .resetPasskey(options, continuation):
+            let credential = try registrationCredential(from: authorization)
+            let resetPublicKeyCredential = ResetPublicKeyCredential(resetOptions: options, publicKeyCredential: credential)
+            try await reachFiveApi.resetWebAuthn(resetPublicKeyCredential: resetPublicKeyCredential, originR5: context.originR5)
+            continuation.resume(returning: ())
+
+        case let .passkeyLogin(scopes, continuation):
+            let authToken = try await authenticateWithPasskey(authorization, scopes: scopes, reachFive: reachFive, originR5: context.originR5)
+            continuation.resume(returning: authToken)
+
+        case let .modalLogin(scopes, siwa, continuation):
+            let loginFlow = try await completeModalLogin(authorization, scopes: scopes, siwa: siwa, context: context)
+            continuation.resume(returning: loginFlow)
+        }
+    }
+
+    /// Complète une connexion modale, seul flux à pouvoir recevoir plusieurs types de credential
+    /// (mot de passe, Sign In With Apple ou passkey).
+    private func completeModalLogin(_ authorization: ASAuthorization, scopes: [String]?, siwa: SignInWithApple?, context: RequestContext) async throws -> LoginFlow {
+        let reachFive = context.reachFive
+        let reachFiveApi = reachFive.reachFiveApi
+        let sdkConfig = reachFive.sdkConfig
+
+        guard let scopes else {
+            throw ReachFiveError.TechnicalError(reason: "didCompleteWithAuthorization: no scope")
+        }
 
         if let passwordCredential = authorization.credential as? ASPasswordCredential {
             // a password was selected to sign in
-            guard case let .loginFlow(continuation) = context.pending else {
-                throw ReachFiveError.TechnicalError(reason: "didCompleteWithAuthorization: unexpected password credential for this request")
-            }
-            guard let scope = context.scope else {
-                throw ReachFiveError.TechnicalError(reason: "didCompleteWithAuthorization: no scope")
-            }
-
             let email: String?
             let phoneNumber: String?
             if passwordCredential.user.contains("@") {
@@ -388,118 +419,43 @@ extension CredentialManager: ASAuthorizationControllerDelegate {
                 password: passwordCredential.password,
                 grantType: "password",
                 clientId: sdkConfig.clientId,
-                scope: scope,
+                scope: scopes.joined(separator: " "),
                 origin: context.originR5
             ))
 
-            let loginFlow = try await context.reachFive.loginFlow(afterPasswordGrant: resp, scopes: context.scopes, origin: context.originR5)
-            continuation.resume(returning: loginFlow)
+            return try await reachFive.loginFlow(afterPasswordGrant: resp, scopes: scopes, origin: context.originR5)
         } else if let appleIDCredential = authorization.credential as? ASAuthorizationAppleIDCredential {
-            guard case let .loginFlow(continuation) = context.pending else {
-                throw ReachFiveError.TechnicalError(reason: "didCompleteWithAuthorization: unexpected Sign In With Apple credential for this request")
+            guard let siwa else {
+                throw ReachFiveError.TechnicalError(reason: "didCompleteWithAuthorization: no nonce, no apple provider")
             }
-            guard case let .signInWithApple(nonce, appleProvider) = context.extra, let scope = context.scope else {
-                throw ReachFiveError.TechnicalError(reason: "didCompleteWithAuthorization: no scope, no nonce, no apple provider")
-            }
-
             guard let identityToken = appleIDCredential.identityToken else {
                 throw ReachFiveError.TechnicalError(reason: "didCompleteWithAuthorization: no id token returned")
             }
-
             guard let idToken = String(data: identityToken, encoding: .utf8) else {
                 throw ReachFiveError.TechnicalError(reason: "didCompleteWithAuthorization: unreadable id token \(identityToken)")
             }
 
             let pkce = Pkce.generate()
             let code = try await reachFiveApi.authorize(params: [
-                "provider": appleProvider.providerConfig.providerWithVariant,
+                "provider": siwa.provider.providerConfig.providerWithVariant,
                 "client_id": sdkConfig.clientId,
                 "id_token": idToken,
                 "response_type": "code",
                 "redirect_uri": sdkConfig.redirectUri.absoluteString,
-                "scope": scope,
+                "scope": scopes.joined(separator: " "),
                 "code_challenge": pkce.codeChallenge,
                 "code_challenge_method": pkce.codeChallengeMethod,
-                "nonce": nonce.codeVerifier,
+                "nonce": siwa.nonce.codeVerifier,
                 "origin": context.originR5,
                 "given_name": appleIDCredential.fullName?.givenName,
                 "family_name": appleIDCredential.fullName?.familyName
             ])
-            let token = try await context.reachFive.authWithCode(code: code, pkce: pkce)
-            continuation.resume(returning: .AchievedLogin(authToken: token))
-        } else if #available(iOS 16.0, *), let credentialRegistration = authorization.credential as? ASAuthorizationPlatformPublicKeyCredentialRegistration {
-            // A new passkey was registered
-            guard let attestationObject = credentialRegistration.rawAttestationObject else {
-                throw ReachFiveError.TechnicalError(reason: "didCompleteWithAuthorization: no attestationObject")
-            }
-
-            let clientDataJSON = credentialRegistration.rawClientDataJSON
-            let r5AuthenticatorAttestationResponse = R5AuthenticatorAttestationResponse(attestationObject: attestationObject.toBase64Url(), clientDataJSON: clientDataJSON.toBase64Url())
-
-            let id = credentialRegistration.credentialID.toBase64Url()
-            let registrationPublicKeyCredential = RegistrationPublicKeyCredential(id: id, rawId: id, type: "public-key", response: r5AuthenticatorAttestationResponse)
-
-            guard case let .passkeyCreation(passkeyCreationType) = context.extra else {
-                throw ReachFiveError.TechnicalError(reason: "didCompleteWithAuthorization: no passkey creation data")
-            }
-
-            switch passkeyCreationType {
-            case let .AddPasskey(authToken):
-                guard case let .registration(continuation) = context.pending else {
-                    throw ReachFiveError.TechnicalError(reason: "didCompleteWithAuthorization: unexpected passkey registration for this request")
-                }
-                try await reachFiveApi.registerWithWebAuthn(authToken: authToken, publicKeyCredential: registrationPublicKeyCredential, originR5: context.originR5)
-                continuation.resume(returning: ())
-
-            case let .Signup(signupOptions):
-                guard case let .authToken(continuation) = context.pending else {
-                    throw ReachFiveError.TechnicalError(reason: "didCompleteWithAuthorization: unexpected passkey registration for this request")
-                }
-                guard let scopes = context.scopes else {
-                    throw ReachFiveError.TechnicalError(reason: "didCompleteWithAuthorization: no scope")
-                }
-
-                let webauthnSignupCredential = WebauthnSignupCredential(webauthnId: signupOptions.options.publicKey.user.id, publicKeyCredential: registrationPublicKeyCredential)
-                let authenticationToken = try await reachFiveApi.signupWithWebAuthn(webauthnSignupCredential: webauthnSignupCredential, originR5: context.originR5)
-                let authToken = try await context.reachFive.loginCallback(tkn: authenticationToken.tkn, scopes: scopes, origin: context.originR5)
-                continuation.resume(returning: authToken)
-
-            case let .ResetPasskey(resetOptions):
-                guard case let .registration(continuation) = context.pending else {
-                    throw ReachFiveError.TechnicalError(reason: "didCompleteWithAuthorization: unexpected passkey registration for this request")
-                }
-                let resetPublicKeyCredential = ResetPublicKeyCredential(resetOptions: resetOptions, publicKeyCredential: registrationPublicKeyCredential)
-                try await reachFiveApi.resetWebAuthn(resetPublicKeyCredential: resetPublicKeyCredential, originR5: context.originR5)
-                continuation.resume(returning: ())
-            }
-        } else if #available(iOS 16.0, *), let credentialAssertion = authorization.credential as? ASAuthorizationPlatformPublicKeyCredentialAssertion {
-            // A passkey was selected to sign in
-
-            guard let scopes = context.scopes else {
-                throw ReachFiveError.TechnicalError(reason: "didCompleteWithAuthorization: no scope")
-            }
-
-            let signature = credentialAssertion.signature.toBase64Url()
-            let clientDataJSON = credentialAssertion.rawClientDataJSON.toBase64Url()
-            let userID = credentialAssertion.userID.toBase64Url()
-
-            let id = credentialAssertion.credentialID.toBase64Url()
-            let authenticatorData = credentialAssertion.rawAuthenticatorData.toBase64Url()
-            let response = R5AuthenticatorAssertionResponse(authenticatorData: authenticatorData, clientDataJSON: clientDataJSON, signature: signature, userHandle: userID)
-
-            let authenticationToken = try await reachFiveApi.authenticateWithWebAuthn(authenticationPublicKeyCredential: AuthenticationPublicKeyCredential(id: id, rawId: id, type: "public-key", response: response))
-            let authToken = try await context.reachFive.loginCallback(tkn: authenticationToken.tkn, scopes: scopes, origin: context.originR5)
-
-            switch context.pending {
-            case let .authToken(continuation):
-                continuation.resume(returning: authToken)
-            case let .loginFlow(continuation):
-                continuation.resume(returning: .AchievedLogin(authToken: authToken))
-            case .registration:
-                throw ReachFiveError.TechnicalError(reason: "didCompleteWithAuthorization: unexpected passkey assertion for this request")
-            }
+            let token = try await reachFive.authWithCode(code: code, pkce: pkce)
+            return .AchievedLogin(authToken: token)
         } else {
-            throw ReachFiveError.TechnicalError(reason: "didCompleteWithAuthorization: Received unknown authorization type.")
+            // a passkey was selected to sign in
+            let authToken = try await authenticateWithPasskey(authorization, scopes: scopes, reachFive: reachFive, originR5: context.originR5)
+            return .AchievedLogin(authToken: authToken)
         }
     }
 
@@ -509,7 +465,7 @@ extension CredentialManager: ASAuthorizationControllerDelegate {
             return
         }
 
-        context.fail(with: Self.adapt(error))
+        context.operation.fail(with: Self.adapt(error))
     }
 
     // Fonction pure, extraite pour être testable unitairement
@@ -524,6 +480,46 @@ extension CredentialManager: ASAuthorizationControllerDelegate {
             return .TechnicalError(reason: "ASAuthorizationError \(authorizationError.code.rawValue): \(error)")
         }
         return .TechnicalError(reason: "\(error.localizedDescription)")
+    }
+}
+
+// MARK: - extraction des credentials reçus
+extension CredentialManager {
+    /// Extrait le credential d'enregistrement de passkey d'une autorisation (signup / add / reset)
+    /// et le convertit dans notre format. Lève une erreur technique si l'autorisation n'en contient pas.
+    private func registrationCredential(from authorization: ASAuthorization) throws -> RegistrationPublicKeyCredential {
+        guard #available(iOS 16.0, *), let credentialRegistration = authorization.credential as? ASAuthorizationPlatformPublicKeyCredentialRegistration else {
+            throw ReachFiveError.TechnicalError(reason: "didCompleteWithAuthorization: expected a passkey registration")
+        }
+        guard let attestationObject = credentialRegistration.rawAttestationObject else {
+            throw ReachFiveError.TechnicalError(reason: "didCompleteWithAuthorization: no attestationObject")
+        }
+
+        let response = R5AuthenticatorAttestationResponse(attestationObject: attestationObject.toBase64Url(), clientDataJSON: credentialRegistration.rawClientDataJSON.toBase64Url())
+        let id = credentialRegistration.credentialID.toBase64Url()
+        return RegistrationPublicKeyCredential(id: id, rawId: id, type: "public-key", response: response)
+    }
+
+    /// Extrait l'assertion de passkey d'une autorisation, la valide auprès du serveur et rend le jeton.
+    /// Partagé par la connexion par passkey (auto-fill / non-discoverable) et la branche passkey de la
+    /// connexion modale. Lève une erreur technique si l'autorisation n'est pas une assertion de passkey.
+    private func authenticateWithPasskey(_ authorization: ASAuthorization, scopes: [String]?, reachFive: ReachFive, originR5: String?) async throws -> AuthToken {
+        guard #available(iOS 16.0, *), let credentialAssertion = authorization.credential as? ASAuthorizationPlatformPublicKeyCredentialAssertion else {
+            throw ReachFiveError.TechnicalError(reason: "didCompleteWithAuthorization: expected a passkey assertion")
+        }
+        guard let scopes else {
+            throw ReachFiveError.TechnicalError(reason: "didCompleteWithAuthorization: no scope")
+        }
+
+        let signature = credentialAssertion.signature.toBase64Url()
+        let clientDataJSON = credentialAssertion.rawClientDataJSON.toBase64Url()
+        let userID = credentialAssertion.userID.toBase64Url()
+        let id = credentialAssertion.credentialID.toBase64Url()
+        let authenticatorData = credentialAssertion.rawAuthenticatorData.toBase64Url()
+        let response = R5AuthenticatorAssertionResponse(authenticatorData: authenticatorData, clientDataJSON: clientDataJSON, signature: signature, userHandle: userID)
+
+        let authenticationToken = try await reachFive.reachFiveApi.authenticateWithWebAuthn(authenticationPublicKeyCredential: AuthenticationPublicKeyCredential(id: id, rawId: id, type: "public-key", response: response))
+        return try await reachFive.loginCallback(tkn: authenticationToken.tkn, scopes: scopes, origin: originR5)
     }
 }
 

--- a/Sources/Core/Classes/CredentialManager.swift
+++ b/Sources/Core/Classes/CredentialManager.swift
@@ -179,7 +179,11 @@ class CredentialManager: NSObject {
     @available(iOS 16.0, *)
     func beginAutoFillAssistedPasskeySignIn(request: ResolvedNativeLoginRequest, reachFive: ReachFive) async throws -> AuthToken {
         let assertionRequestOptions = try await reachFive.reachFiveApi.createWebAuthnAuthenticationOptions(webAuthnLoginRequest: makeWebAuthnLoginRequest(for: request, reachFive: reachFive))
-        let authorizationRequest = try makePasskeyAssertionRequest(assertionRequestOptions, restrictedToAllowedCredentials: false)
+        let authorizationRequest = if #available(iOS 16.0, *) {
+            try makePasskeyAssertionRequest(assertionRequestOptions, restrictedToAllowedCredentials: false)
+        } else {
+            throw ReachFiveError.TechnicalError(reason: "Passkey AutoFill-assisted sign-in requires iOS 16 or later.")
+        }
 
         // AutoFill-assisted requests only support ASAuthorizationPlatformPublicKeyCredentialAssertionRequest.
         let authorization = try await perform(requests: [authorizationRequest], anchor: request.anchor) {

--- a/Sources/Core/Classes/CredentialManager.swift
+++ b/Sources/Core/Classes/CredentialManager.swift
@@ -186,7 +186,7 @@ class CredentialManager: NSObject {
             $0.performAutoFillAssistedRequests()
         }
 
-        return try await authenticateWithPasskey(authorization, scopes: request.scopes, reachFive: reachFive, originR5: request.origin)
+        return try await authenticate(with: authorization, scopes: request.scopes, reachFive: reachFive, originR5: request.origin)
     }
 
     // MARK: - Modal
@@ -205,7 +205,7 @@ class CredentialManager: NSObject {
             performRequests(on: $0, mode: mode)
         }
 
-        return try await authenticateWithPasskey(authorization, scopes: request.scopes, reachFive: reachFive, originR5: request.origin)
+        return try await authenticate(with: authorization, scopes: request.scopes, reachFive: reachFive, originR5: request.origin)
     }
 
     func login(withRequest request: ResolvedNativeLoginRequest, usingModalAuthorizationFor requestTypes: [ModalAuthorization], display mode: Mode, appleProvider: ConfiguredAppleProvider?, reachFive: ReachFive) async throws -> LoginFlow {
@@ -372,19 +372,23 @@ extension CredentialManager {
         return RegistrationPublicKeyCredential(id: id, rawId: id, type: "public-key", response: response)
     }
 
-    /// Extrait l'assertion de passkey d'une autorisation, la valide auprès du serveur et rend le jeton.
+    /// Extrait l'assertion WebAuthn d'une autorisation, la valide auprès du serveur et rend le jeton.
     /// Partagé par la connexion par passkey (auto-fill / non-discoverable) et la branche passkey de la
-    /// connexion modale. Lève une erreur technique si l'autorisation n'est pas une assertion de passkey.
-    private func authenticateWithPasskey(_ authorization: ASAuthorization, scopes: [String], reachFive: ReachFive, originR5: String?) async throws -> AuthToken {
-        guard #available(iOS 16.0, *), let credentialAssertion = authorization.credential as? ASAuthorizationPlatformPublicKeyCredentialAssertion else {
-            throw ReachFiveError.TechnicalError(reason: "didCompleteWithAuthorization: expected a passkey assertion")
+    /// connexion modale. Lève une erreur technique si l'autorisation n'est pas une assertion WebAuthn.
+    ///
+    /// Typée sur ``ASAuthorizationPublicKeyCredentialAssertion`` et non sur le credential de plateforme :
+    /// le protocole déclare tous les champs qu'on lit, et une assertion de clé de sécurité s'y conforme
+    /// aussi, donc supporter les clés de sécurité ne touchera pas cette méthode.
+    private func authenticate(with authorization: ASAuthorization, scopes: [String], reachFive: ReachFive, originR5: String?) async throws -> AuthToken {
+        guard #available(iOS 15.0, *), let assertion = authorization.credential as? any ASAuthorizationPublicKeyCredentialAssertion else {
+            throw ReachFiveError.TechnicalError(reason: "didCompleteWithAuthorization: expected a WebAuthn assertion")
         }
 
-        let signature = credentialAssertion.signature.toBase64Url()
-        let clientDataJSON = credentialAssertion.rawClientDataJSON.toBase64Url()
-        let userID = credentialAssertion.userID.toBase64Url()
-        let id = credentialAssertion.credentialID.toBase64Url()
-        let authenticatorData = credentialAssertion.rawAuthenticatorData.toBase64Url()
+        let signature = assertion.signature.toBase64Url()
+        let clientDataJSON = assertion.rawClientDataJSON.toBase64Url()
+        let userID = assertion.userID.toBase64Url()
+        let id = assertion.credentialID.toBase64Url()
+        let authenticatorData = assertion.rawAuthenticatorData.toBase64Url()
         let response = R5AuthenticatorAssertionResponse(authenticatorData: authenticatorData, clientDataJSON: clientDataJSON, signature: signature, userHandle: userID)
 
         let authenticationToken = try await reachFive.reachFiveApi.authenticateWithWebAuthn(authenticationPublicKeyCredential: AuthenticationPublicKeyCredential(id: id, rawId: id, type: "public-key", response: response))
@@ -444,7 +448,7 @@ extension CredentialManager {
             return .AchievedLogin(authToken: token)
         } else {
             // a passkey was selected to sign in
-            let authToken = try await authenticateWithPasskey(authorization, scopes: scopes, reachFive: reachFive, originR5: originR5)
+            let authToken = try await authenticate(with: authorization, scopes: scopes, reachFive: reachFive, originR5: originR5)
             return .AchievedLogin(authToken: authToken)
         }
     }

--- a/Sources/Core/Classes/CredentialManager.swift
+++ b/Sources/Core/Classes/CredentialManager.swift
@@ -290,13 +290,17 @@ class CredentialManager: NSObject {
                 requests.append(appleIDRequest)
 
             case .Passkey:
-                do {
-                    // Allow the user to use a saved passkey, if they have one.
-                    let authOptions = try await fetchAuthenticationOptions(reachFive, webAuthnLoginRequest)
-                    try requests.append(makePasskeyAssertionRequest(authOptions, restrictedToAllowedCredentials: false))
-                } catch let error where requestTypes.count > 1 {
-                    // if there are other types of requests, do not block auth if only passkey fails. Just eat the error
-                    Logger.shared.log("Passkey request error ignored in multi-type authorization: \(error)")
+                // `.Passkey` n'est pas constructible sous iOS 16, donc cette branche ne s'exécute jamais
+                // ailleurs — la garde est pour le compilateur, qui ne peut pas le savoir.
+                if #available(iOS 16.0, *) {
+                    do {
+                        // Allow the user to use a saved passkey, if they have one.
+                        let authOptions = try await fetchAuthenticationOptions(reachFive, webAuthnLoginRequest)
+                        try requests.append(makePasskeyAssertionRequest(authOptions, restrictedToAllowedCredentials: false))
+                    } catch let error where requestTypes.count > 1 {
+                        // if there are other types of requests, do not block auth if only passkey fails. Just eat the error
+                        Logger.shared.log("Passkey request error ignored in multi-type authorization: \(error)")
+                    }
                 }
             }
         }
@@ -507,13 +511,12 @@ extension CredentialManager {
     ///   serveur — ce que fait la connexion non-discoverable, qui sait de quel compte il s'agit. L'auto-fill
     ///   et la connexion modale laissent au contraire l'utilisateur choisir parmi ses passkeys.
     ///
-    /// Volontairement sans annotation `@available` : la garde interne permet de l'appeler depuis les points
-    /// d'entrée qui ne peuvent pas être annotés (cf. `NonDiscoverableAuthorization`, ouvert aux Security
-    /// Keys d'iOS 15). Internal pour être testable.
+    /// Ce sont les appelants qui portent la garde de disponibilité : `.Passkey` n'étant pas constructible
+    /// sous iOS 16, sa présence dans une demande implique déjà iOS 16 à l'exécution.
+    ///
+    /// Internal pour être testable.
+    @available(iOS 16.0, *)
     func makePasskeyAssertionRequest(_ options: AuthenticationOptions, restrictedToAllowedCredentials: Bool) throws -> ASAuthorizationRequest {
-        guard #available(iOS 16.0, *) else {
-            throw ReachFiveError.TechnicalError(reason: "Passkey sign-in requires iOS 16 or later.")
-        }
         guard let challenge = options.publicKey.challenge.decodeBase64Url() else {
             throw ReachFiveError.TechnicalError(reason: "unreadable challenge: \(options.publicKey.challenge)")
         }

--- a/Sources/Core/Classes/CredentialManager.swift
+++ b/Sources/Core/Classes/CredentialManager.swift
@@ -1,56 +1,25 @@
 import Foundation
 import AuthenticationServices
 
-// Tous les callbacks d'ASAuthorizationController arrivent sur le main thread ; l'isolation @MainActor
-// protège l'état mutable partagé entre les points d'entrée async et le delegate.
+// Les deux protocoles d'ASAuthorizationController (delegate et presentationContextProvider) sont annotés
+// NS_SWIFT_UI_ACTOR : leurs callbacks arrivent donc sur le main actor, et l'isolation @MainActor de la
+// classe protège l'état mutable partagé entre les points d'entrée async et ces callbacks.
 @MainActor
-public class CredentialManager: NSObject {
+class CredentialManager: NSObject {
     // MARK: - Contexte de requête
 
-    // Les requêtes peuvent s'entrelacer (une requête modale peut démarrer pendant une requête auto-fill).
-    // Tout l'état d'une requête vit donc dans un RequestContext indexé par son controller : chaque callback
-    // du delegate retrouve le contexte de SA requête, et une requête ne peut pas écraser l'état d'une autre.
-    // Internal (et non private) pour que les tests puissent piloter perform(_:requests:...).
-    struct RequestContext {
+    // Les requêtes peuvent se chevaucher : une nouvelle requête annule celles en cours, mais le callback
+    // système d'une requête annulée peut encore arriver après. Tout l'état d'une requête vit donc dans un
+    // RequestContext indexé par son controller : chaque callback retrouve le contexte de sa requête, et
+    // une requête ne peut pas écraser l'état d'une autre.
+    private struct RequestContext {
         // retenu : maintient la requête système en vie jusqu'à sa complétion
         let controller: ASAuthorizationController
-        // retenu fort pendant la durée de la requête : pas de cycle permanent, et le SDK
-        // reste vivant jusqu'à la complétion (pas de back-pointer weak à dénuller)
-        let reachFive: ReachFive
         // anchor pour le presentationContextProvider
         let anchor: ASPresentationAnchor
-        // origin optionnel pour les événements utilisateur
-        let originR5: String?
-        // l'opération demandée : continuation typée + données propres au flux
-        let operation: Operation
-    }
-
-    /// L'opération portée par une requête. Chaque cas fixe d'un bloc le type de credential attendu, le
-    /// traitement à appliquer et le type de valeur rendu par sa continuation : la nature de la requête
-    /// est donc connue de façon univoque, sans avoir à recouper à la main un `Pending` et un `Extra` dans
-    /// chaque branche de complétion. La continuation est le dernier associé, non étiqueté.
-    enum Operation {
-        /// Création de passkey à l'inscription → jeton d'authentification.
-        case signup(options: RegistrationOptions, scopes: [String], CheckedContinuation<AuthToken, Error>)
-        /// Enregistrement d'une passkey pour un compte déjà connecté (add) → rien.
-        case addPasskey(authToken: AuthToken, CheckedContinuation<Void, Error>)
-        /// Réinitialisation des passkeys → rien.
-        case resetPasskey(options: ResetOptions, CheckedContinuation<Void, Error>)
-        /// Connexion par assertion de passkey (auto-fill ou non-discoverable) → jeton d'authentification.
-        case passkeyLogin(scopes: [String]?, CheckedContinuation<AuthToken, Error>)
-        /// Connexion modale (mot de passe, Sign In With Apple ou passkey), pouvant déboucher sur un
-        /// step-up MFA → LoginFlow. Seul flux à pouvoir recevoir plusieurs types de credential.
-        case modalLogin(scopes: [String]?, siwa: SignInWithApple?, CheckedContinuation<LoginFlow, Error>)
-
-        func fail(with error: Error) {
-            switch self {
-            case let .signup(_, _, continuation): continuation.resume(throwing: error)
-            case let .addPasskey(_, continuation): continuation.resume(throwing: error)
-            case let .resetPasskey(_, continuation): continuation.resume(throwing: error)
-            case let .passkeyLogin(_, continuation): continuation.resume(throwing: error)
-            case let .modalLogin(_, _, continuation): continuation.resume(throwing: error)
-            }
-        }
+        // continuation de l'appelant, reprise exactement une fois : toute reprise passe par le retrait
+        // du contexte du dictionnaire, et seul le retrait qui réussit reprend la continuation
+        let continuation: CheckedContinuation<ASAuthorization, Error>
     }
 
     // Données d'un Sign In With Apple, à conserver entre la construction de la requête et sa complétion.
@@ -67,44 +36,93 @@ public class CredentialManager: NSObject {
 
     // MARK: - Cycle de vie des requêtes
 
-    /// Annule les requêtes en cours, principalement pour annuler une requête auto-fill avant de démarrer
-    /// une requête modale (sinon cette dernière échouerait). Chaque annulation déclenche
-    /// `didCompleteWithError(.canceled)` pour son controller, ce qui résout sa continuation en `.AuthCanceled`.
-    private func cancelInFlightRequests() {
-        guard #available(iOS 16.0, *) else { return } // cancel() n'existe qu'à partir d'iOS 16
-        for context in contexts.values {
-            context.controller.cancel()
+    /// Soumet une requête système et rend l'autorisation obtenue. Le post-traitement (validation serveur,
+    /// échange de jeton) reste dans la tâche de l'appelant, qui garde donc la main sur son annulation et
+    /// sur ses erreurs, et chaque flux se lit d'un seul tenant à son point d'entrée.
+    ///
+    /// Le contexte est enregistré avant la soumission : comme tout se passe sur le main actor, la
+    /// continuation est en place avant que le delegate puisse tirer.
+    ///
+    /// Internal pour être testable : un test pilote la méthode avec un `submit` inerte (la requête n'est
+    /// jamais soumise au système) puis simule les callbacks du delegate.
+    func perform(
+        requests: [ASAuthorizationRequest],
+        anchor: ASPresentationAnchor,
+        using submit: (ASAuthorizationController) -> Void
+    ) async throws -> ASAuthorization {
+        guard !requests.isEmpty else {
+            // ASAuthorizationController exige au moins une requête. Sans cette garde, le système ne
+            // rappellerait jamais le delegate et l'appelant resterait suspendu indéfiniment.
+            throw ReachFiveError.TechnicalError(reason: "No authorization request to perform")
+        }
+
+        let controller = ASAuthorizationController(authorizationRequests: requests)
+        controller.delegate = self
+        controller.presentationContextProvider = self
+        let key = ObjectIdentifier(controller)
+
+        return try await withTaskCancellationHandler {
+            // La tâche appelante peut avoir été annulée avant même d'arriver ici : ne rien soumettre.
+            try Task.checkCancellation()
+
+            return try await withCheckedThrowingContinuation { continuation in
+                // Annulation des requêtes en cours et soumission de la nouvelle dans le même bloc
+                // synchrone : aucune autre tâche du main actor ne peut s'exécuter entre les deux.
+                cancelInFlightRequests()
+                contexts[key] = RequestContext(controller: controller, anchor: anchor, continuation: continuation)
+                submit(controller)
+            }
+        } onCancel: {
+            // onCancel est appelé hors du main actor ; on y repasse pour toucher `contexts`. Le saut de
+            // tâche ne peut pas devancer l'enregistrement du contexte : le bloc ci-dessus ne rend la main
+            // au main actor qu'après la soumission.
+            Task { @MainActor in self.cancelBecauseCallerWasCancelled(key) }
         }
     }
 
-    /// Crée le controller, enregistre le contexte de la requête PUIS lance la requête système via `perform` :
-    /// comme tout se passe sur le main actor, la continuation est en place avant que le delegate puisse tirer.
+    /// Annule les requêtes en cours, principalement pour annuler une requête auto-fill avant de démarrer
+    /// une requête modale (sinon cette dernière échouerait).
     ///
-    /// L'`Operation` à construire est passée comme closure recevant la continuation (`{ .signup(…, $0) }`),
-    /// ce qui fixe le type de retour `T` de la requête. Internal pour être testable : un test pilote la méthode
-    /// avec un `perform` inerte puis simule les callbacks du delegate.
-    func perform<T>(
-        _ makeOperation: (CheckedContinuation<T, Error>) -> Operation,
-        requests: [ASAuthorizationRequest],
-        reachFive: ReachFive,
-        anchor: ASPresentationAnchor,
-        originR5: String?,
-        using perform: (ASAuthorizationController) -> Void
-    ) async throws -> T {
-        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<T, Error>) in
-            let controller = ASAuthorizationController(authorizationRequests: requests)
-            controller.delegate = self
-            controller.presentationContextProvider = self
-            contexts[ObjectIdentifier(controller)] = RequestContext(controller: controller, reachFive: reachFive, anchor: anchor, originR5: originR5, operation: makeOperation(continuation))
-            perform(controller)
+    /// La continuation de chaque requête annulée est reprise ici en `.AuthCanceled`, sans attendre le
+    /// `didCompleteWithError(.canceled)` du système : celui-ci n'est promis que si un flux tournait
+    /// effectivement (cf. la doc de `ASAuthorizationController.cancel()`), et une requête dont le système
+    /// ne rappelle jamais laisserait son appelant suspendu et son contexte en mémoire pour toujours. Le
+    /// callback tardif éventuel ne trouve plus de contexte et est ignoré.
+    ///
+    /// Appelé par ``perform(requests:anchor:using:)`` dans le même bloc synchrone que la soumission de la
+    /// nouvelle requête : l'application ne peut donc pas relancer une requête auto-fill — sa réaction
+    /// habituelle à `.AuthCanceled` — avant que la nouvelle requête ne soit soumise.
+    ///
+    /// Internal pour être testable.
+    func cancelInFlightRequests() {
+        let inFlight = Array(contexts.values)
+        contexts.removeAll()
+        for context in inFlight {
+            if #available(iOS 16.0, *) { // cancel() n'existe qu'à partir d'iOS 16
+                context.controller.cancel()
+            }
+            context.continuation.resume(throwing: ReachFiveError.AuthCanceled)
         }
+    }
+
+    /// Reprend la requête `key` en `CancellationError` parce que la tâche appelante a été annulée, et
+    /// arrête la requête système. Volontairement pas `.AuthCanceled` : cette erreur signale une annulation
+    /// par l'utilisateur, à laquelle les applications réagissent en relançant une requête auto-fill, alors
+    /// qu'ici c'est l'écran appelant qui disparaît.
+    private func cancelBecauseCallerWasCancelled(_ key: ObjectIdentifier) {
+        guard let context = contexts.removeValue(forKey: key) else {
+            // requête déjà complétée ou jamais enregistrée : rien à faire
+            return
+        }
+        if #available(iOS 16.0, *) {
+            context.controller.cancel()
+        }
+        context.continuation.resume(throwing: CancellationError())
     }
 
     // MARK: - Signup
     @available(iOS 16.0, *)
     func signUp(withRequest request: SignupOptions, anchor: ASPresentationAnchor, originR5: String? = nil, reachFive: ReachFive) async throws -> AuthToken {
-        cancelInFlightRequests()
-
         let options = try await reachFive.reachFiveApi.createWebAuthnSignupOptions(webAuthnSignupOptions: request)
         let registrationRequest = try makeCredentialRegistrationRequest(from: options, friendlyName: request.friendlyName)
 
@@ -112,70 +130,64 @@ public class CredentialManager: NSObject {
         // sans dupliquer la valeur en paramètre, un token de scope OAuth ne pouvant pas contenir d'espace.
         let scopes = request.scope.components(separatedBy: " ")
 
-        return try await perform({ .signup(options: options, scopes: scopes, $0) }, requests: [registrationRequest], reachFive: reachFive, anchor: anchor, originR5: originR5) {
+        let authorization = try await perform(requests: [registrationRequest], anchor: anchor) {
             $0.performRequests()
         }
+
+        let credential = try registrationCredential(from: authorization)
+        let webauthnSignupCredential = WebauthnSignupCredential(webauthnId: options.options.publicKey.user.id, publicKeyCredential: credential)
+        let authenticationToken = try await reachFive.reachFiveApi.signupWithWebAuthn(webauthnSignupCredential: webauthnSignupCredential, originR5: originR5)
+        return try await reachFive.loginCallback(tkn: authenticationToken.tkn, scopes: scopes, origin: originR5)
     }
 
     // MARK: - Register
     @available(iOS 16.0, *)
     func registerNewPasskey(withRequest request: NewPasskeyRequest, authToken: AuthToken, reachFive: ReachFive) async throws {
-        // Here it is very important to cancel a running auto-fill request, otherwise it will fail like other modal requests
-        // so can't separate this method from the rest of the class
-        cancelInFlightRequests()
-
         let options = try await reachFive.reachFiveApi.createWebAuthnRegistrationOptions(authToken: authToken, registrationRequest: RegistrationRequest(origin: request.originWebAuthn!, friendlyName: request.friendlyName))
         let registrationRequest = try makeCredentialRegistrationRequest(from: options, friendlyName: request.friendlyName)
 
-        try await perform({ .addPasskey(authToken: authToken, $0) }, requests: [registrationRequest], reachFive: reachFive, anchor: request.anchor, originR5: request.origin) {
+        let authorization = try await perform(requests: [registrationRequest], anchor: request.anchor) {
             $0.performRequests()
         }
+
+        let credential = try registrationCredential(from: authorization)
+        try await reachFive.reachFiveApi.registerWithWebAuthn(authToken: authToken, publicKeyCredential: credential, originR5: request.origin)
     }
 
     // MARK: - Reset
     @available(iOS 16.0, *)
     func resetPasskeys(withRequest request: ResetPasskeyRequest, reachFive: ReachFive) async throws {
-        // Here it is very important to cancel a running auto-fill request, otherwise it will fail like other modal requests
-        // so can't separate this method from the rest of the class
-        cancelInFlightRequests()
-
         let resetOptions = ResetOptions(email: request.email, phoneNumber: request.phoneNumber, verificationCode: request.verificationCode, friendlyName: request.friendlyName, origin: request.originWebAuthn!, clientId: reachFive.sdkConfig.clientId)
         let options = try await reachFive.reachFiveApi.createWebAuthnResetOptions(resetOptions: resetOptions)
         let registrationRequest = try makeCredentialRegistrationRequest(from: options, friendlyName: request.friendlyName)
 
-        try await perform({ .resetPasskey(options: resetOptions, $0) }, requests: [registrationRequest], reachFive: reachFive, anchor: request.anchor, originR5: request.origin) {
+        let authorization = try await perform(requests: [registrationRequest], anchor: request.anchor) {
             $0.performRequests()
         }
+
+        let credential = try registrationCredential(from: authorization)
+        let resetPublicKeyCredential = ResetPublicKeyCredential(resetOptions: resetOptions, publicKeyCredential: credential)
+        try await reachFive.reachFiveApi.resetWebAuthn(resetPublicKeyCredential: resetPublicKeyCredential, originR5: request.origin)
     }
 
     // MARK: - Auto-fill
     @available(macCatalyst, unavailable)
     @available(iOS 16.0, *)
     func beginAutoFillAssistedPasskeySignIn(request: NativeLoginRequest, reachFive: ReachFive) async throws -> AuthToken {
-        cancelInFlightRequests()
-
-        let webAuthnLoginRequest = WebAuthnLoginRequest(clientId: reachFive.sdkConfig.clientId, origin: request.originWebAuthn!, scope: request.scopes)
-
-        let assertionRequestOptions = try await reachFive.reachFiveApi.createWebAuthnAuthenticationOptions(webAuthnLoginRequest: webAuthnLoginRequest)
-        // Cette garde semble redondante (la méthode est déjà @available(iOS 16.0, *)) mais elle est nécessaire
-        // pour compiler sous Xcode 26 (peut-être un bug Xcode). Ne pas la supprimer. Cf. commit 6a65a83.
-        let authorizationRequest = if #available(iOS 16.0, *) {
-            try createCredentialAssertionRequest(assertionRequestOptions)
-        } else {
-            throw ReachFiveError.TechnicalError(reason: "Passkey AutoFill-assisted sign-in requires iOS 16 or later.")
-        }
+        let assertionRequestOptions = try await reachFive.reachFiveApi.createWebAuthnAuthenticationOptions(webAuthnLoginRequest: makeWebAuthnLoginRequest(for: request, reachFive: reachFive))
+        let authorizationRequest = try makePasskeyAssertionRequest(assertionRequestOptions, restrictedToAllowedCredentials: false)
 
         // AutoFill-assisted requests only support ASAuthorizationPlatformPublicKeyCredentialAssertionRequest.
-        return try await perform({ .passkeyLogin(scopes: request.scopes, $0) }, requests: [authorizationRequest], reachFive: reachFive, anchor: request.anchor, originR5: request.origin) {
+        let authorization = try await perform(requests: [authorizationRequest], anchor: request.anchor) {
             $0.performAutoFillAssistedRequests()
         }
+
+        return try await authenticateWithPasskey(authorization, scopes: request.scopes, reachFive: reachFive, originR5: request.origin)
     }
 
     // MARK: - Modal
     func login(withNonDiscoverableUsername username: Username, forRequest request: NativeLoginRequest, usingModalAuthorizationFor requestTypes: [NonDiscoverableAuthorization], display mode: Mode, reachFive: ReachFive) async throws -> AuthToken {
-        cancelInFlightRequests()
-
-        let webAuthnLoginRequest = WebAuthnLoginRequest(clientId: reachFive.sdkConfig.clientId, origin: request.originWebAuthn!, scope: request.scopes)
+        let webAuthnLoginRequest = makeWebAuthnLoginRequest(for: request, reachFive: reachFive)
         switch username {
 
         case .Unspecified(username: let username):
@@ -190,43 +202,33 @@ public class CredentialManager: NSObject {
             webAuthnLoginRequest.phoneNumber = phoneNumber
         }
 
-        let authzs = requestTypes.compactMap { adaptAuthz($0) }
+        let built = try await buildAuthorizationRequests(
+            webAuthnLoginRequest,
+            reachFive: reachFive,
+            authorizing: requestTypes.compactMap { adaptAuthz($0) },
+            restrictingPasskeysToAllowedCredentials: true
+        )
 
-        let built = try await buildAuthorizationRequests(webAuthnLoginRequest, reachFive: reachFive, authorizing: authzs) { assertionRequestOptions in
-            guard #available(iOS 16.0, *) else { // can't happen, because this is called from a >= iOS 16 context
-                throw ReachFiveError.TechnicalError(reason: "Must be iOS 16 or higher")
-            }
-            let assertionRequest = try self.createCredentialAssertionRequest(assertionRequestOptions)
-            guard let allowedCredentials = assertionRequestOptions.publicKey.allowCredentials else {
-                throw ReachFiveError.AuthFailure(reason: "no allowCredentials returned")
-            }
-
-            let credentialIDs = allowedCredentials.compactMap { $0.id.decodeBase64Url() }
-            assertionRequest.allowedCredentials = credentialIDs.map(ASAuthorizationPlatformPublicKeyCredentialDescriptor.init(credentialID:))
-
-            return assertionRequest
-        }
-
-        return try await perform({ .passkeyLogin(scopes: request.scopes, $0) }, requests: built.requests, reachFive: reachFive, anchor: request.anchor, originR5: request.origin) {
+        let authorization = try await perform(requests: built.requests, anchor: request.anchor) {
             performRequests(on: $0, mode: mode)
         }
+
+        return try await authenticateWithPasskey(authorization, scopes: request.scopes, reachFive: reachFive, originR5: request.origin)
     }
 
     func login(withRequest request: NativeLoginRequest, usingModalAuthorizationFor requestTypes: [ModalAuthorization], display mode: Mode, appleProvider: ConfiguredAppleProvider?, reachFive: ReachFive) async throws -> LoginFlow {
-        cancelInFlightRequests()
+        let built = try await buildAuthorizationRequests(
+            makeWebAuthnLoginRequest(for: request, reachFive: reachFive),
+            reachFive: reachFive,
+            authorizing: requestTypes,
+            appleProvider: appleProvider
+        )
 
-        let webAuthnLoginRequest = WebAuthnLoginRequest(clientId: reachFive.sdkConfig.clientId, origin: request.originWebAuthn!, scope: request.scopes)
-
-        let built = try await buildAuthorizationRequests(webAuthnLoginRequest, reachFive: reachFive, authorizing: requestTypes, appleProvider: appleProvider) { authenticationOptions in
-            guard #available(iOS 16.0, *) else { // can't happen, because this is called from a >= iOS 16 context
-                throw ReachFiveError.TechnicalError(reason: "Must be iOS 16 or higher")
-            }
-            return try self.createCredentialAssertionRequest(authenticationOptions)
-        }
-
-        return try await perform({ .modalLogin(scopes: request.scopes, siwa: built.siwa, $0) }, requests: built.requests, reachFive: reachFive, anchor: request.anchor, originR5: request.origin) {
+        let authorization = try await perform(requests: built.requests, anchor: request.anchor) {
             performRequests(on: $0, mode: mode)
         }
+
+        return try await completeModalLogin(authorization, scopes: request.scopes, siwa: built.siwa, reachFive: reachFive, originR5: request.origin)
     }
 
     // Internal pour être testable
@@ -239,7 +241,14 @@ public class CredentialManager: NSObject {
     /// Construit les `ASAuthorizationRequest` pour les types demandés, sans toucher à l'état de la classe.
     /// `fetchAuthenticationOptions` fait l'appel réseau par défaut ; un test peut le substituer pour
     /// construire les requêtes sans réseau.
-    func buildAuthorizationRequests(_ webAuthnLoginRequest: WebAuthnLoginRequest, reachFive: ReachFive,authorizing requestTypes: [ModalAuthorization], appleProvider: ConfiguredAppleProvider? = nil, fetchAuthenticationOptions: (ReachFive, WebAuthnLoginRequest) async throws -> AuthenticationOptions = { try await $0.reachFiveApi.createWebAuthnAuthenticationOptions(webAuthnLoginRequest: $1) }, makeAuthorization: (AuthenticationOptions) throws -> ASAuthorizationRequest) async throws -> BuiltRequests {
+    func buildAuthorizationRequests(
+        _ webAuthnLoginRequest: WebAuthnLoginRequest,
+        reachFive: ReachFive,
+        authorizing requestTypes: [ModalAuthorization],
+        appleProvider: ConfiguredAppleProvider? = nil,
+        restrictingPasskeysToAllowedCredentials restrictToAllowedCredentials: Bool = false,
+        fetchAuthenticationOptions: (ReachFive, WebAuthnLoginRequest) async throws -> AuthenticationOptions = { try await $0.reachFiveApi.createWebAuthnAuthenticationOptions(webAuthnLoginRequest: $1) }
+    ) async throws -> BuiltRequests {
         var requests: [ASAuthorizationRequest] = []
         var siwa: SignInWithApple? = nil
 
@@ -275,8 +284,7 @@ public class CredentialManager: NSObject {
                 do {
                     // Allow the user to use a saved passkey, if they have one.
                     let authOptions = try await fetchAuthenticationOptions(reachFive, webAuthnLoginRequest)
-                    let passkeyRequest = try makeAuthorization(authOptions)
-                    requests.append(passkeyRequest)
+                    requests.append(try makePasskeyAssertionRequest(authOptions, restrictedToAllowedCredentials: restrictToAllowedCredentials))
                 } catch let error where requestTypes.count > 1 {
                     // if there are other types of requests, do not block auth if only passkey fails. Just eat the error
                     Logger.shared.log("Passkey request error ignored in multi-type authorization: \(error)")
@@ -308,95 +316,96 @@ public class CredentialManager: NSObject {
 
 // MARK: - ASAuthorizationControllerPresentationContextProviding
 extension CredentialManager: ASAuthorizationControllerPresentationContextProviding {
-    nonisolated public func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
-        // AuthenticationServices délivre ce callback sur le main thread
-        MainActor.assumeIsolated {
-            contexts[ObjectIdentifier(controller)]?.anchor ?? ASPresentationAnchor()
+    func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
+        guard let anchor = contexts[ObjectIdentifier(controller)]?.anchor else {
+            // Ne devrait pas arriver : le contexte est enregistré avant la soumission de la requête et
+            // retiré à sa complétion. Une fenêtre détachée vaut mieux qu'un crash, mais elle serait
+            // invisible à l'écran : on la signale.
+            Logger.shared.log("presentationAnchor: no in-flight request for this controller, falling back to a detached window")
+            return ASPresentationAnchor()
         }
+        return anchor
     }
 }
 
 // MARK: - ASAuthorizationControllerDelegate
 extension CredentialManager: ASAuthorizationControllerDelegate {
 
-    nonisolated public func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
-        // AuthenticationServices délivre ce callback sur le main thread
-        MainActor.assumeIsolated {
-            handleAuthorization(authorization, for: controller)
-        }
+    func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
+        takeContext(for: controller)?.continuation.resume(returning: authorization)
     }
 
-    nonisolated public func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
-        // AuthenticationServices délivre ce callback sur le main thread
-        MainActor.assumeIsolated {
-            handleError(error, for: controller)
-        }
+    func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
+        takeContext(for: controller)?.continuation.resume(throwing: Self.adapt(error))
     }
 
-    // Retire le contexte à l'entrée du callback : garantit qu'une continuation est résolue exactement une fois,
-    // et qu'un cancelInFlightRequests() ultérieur ne peut plus toucher une requête dont la complétion est en cours.
+    // Retire le contexte à l'entrée du callback : garantit qu'une continuation est résolue exactement une
+    // fois (un second callback pour le même controller ne trouve plus rien), et qu'une annulation
+    // ultérieure ne peut plus toucher une requête déjà complétée.
     private func takeContext(for controller: ASAuthorizationController) -> RequestContext? {
         contexts.removeValue(forKey: ObjectIdentifier(controller))
     }
 
-    private func handleAuthorization(_ authorization: ASAuthorization, for controller: ASAuthorizationController) {
-        guard let context = takeContext(for: controller) else {
-            // controller inconnu ou requête déjà résolue : rien à faire
-            return
+    // Fonction pure, extraite pour être testable unitairement
+    nonisolated static func adapt(_ error: Error) -> ReachFiveError {
+        if let authorizationError = error as? ASAuthorizationError {
+            if authorizationError.code == .canceled {
+                // Either the system doesn't find any credentials and the request ends silently, or the user cancels the request.
+                // This is a good time to show a traditional login form, or ask the user to create an account.
+                return .AuthCanceled
+            }
+            // Another ASAuthorization error.
+            return .TechnicalError(reason: "ASAuthorizationError \(authorizationError.code.rawValue): \(error)")
+        }
+        return .TechnicalError(reason: "\(error.localizedDescription)")
+    }
+}
+
+// MARK: - exploitation des credentials reçus
+extension CredentialManager {
+    /// Extrait le credential d'enregistrement de passkey d'une autorisation (signup / add / reset)
+    /// et le convertit dans notre format. Lève une erreur technique si l'autorisation n'en contient pas.
+    private func registrationCredential(from authorization: ASAuthorization) throws -> RegistrationPublicKeyCredential {
+        guard #available(iOS 16.0, *), let credentialRegistration = authorization.credential as? ASAuthorizationPlatformPublicKeyCredentialRegistration else {
+            throw ReachFiveError.TechnicalError(reason: "didCompleteWithAuthorization: expected a passkey registration")
+        }
+        guard let attestationObject = credentialRegistration.rawAttestationObject else {
+            throw ReachFiveError.TechnicalError(reason: "didCompleteWithAuthorization: no attestationObject")
         }
 
-        Task { @MainActor in
-            do {
-                try await complete(authorization, context: context)
-            } catch {
-                context.operation.fail(with: error)
-            }
-        }
+        let response = R5AuthenticatorAttestationResponse(attestationObject: attestationObject.toBase64Url(), clientDataJSON: credentialRegistration.rawClientDataJSON.toBase64Url())
+        let id = credentialRegistration.credentialID.toBase64Url()
+        return RegistrationPublicKeyCredential(id: id, rawId: id, type: "public-key", response: response)
     }
 
-    /// Un seul `switch` sur l'opération : chaque branche sait quel credential elle attend et le récupère
-    /// via un helper d'extraction. Plus aucun recoupement pending/extra/credential à faire à la main.
-    private func complete(_ authorization: ASAuthorization, context: RequestContext) async throws {
-        let reachFive = context.reachFive
-        let reachFiveApi = reachFive.reachFiveApi
-
-        switch context.operation {
-        case let .signup(options, scopes, continuation):
-            let credential = try registrationCredential(from: authorization)
-            let webauthnSignupCredential = WebauthnSignupCredential(webauthnId: options.options.publicKey.user.id, publicKeyCredential: credential)
-            let authenticationToken = try await reachFiveApi.signupWithWebAuthn(webauthnSignupCredential: webauthnSignupCredential, originR5: context.originR5)
-            let authToken = try await reachFive.loginCallback(tkn: authenticationToken.tkn, scopes: scopes, origin: context.originR5)
-            continuation.resume(returning: authToken)
-
-        case let .addPasskey(authToken, continuation):
-            let credential = try registrationCredential(from: authorization)
-            try await reachFiveApi.registerWithWebAuthn(authToken: authToken, publicKeyCredential: credential, originR5: context.originR5)
-            continuation.resume(returning: ())
-
-        case let .resetPasskey(options, continuation):
-            let credential = try registrationCredential(from: authorization)
-            let resetPublicKeyCredential = ResetPublicKeyCredential(resetOptions: options, publicKeyCredential: credential)
-            try await reachFiveApi.resetWebAuthn(resetPublicKeyCredential: resetPublicKeyCredential, originR5: context.originR5)
-            continuation.resume(returning: ())
-
-        case let .passkeyLogin(scopes, continuation):
-            guard let scopes else { throw ReachFiveError.TechnicalError(reason: "didCompleteWithAuthorization: no scope") }
-            let authToken = try await authenticateWithPasskey(authorization, scopes: scopes, reachFive: reachFive, originR5: context.originR5)
-            continuation.resume(returning: authToken)
-
-        case let .modalLogin(scopes, siwa, continuation):
-            guard let scopes else { throw ReachFiveError.TechnicalError(reason: "didCompleteWithAuthorization: no scope") }
-            let loginFlow = try await completeModalLogin(authorization, scopes: scopes, siwa: siwa, reachFive: reachFive, originR5: context.originR5)
-            continuation.resume(returning: loginFlow)
+    /// Extrait l'assertion de passkey d'une autorisation, la valide auprès du serveur et rend le jeton.
+    /// Partagé par la connexion par passkey (auto-fill / non-discoverable) et la branche passkey de la
+    /// connexion modale. Lève une erreur technique si l'autorisation n'est pas une assertion de passkey.
+    ///
+    /// `scopes` reste optionnel : `loginCallback` retombe sur les scopes du SDK, comme partout ailleurs.
+    private func authenticateWithPasskey(_ authorization: ASAuthorization, scopes: [String]?, reachFive: ReachFive, originR5: String?) async throws -> AuthToken {
+        guard #available(iOS 16.0, *), let credentialAssertion = authorization.credential as? ASAuthorizationPlatformPublicKeyCredentialAssertion else {
+            throw ReachFiveError.TechnicalError(reason: "didCompleteWithAuthorization: expected a passkey assertion")
         }
+
+        let signature = credentialAssertion.signature.toBase64Url()
+        let clientDataJSON = credentialAssertion.rawClientDataJSON.toBase64Url()
+        let userID = credentialAssertion.userID.toBase64Url()
+        let id = credentialAssertion.credentialID.toBase64Url()
+        let authenticatorData = credentialAssertion.rawAuthenticatorData.toBase64Url()
+        let response = R5AuthenticatorAssertionResponse(authenticatorData: authenticatorData, clientDataJSON: clientDataJSON, signature: signature, userHandle: userID)
+
+        let authenticationToken = try await reachFive.reachFiveApi.authenticateWithWebAuthn(authenticationPublicKeyCredential: AuthenticationPublicKeyCredential(id: id, rawId: id, type: "public-key", response: response))
+        return try await reachFive.loginCallback(tkn: authenticationToken.tkn, scopes: scopes, origin: originR5)
     }
 
     /// Complète une connexion modale, seul flux à pouvoir recevoir plusieurs types de credential
     /// (mot de passe, Sign In With Apple ou passkey).
-    private func completeModalLogin(_ authorization: ASAuthorization, scopes: [String], siwa: SignInWithApple?, reachFive: ReachFive, originR5: String?) async throws -> LoginFlow {
+    private func completeModalLogin(_ authorization: ASAuthorization, scopes: [String]?, siwa: SignInWithApple?, reachFive: ReachFive, originR5: String?) async throws -> LoginFlow {
         let reachFiveApi = reachFive.reachFiveApi
         let sdkConfig = reachFive.sdkConfig
-        let scope = scopes.joined(separator: " ")
+        // même repli que loginCallback / loginFlow : à défaut de scopes demandés, ceux du SDK
+        let scope = (scopes ?? reachFive.scope).joined(separator: " ")
 
         if let passwordCredential = authorization.credential as? ASPasswordCredential {
             // a password was selected to sign in
@@ -456,72 +465,23 @@ extension CredentialManager: ASAuthorizationControllerDelegate {
             return .AchievedLogin(authToken: authToken)
         }
     }
-
-    private func handleError(_ error: Error, for controller: ASAuthorizationController) {
-        guard let context = takeContext(for: controller) else {
-            // controller inconnu ou requête déjà résolue : rien à faire
-            return
-        }
-
-        context.operation.fail(with: Self.adapt(error))
-    }
-
-    // Fonction pure, extraite pour être testable unitairement
-    nonisolated static func adapt(_ error: Error) -> ReachFiveError {
-        if let authorizationError = error as? ASAuthorizationError {
-            if authorizationError.code == .canceled {
-                // Either the system doesn't find any credentials and the request ends silently, or the user cancels the request.
-                // This is a good time to show a traditional login form, or ask the user to create an account.
-                return .AuthCanceled
-            }
-            // Another ASAuthorization error.
-            return .TechnicalError(reason: "ASAuthorizationError \(authorizationError.code.rawValue): \(error)")
-        }
-        return .TechnicalError(reason: "\(error.localizedDescription)")
-    }
 }
 
-// MARK: - extraction des credentials reçus
+// MARK: - construction des requêtes
 extension CredentialManager {
-    /// Extrait le credential d'enregistrement de passkey d'une autorisation (signup / add / reset)
-    /// et le convertit dans notre format. Lève une erreur technique si l'autorisation n'en contient pas.
-    private func registrationCredential(from authorization: ASAuthorization) throws -> RegistrationPublicKeyCredential {
-        guard #available(iOS 16.0, *), let credentialRegistration = authorization.credential as? ASAuthorizationPlatformPublicKeyCredentialRegistration else {
-            throw ReachFiveError.TechnicalError(reason: "didCompleteWithAuthorization: expected a passkey registration")
-        }
-        guard let attestationObject = credentialRegistration.rawAttestationObject else {
-            throw ReachFiveError.TechnicalError(reason: "didCompleteWithAuthorization: no attestationObject")
-        }
-
-        let response = R5AuthenticatorAttestationResponse(attestationObject: attestationObject.toBase64Url(), clientDataJSON: credentialRegistration.rawClientDataJSON.toBase64Url())
-        let id = credentialRegistration.credentialID.toBase64Url()
-        return RegistrationPublicKeyCredential(id: id, rawId: id, type: "public-key", response: response)
+    /// Le socle commun aux trois flux de connexion WebAuthn.
+    private func makeWebAuthnLoginRequest(for request: NativeLoginRequest, reachFive: ReachFive) -> WebAuthnLoginRequest {
+        WebAuthnLoginRequest(clientId: reachFive.sdkConfig.clientId, origin: request.originWebAuthn!, scope: request.scopes)
     }
 
-    /// Extrait l'assertion de passkey d'une autorisation, la valide auprès du serveur et rend le jeton.
-    /// Partagé par la connexion par passkey (auto-fill / non-discoverable) et la branche passkey de la
-    /// connexion modale. Lève une erreur technique si l'autorisation n'est pas une assertion de passkey.
-    private func authenticateWithPasskey(_ authorization: ASAuthorization, scopes: [String], reachFive: ReachFive, originR5: String?) async throws -> AuthToken {
-        guard #available(iOS 16.0, *), let credentialAssertion = authorization.credential as? ASAuthorizationPlatformPublicKeyCredentialAssertion else {
-            throw ReachFiveError.TechnicalError(reason: "didCompleteWithAuthorization: expected a passkey assertion")
-        }
-
-        let signature = credentialAssertion.signature.toBase64Url()
-        let clientDataJSON = credentialAssertion.rawClientDataJSON.toBase64Url()
-        let userID = credentialAssertion.userID.toBase64Url()
-        let id = credentialAssertion.credentialID.toBase64Url()
-        let authenticatorData = credentialAssertion.rawAuthenticatorData.toBase64Url()
-        let response = R5AuthenticatorAssertionResponse(authenticatorData: authenticatorData, clientDataJSON: clientDataJSON, signature: signature, userHandle: userID)
-
-        let authenticationToken = try await reachFive.reachFiveApi.authenticateWithWebAuthn(authenticationPublicKeyCredential: AuthenticationPublicKeyCredential(id: id, rawId: id, type: "public-key", response: response))
-        return try await reachFive.loginCallback(tkn: authenticationToken.tkn, scopes: scopes, origin: originR5)
-    }
-}
-
-// MARK: - utilities
-extension CredentialManager {
     /// Construit une requête d'enregistrement de passkey à partir des options renvoyées par le serveur.
-    /// Pendant symétrique de ``createCredentialAssertionRequest(_:)``. Internal pour être testable.
+    /// Pendant symétrique de ``makePasskeyAssertionRequest(_:restrictedToAllowedCredentials:)``.
+    ///
+    /// `friendlyName` est celui demandé par l'application, et non `options.friendlyName` : rien ne garantit
+    /// que le serveur renvoie la valeur qu'on lui a passée, et c'est bien l'intention de l'application qui
+    /// doit nommer la passkey dans le trousseau.
+    ///
+    /// Internal pour être testable.
     @available(iOS 16.0, *)
     func makeCredentialRegistrationRequest(from options: RegistrationOptions, friendlyName: String) throws -> ASAuthorizationRequest {
         guard let challenge = options.options.publicKey.challenge.decodeBase64Url() else {
@@ -536,14 +496,36 @@ extension CredentialManager {
         return publicKeyCredentialProvider.createCredentialRegistrationRequest(challenge: challenge, name: friendlyName, userID: userID)
     }
 
-    @available(iOS 16.0, *)
-    private func createCredentialAssertionRequest(_ assertionRequestOptions: AuthenticationOptions) throws -> ASAuthorizationPlatformPublicKeyCredentialAssertionRequest {
-        guard let challenge = assertionRequestOptions.publicKey.challenge.decodeBase64Url() else {
-            throw ReachFiveError.TechnicalError(reason: "unreadable challenge: \(assertionRequestOptions.publicKey.challenge)")
+    /// Construit une requête d'assertion de passkey à partir des options renvoyées par le serveur.
+    ///
+    /// - Parameter restrictedToAllowedCredentials: restreint la requête aux credentials listés par le
+    ///   serveur — ce que fait la connexion non-discoverable, qui sait de quel compte il s'agit. L'auto-fill
+    ///   et la connexion modale laissent au contraire l'utilisateur choisir parmi ses passkeys.
+    ///
+    /// Volontairement sans annotation `@available` : la garde interne permet de l'appeler depuis les points
+    /// d'entrée qui ne peuvent pas être annotés (cf. `NonDiscoverableAuthorization`, ouvert aux Security
+    /// Keys d'iOS 15). Internal pour être testable.
+    func makePasskeyAssertionRequest(_ options: AuthenticationOptions, restrictedToAllowedCredentials: Bool) throws -> ASAuthorizationRequest {
+        guard #available(iOS 16.0, *) else {
+            throw ReachFiveError.TechnicalError(reason: "Passkey sign-in requires iOS 16 or later.")
+        }
+        guard let challenge = options.publicKey.challenge.decodeBase64Url() else {
+            throw ReachFiveError.TechnicalError(reason: "unreadable challenge: \(options.publicKey.challenge)")
         }
 
-        let publicKeyCredentialProvider = ASAuthorizationPlatformPublicKeyCredentialProvider(relyingPartyIdentifier: assertionRequestOptions.publicKey.rpId)
-        return publicKeyCredentialProvider.createCredentialAssertionRequest(challenge: challenge)
+        let publicKeyCredentialProvider = ASAuthorizationPlatformPublicKeyCredentialProvider(relyingPartyIdentifier: options.publicKey.rpId)
+        let assertionRequest = publicKeyCredentialProvider.createCredentialAssertionRequest(challenge: challenge)
+
+        guard restrictedToAllowedCredentials else { return assertionRequest }
+
+        guard let allowedCredentials = options.publicKey.allowCredentials else {
+            throw ReachFiveError.AuthFailure(reason: "no allowCredentials returned")
+        }
+        assertionRequest.allowedCredentials = allowedCredentials
+            .compactMap { $0.id.decodeBase64Url() }
+            .map(ASAuthorizationPlatformPublicKeyCredentialDescriptor.init(credentialID:))
+
+        return assertionRequest
     }
 
     private func adaptAuthz(_ nda: NonDiscoverableAuthorization) -> ModalAuthorization? {

--- a/Sources/Core/Classes/CredentialManager.swift
+++ b/Sources/Core/Classes/CredentialManager.swift
@@ -8,7 +8,7 @@ import Foundation
 class CredentialManager: NSObject {
     // MARK: - Request context
 
-    /// Requests can overlap: a new request cancels the ones in flight, but the system callback of a
+    /// Requests can overlap: a new request cancels the ongoing ones, but the system callback of a
     /// canceled request can still arrive afterwards. All of a request's state therefore lives in a
     /// RequestContext indexed by its controller: each callback finds the context of its own request, and
     /// one request can never overwrite another's state.
@@ -32,7 +32,7 @@ class CredentialManager: NSObject {
         let provider: ConfiguredAppleProvider
     }
 
-    /// requests in flight, indexed by their controller
+    /// ongoing requests, indexed by their controller
     private var contexts: [ObjectIdentifier: RequestContext] = [:]
 
     /// Monotonic, never reset: a fresh identity for each request, so a cancellation that lands late can
@@ -79,9 +79,9 @@ class CredentialManager: NSObject {
             guard !Task.isCancelled else { throw Self.callerCanceled }
 
             return try await withCheckedThrowingContinuation { continuation in
-                // Canceling requests in flight and submitting the new one in the same synchronous block:
+                // Canceling the ongoing requests and submitting the new one in the same synchronous block:
                 // no other task can run on the main actor in between.
-                cancelInFlightRequests()
+                cancelOngoingRequests()
                 contexts[ObjectIdentifier(controller)] = RequestContext(id: id, controller: controller, anchor: anchor, continuation: continuation)
                 submit(controller)
             }
@@ -95,7 +95,7 @@ class CredentialManager: NSObject {
         }
     }
 
-    /// Cancels requests in flight, mainly to cancel an auto-fill request before starting a modal one
+    /// Cancels the ongoing requests, mainly to cancel an auto-fill request before starting a modal one
     /// (otherwise the latter would fail).
     ///
     /// Each canceled request's continuation is resumed here with `.AuthCanceled`, without waiting for the
@@ -109,10 +109,10 @@ class CredentialManager: NSObject {
     /// `.AuthCanceled` — before the new request has been submitted.
     ///
     /// Internal for testability.
-    func cancelInFlightRequests() {
-        let inFlight = Array(contexts.values)
+    func cancelOngoingRequests() {
+        let ongoing = Array(contexts.values)
         contexts.removeAll()
-        for context in inFlight {
+        for context in ongoing {
             if #available(iOS 16.0, *) { // cancel() only exists from iOS 16
                 context.controller.cancel()
             }
@@ -368,7 +368,7 @@ extension CredentialManager: ASAuthorizationControllerPresentationContextProvidi
             // Should not happen: the context is registered before the request is submitted and removed
             // only once it completes. A detached window is better than a crash, but it would be invisible
             // on screen: log it.
-            Logger.shared.log("presentationAnchor: no in-flight request for this controller, falling back to a detached window")
+            Logger.shared.log("presentationAnchor: no ongoing request for this controller, falling back to a detached window")
             return ASPresentationAnchor()
         }
         return anchor

--- a/Sources/Core/Classes/CredentialManager.swift
+++ b/Sources/Core/Classes/CredentialManager.swift
@@ -144,8 +144,8 @@ class CredentialManager: NSObject {
     // MARK: - Register
 
     @available(iOS 16.0, *)
-    func registerNewPasskey(withRequest request: NewPasskeyRequest, authToken: AuthToken, reachFive: ReachFive) async throws {
-        let options = try await reachFive.reachFiveApi.createWebAuthnRegistrationOptions(authToken: authToken, registrationRequest: RegistrationRequest(origin: request.originWebAuthn!, friendlyName: request.friendlyName))
+    func registerNewPasskey(withRequest request: NewPasskeyRequest, originWebAuthn: String, authToken: AuthToken, reachFive: ReachFive) async throws {
+        let options = try await reachFive.reachFiveApi.createWebAuthnRegistrationOptions(authToken: authToken, registrationRequest: RegistrationRequest(origin: originWebAuthn, friendlyName: request.friendlyName))
         let registrationRequest = try makeCredentialRegistrationRequest(from: options, friendlyName: request.friendlyName)
 
         let authorization = try await perform(requests: [registrationRequest], anchor: request.anchor) {
@@ -159,8 +159,8 @@ class CredentialManager: NSObject {
     // MARK: - Reset
 
     @available(iOS 16.0, *)
-    func resetPasskeys(withRequest request: ResetPasskeyRequest, reachFive: ReachFive) async throws {
-        let resetOptions = ResetOptions(email: request.email, phoneNumber: request.phoneNumber, verificationCode: request.verificationCode, friendlyName: request.friendlyName, origin: request.originWebAuthn!, clientId: reachFive.sdkConfig.clientId)
+    func resetPasskeys(withRequest request: ResetPasskeyRequest, originWebAuthn: String, reachFive: ReachFive) async throws {
+        let resetOptions = ResetOptions(email: request.email, phoneNumber: request.phoneNumber, verificationCode: request.verificationCode, friendlyName: request.friendlyName, origin: originWebAuthn, clientId: reachFive.sdkConfig.clientId)
         let options = try await reachFive.reachFiveApi.createWebAuthnResetOptions(resetOptions: resetOptions)
         let registrationRequest = try makeCredentialRegistrationRequest(from: options, friendlyName: request.friendlyName)
 
@@ -177,7 +177,7 @@ class CredentialManager: NSObject {
 
     @available(macCatalyst, unavailable)
     @available(iOS 16.0, *)
-    func beginAutoFillAssistedPasskeySignIn(request: NativeLoginRequest, reachFive: ReachFive) async throws -> AuthToken {
+    func beginAutoFillAssistedPasskeySignIn(request: ResolvedNativeLoginRequest, reachFive: ReachFive) async throws -> AuthToken {
         let assertionRequestOptions = try await reachFive.reachFiveApi.createWebAuthnAuthenticationOptions(webAuthnLoginRequest: makeWebAuthnLoginRequest(for: request, reachFive: reachFive))
         let authorizationRequest = try makePasskeyAssertionRequest(assertionRequestOptions, restrictedToAllowedCredentials: false)
 
@@ -191,7 +191,7 @@ class CredentialManager: NSObject {
 
     // MARK: - Modal
 
-    func login(withNonDiscoverableUsername username: Username, forRequest request: NativeLoginRequest, usingModalAuthorizationFor requestTypes: [NonDiscoverableAuthorization], display mode: Mode, reachFive: ReachFive) async throws -> AuthToken {
+    func login(withNonDiscoverableUsername username: Username, forRequest request: ResolvedNativeLoginRequest, usingModalAuthorizationFor requestTypes: [NonDiscoverableAuthorization], display mode: Mode, reachFive: ReachFive) async throws -> AuthToken {
         let webAuthnLoginRequest = makeWebAuthnLoginRequest(for: request, username: username, reachFive: reachFive)
 
         let built = try await buildAuthorizationRequests(
@@ -208,7 +208,7 @@ class CredentialManager: NSObject {
         return try await authenticateWithPasskey(authorization, scopes: request.scopes, reachFive: reachFive, originR5: request.origin)
     }
 
-    func login(withRequest request: NativeLoginRequest, usingModalAuthorizationFor requestTypes: [ModalAuthorization], display mode: Mode, appleProvider: ConfiguredAppleProvider?, reachFive: ReachFive) async throws -> LoginFlow {
+    func login(withRequest request: ResolvedNativeLoginRequest, usingModalAuthorizationFor requestTypes: [ModalAuthorization], display mode: Mode, appleProvider: ConfiguredAppleProvider?, reachFive: ReachFive) async throws -> LoginFlow {
         let built = try await buildAuthorizationRequests(
             makeWebAuthnLoginRequest(for: request, reachFive: reachFive),
             reachFive: reachFive,
@@ -375,9 +375,7 @@ extension CredentialManager {
     /// Extrait l'assertion de passkey d'une autorisation, la valide auprès du serveur et rend le jeton.
     /// Partagé par la connexion par passkey (auto-fill / non-discoverable) et la branche passkey de la
     /// connexion modale. Lève une erreur technique si l'autorisation n'est pas une assertion de passkey.
-    ///
-    /// `scopes` reste optionnel : `loginCallback` retombe sur les scopes du SDK, comme partout ailleurs.
-    private func authenticateWithPasskey(_ authorization: ASAuthorization, scopes: [String]?, reachFive: ReachFive, originR5: String?) async throws -> AuthToken {
+    private func authenticateWithPasskey(_ authorization: ASAuthorization, scopes: [String], reachFive: ReachFive, originR5: String?) async throws -> AuthToken {
         guard #available(iOS 16.0, *), let credentialAssertion = authorization.credential as? ASAuthorizationPlatformPublicKeyCredentialAssertion else {
             throw ReachFiveError.TechnicalError(reason: "didCompleteWithAuthorization: expected a passkey assertion")
         }
@@ -395,11 +393,10 @@ extension CredentialManager {
 
     /// Complète une connexion modale, seul flux à pouvoir recevoir plusieurs types de credential
     /// (mot de passe, Sign In With Apple ou passkey).
-    private func completeModalLogin(_ authorization: ASAuthorization, scopes: [String]?, siwa: SignInWithApple?, reachFive: ReachFive, originR5: String?) async throws -> LoginFlow {
+    private func completeModalLogin(_ authorization: ASAuthorization, scopes: [String], siwa: SignInWithApple?, reachFive: ReachFive, originR5: String?) async throws -> LoginFlow {
         let reachFiveApi = reachFive.reachFiveApi
         let sdkConfig = reachFive.sdkConfig
-        // même repli que loginCallback / loginFlow : à défaut de scopes demandés, ceux du SDK
-        let scope = (scopes ?? reachFive.scope).joined(separator: " ")
+        let scope = scopes.joined(separator: " ")
 
         if let passwordCredential = authorization.credential as? ASPasswordCredential {
             // a password was selected to sign in
@@ -457,8 +454,8 @@ extension CredentialManager {
 
 extension CredentialManager {
     /// Le socle commun aux trois flux de connexion WebAuthn.
-    private func makeWebAuthnLoginRequest(for request: NativeLoginRequest, username: Username? = nil, reachFive: ReachFive) -> WebAuthnLoginRequest {
-        WebAuthnLoginRequest(clientId: reachFive.sdkConfig.clientId, origin: request.originWebAuthn!, username: username, scope: request.scopes)
+    private func makeWebAuthnLoginRequest(for request: ResolvedNativeLoginRequest, username: Username? = nil, reachFive: ReachFive) -> WebAuthnLoginRequest {
+        WebAuthnLoginRequest(clientId: reachFive.sdkConfig.clientId, origin: request.originWebAuthn, username: username, scope: request.scopes)
     }
 
     /// Construit une requête d'enregistrement de passkey à partir des options renvoyées par le serveur.

--- a/Sources/Core/Classes/CredentialManager.swift
+++ b/Sources/Core/Classes/CredentialManager.swift
@@ -192,8 +192,7 @@ class CredentialManager: NSObject {
     // MARK: - Modal
 
     func login(withNonDiscoverableUsername username: Username, forRequest request: NativeLoginRequest, usingModalAuthorizationFor requestTypes: [NonDiscoverableAuthorization], display mode: Mode, reachFive: ReachFive) async throws -> AuthToken {
-        let webAuthnLoginRequest = makeWebAuthnLoginRequest(for: request, reachFive: reachFive)
-        (webAuthnLoginRequest.email, webAuthnLoginRequest.phoneNumber) = username.identifiers
+        let webAuthnLoginRequest = makeWebAuthnLoginRequest(for: request, username: username, reachFive: reachFive)
 
         let built = try await buildAuthorizationRequests(
             webAuthnLoginRequest,
@@ -458,8 +457,8 @@ extension CredentialManager {
 
 extension CredentialManager {
     /// Le socle commun aux trois flux de connexion WebAuthn.
-    private func makeWebAuthnLoginRequest(for request: NativeLoginRequest, reachFive: ReachFive) -> WebAuthnLoginRequest {
-        WebAuthnLoginRequest(clientId: reachFive.sdkConfig.clientId, origin: request.originWebAuthn!, scope: request.scopes)
+    private func makeWebAuthnLoginRequest(for request: NativeLoginRequest, username: Username? = nil, reachFive: ReachFive) -> WebAuthnLoginRequest {
+        WebAuthnLoginRequest(clientId: reachFive.sdkConfig.clientId, origin: request.originWebAuthn!, username: username, scope: request.scopes)
     }
 
     /// Construit une requête d'enregistrement de passkey à partir des options renvoyées par le serveur.

--- a/Sources/Core/Classes/CredentialManager.swift
+++ b/Sources/Core/Classes/CredentialManager.swift
@@ -193,18 +193,7 @@ class CredentialManager: NSObject {
 
     func login(withNonDiscoverableUsername username: Username, forRequest request: NativeLoginRequest, usingModalAuthorizationFor requestTypes: [NonDiscoverableAuthorization], display mode: Mode, reachFive: ReachFive) async throws -> AuthToken {
         let webAuthnLoginRequest = makeWebAuthnLoginRequest(for: request, reachFive: reachFive)
-        switch username {
-        case let .Unspecified(username: username):
-            if username.contains("@") {
-                webAuthnLoginRequest.email = username
-            } else {
-                webAuthnLoginRequest.phoneNumber = username
-            }
-        case let .Email(email: email):
-            webAuthnLoginRequest.email = email
-        case let .PhoneNumber(phoneNumber: phoneNumber):
-            webAuthnLoginRequest.phoneNumber = phoneNumber
-        }
+        (webAuthnLoginRequest.email, webAuthnLoginRequest.phoneNumber) = username.identifiers
 
         let built = try await buildAuthorizationRequests(
             webAuthnLoginRequest,
@@ -415,15 +404,7 @@ extension CredentialManager {
 
         if let passwordCredential = authorization.credential as? ASPasswordCredential {
             // a password was selected to sign in
-            let email: String?
-            let phoneNumber: String?
-            if passwordCredential.user.contains("@") {
-                email = passwordCredential.user
-                phoneNumber = nil
-            } else {
-                email = nil
-                phoneNumber = passwordCredential.user
-            }
+            let (email, phoneNumber) = Username.Unspecified(passwordCredential.user).identifiers
 
             let resp = try await reachFiveApi.loginWithPassword(loginRequest: LoginRequest(
                 email: email,

--- a/Sources/Core/Classes/CredentialManager.swift
+++ b/Sources/Core/Classes/CredentialManager.swift
@@ -1,38 +1,38 @@
-import Foundation
 import AuthenticationServices
+import Foundation
 
-// Les deux protocoles d'ASAuthorizationController (delegate et presentationContextProvider) sont annotés
-// NS_SWIFT_UI_ACTOR : leurs callbacks arrivent donc sur le main actor, et l'isolation @MainActor de la
-// classe protège l'état mutable partagé entre les points d'entrée async et ces callbacks.
+/// Les deux protocoles d'ASAuthorizationController (delegate et presentationContextProvider) sont annotés
+/// NS_SWIFT_UI_ACTOR : leurs callbacks arrivent donc sur le main actor, et l'isolation @MainActor de la
+/// classe protège l'état mutable partagé entre les points d'entrée async et ces callbacks.
 @MainActor
 class CredentialManager: NSObject {
     // MARK: - Contexte de requête
 
-    // Les requêtes peuvent se chevaucher : une nouvelle requête annule celles en cours, mais le callback
-    // système d'une requête annulée peut encore arriver après. Tout l'état d'une requête vit donc dans un
-    // RequestContext indexé par son controller : chaque callback retrouve le contexte de sa requête, et
-    // une requête ne peut pas écraser l'état d'une autre.
+    /// Les requêtes peuvent se chevaucher : une nouvelle requête annule celles en cours, mais le callback
+    /// système d'une requête annulée peut encore arriver après. Tout l'état d'une requête vit donc dans un
+    /// RequestContext indexé par son controller : chaque callback retrouve le contexte de sa requête, et
+    /// une requête ne peut pas écraser l'état d'une autre.
     private struct RequestContext {
-        // retenu : maintient la requête système en vie jusqu'à sa complétion
+        /// retenu : maintient la requête système en vie jusqu'à sa complétion
         let controller: ASAuthorizationController
-        // anchor pour le presentationContextProvider
+        /// anchor pour le presentationContextProvider
         let anchor: ASPresentationAnchor
-        // continuation de l'appelant, reprise exactement une fois : toute reprise passe par le retrait
-        // du contexte du dictionnaire, et seul le retrait qui réussit reprend la continuation
+        /// continuation de l'appelant, reprise exactement une fois : toute reprise passe par le retrait
+        /// du contexte du dictionnaire, et seul le retrait qui réussit reprend la continuation
         let continuation: CheckedContinuation<ASAuthorization, Error>
     }
 
-    // Données d'un Sign In With Apple, à conserver entre la construction de la requête et sa complétion.
+    /// Données d'un Sign In With Apple, à conserver entre la construction de la requête et sa complétion.
     struct SignInWithApple {
         let nonce: Pkce
         let provider: ConfiguredAppleProvider
     }
 
-    // les requêtes en cours, indexées par leur controller
+    /// les requêtes en cours, indexées par leur controller
     private var contexts: [ObjectIdentifier: RequestContext] = [:]
 
-    // nonisolated : appelé depuis l'init synchrone de ReachFive, hors du main actor
-    nonisolated override init() {}
+    /// nonisolated : appelé depuis l'init synchrone de ReachFive, hors du main actor
+    override nonisolated init() {}
 
     // MARK: - Cycle de vie des requêtes
 
@@ -121,6 +121,7 @@ class CredentialManager: NSObject {
     }
 
     // MARK: - Signup
+
     @available(iOS 16.0, *)
     func signUp(withRequest request: SignupOptions, anchor: ASPresentationAnchor, originR5: String? = nil, reachFive: ReachFive) async throws -> AuthToken {
         let options = try await reachFive.reachFiveApi.createWebAuthnSignupOptions(webAuthnSignupOptions: request)
@@ -141,6 +142,7 @@ class CredentialManager: NSObject {
     }
 
     // MARK: - Register
+
     @available(iOS 16.0, *)
     func registerNewPasskey(withRequest request: NewPasskeyRequest, authToken: AuthToken, reachFive: ReachFive) async throws {
         let options = try await reachFive.reachFiveApi.createWebAuthnRegistrationOptions(authToken: authToken, registrationRequest: RegistrationRequest(origin: request.originWebAuthn!, friendlyName: request.friendlyName))
@@ -155,6 +157,7 @@ class CredentialManager: NSObject {
     }
 
     // MARK: - Reset
+
     @available(iOS 16.0, *)
     func resetPasskeys(withRequest request: ResetPasskeyRequest, reachFive: ReachFive) async throws {
         let resetOptions = ResetOptions(email: request.email, phoneNumber: request.phoneNumber, verificationCode: request.verificationCode, friendlyName: request.friendlyName, origin: request.originWebAuthn!, clientId: reachFive.sdkConfig.clientId)
@@ -171,6 +174,7 @@ class CredentialManager: NSObject {
     }
 
     // MARK: - Auto-fill
+
     @available(macCatalyst, unavailable)
     @available(iOS 16.0, *)
     func beginAutoFillAssistedPasskeySignIn(request: NativeLoginRequest, reachFive: ReachFive) async throws -> AuthToken {
@@ -186,19 +190,19 @@ class CredentialManager: NSObject {
     }
 
     // MARK: - Modal
+
     func login(withNonDiscoverableUsername username: Username, forRequest request: NativeLoginRequest, usingModalAuthorizationFor requestTypes: [NonDiscoverableAuthorization], display mode: Mode, reachFive: ReachFive) async throws -> AuthToken {
         let webAuthnLoginRequest = makeWebAuthnLoginRequest(for: request, reachFive: reachFive)
         switch username {
-
-        case .Unspecified(username: let username):
+        case let .Unspecified(username: username):
             if username.contains("@") {
                 webAuthnLoginRequest.email = username
             } else {
                 webAuthnLoginRequest.phoneNumber = username
             }
-        case .Email(email: let email):
+        case let .Email(email: email):
             webAuthnLoginRequest.email = email
-        case .PhoneNumber(phoneNumber: let phoneNumber):
+        case let .PhoneNumber(phoneNumber: phoneNumber):
             webAuthnLoginRequest.phoneNumber = phoneNumber
         }
 
@@ -231,10 +235,10 @@ class CredentialManager: NSObject {
         return try await completeModalLogin(authorization, scopes: request.scopes, siwa: built.siwa, reachFive: reachFive, originR5: request.origin)
     }
 
-    // Internal pour être testable
+    /// Internal pour être testable
     struct BuiltRequests {
         let requests: [ASAuthorizationRequest]
-        // renseigné si une requête Sign In With Apple fait partie du lot
+        /// renseigné si une requête Sign In With Apple fait partie du lot
         let siwa: SignInWithApple?
     }
 
@@ -264,10 +268,10 @@ class CredentialManager: NSObject {
                 let appleIDRequest = ASAuthorizationAppleIDProvider().createRequest()
                 var appleScopes: [ASAuthorization.Scope] = []
                 if let scope = appleProvider?.providerConfig.scope {
-                    if scope.contains(where: { s in s == "email"}) {
+                    if scope.contains(where: { s in s == "email" }) {
                         appleScopes.append(.email)
                     }
-                    if scope.contains(where: { s in s == "name"}) {
+                    if scope.contains(where: { s in s == "name" }) {
                         appleScopes.append(.fullName)
                     }
                 }
@@ -284,7 +288,7 @@ class CredentialManager: NSObject {
                 do {
                     // Allow the user to use a saved passkey, if they have one.
                     let authOptions = try await fetchAuthenticationOptions(reachFive, webAuthnLoginRequest)
-                    requests.append(try makePasskeyAssertionRequest(authOptions, restrictedToAllowedCredentials: restrictToAllowedCredentials))
+                    try requests.append(makePasskeyAssertionRequest(authOptions, restrictedToAllowedCredentials: restrictToAllowedCredentials))
                 } catch let error where requestTypes.count > 1 {
                     // if there are other types of requests, do not block auth if only passkey fails. Just eat the error
                     Logger.shared.log("Passkey request error ignored in multi-type authorization: \(error)")
@@ -315,6 +319,7 @@ class CredentialManager: NSObject {
 }
 
 // MARK: - ASAuthorizationControllerPresentationContextProviding
+
 extension CredentialManager: ASAuthorizationControllerPresentationContextProviding {
     func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
         guard let anchor = contexts[ObjectIdentifier(controller)]?.anchor else {
@@ -329,8 +334,8 @@ extension CredentialManager: ASAuthorizationControllerPresentationContextProvidi
 }
 
 // MARK: - ASAuthorizationControllerDelegate
-extension CredentialManager: ASAuthorizationControllerDelegate {
 
+extension CredentialManager: ASAuthorizationControllerDelegate {
     func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
         takeContext(for: controller)?.continuation.resume(returning: authorization)
     }
@@ -339,14 +344,14 @@ extension CredentialManager: ASAuthorizationControllerDelegate {
         takeContext(for: controller)?.continuation.resume(throwing: Self.adapt(error))
     }
 
-    // Retire le contexte à l'entrée du callback : garantit qu'une continuation est résolue exactement une
-    // fois (un second callback pour le même controller ne trouve plus rien), et qu'une annulation
-    // ultérieure ne peut plus toucher une requête déjà complétée.
+    /// Retire le contexte à l'entrée du callback : garantit qu'une continuation est résolue exactement une
+    /// fois (un second callback pour le même controller ne trouve plus rien), et qu'une annulation
+    /// ultérieure ne peut plus toucher une requête déjà complétée.
     private func takeContext(for controller: ASAuthorizationController) -> RequestContext? {
         contexts.removeValue(forKey: ObjectIdentifier(controller))
     }
 
-    // Fonction pure, extraite pour être testable unitairement
+    /// Fonction pure, extraite pour être testable unitairement
     nonisolated static func adapt(_ error: Error) -> ReachFiveError {
         if let authorizationError = error as? ASAuthorizationError {
             if authorizationError.code == .canceled {
@@ -362,6 +367,7 @@ extension CredentialManager: ASAuthorizationControllerDelegate {
 }
 
 // MARK: - exploitation des credentials reçus
+
 extension CredentialManager {
     /// Extrait le credential d'enregistrement de passkey d'une autorisation (signup / add / reset)
     /// et le convertit dans notre format. Lève une erreur technique si l'autorisation n'en contient pas.
@@ -455,7 +461,7 @@ extension CredentialManager {
                 "nonce": siwa.nonce.codeVerifier,
                 "origin": originR5,
                 "given_name": appleIDCredential.fullName?.givenName,
-                "family_name": appleIDCredential.fullName?.familyName
+                "family_name": appleIDCredential.fullName?.familyName,
             ])
             let token = try await reachFive.authWithCode(code: code, pkce: pkce)
             return .AchievedLogin(authToken: token)
@@ -468,6 +474,7 @@ extension CredentialManager {
 }
 
 // MARK: - construction des requêtes
+
 extension CredentialManager {
     /// Le socle commun aux trois flux de connexion WebAuthn.
     private func makeWebAuthnLoginRequest(for request: NativeLoginRequest, reachFive: ReachFive) -> WebAuthnLoginRequest {

--- a/Sources/Core/Classes/CredentialManager.swift
+++ b/Sources/Core/Classes/CredentialManager.swift
@@ -10,7 +10,8 @@ public class CredentialManager: NSObject {
     // Les requêtes peuvent s'entrelacer (une requête modale peut démarrer pendant une requête auto-fill).
     // Tout l'état d'une requête vit donc dans un RequestContext indexé par son controller : chaque callback
     // du delegate retrouve le contexte de SA requête, et une requête ne peut pas écraser l'état d'une autre.
-    private struct RequestContext {
+    // Internal (et non private) pour que les tests puissent piloter perform(_:requests:...).
+    struct RequestContext {
         enum Pending {
             // signup, auto-fill, login non-discoverable
             case authToken(CheckedContinuation<AuthToken, Error>)
@@ -18,6 +19,14 @@ public class CredentialManager: NSObject {
             case loginFlow(CheckedContinuation<LoginFlow, Error>)
             // enregistrement d'une nouvelle clé (add/reset)
             case registration(CheckedContinuation<Void, Error>)
+        }
+
+        // Données propres à un flux : une création de passkey (signup/add/reset) et un Sign In With Apple
+        // ne coexistent jamais dans une même requête.
+        enum Extra {
+            case passkeyCreation(PasskeyCreationType)
+            case signInWithApple(nonce: Pkce, provider: ConfiguredAppleProvider)
+            case none
         }
 
         // retenu : maintient la requête système en vie jusqu'à sa complétion
@@ -34,11 +43,8 @@ public class CredentialManager: NSObject {
         var scope: String? { scopes?.joined(separator: " ") }
         // origin optionnel pour les événements utilisateur
         let originR5: String?
-        // données pour signup/register
-        let passkeyCreationType: PasskeyCreationType?
-        // le nonce pour Sign In With Apple
-        let nonce: Pkce?
-        let appleProvider: ConfiguredAppleProvider?
+        // données propres au flux (création de passkey ou Sign In With Apple)
+        let extra: Extra
 
         func fail(with error: Error) {
             switch pending {
@@ -49,7 +55,7 @@ public class CredentialManager: NSObject {
         }
     }
 
-    // les requêtes en vol, indexées par leur controller
+    // les requêtes en cours, indexées par leur controller
     private var contexts: [ObjectIdentifier: RequestContext] = [:]
 
     enum PasskeyCreationType {
@@ -63,7 +69,7 @@ public class CredentialManager: NSObject {
 
     // MARK: - Cycle de vie des requêtes
 
-    /// Annule les requêtes en vol, principalement pour annuler une requête auto-fill avant de démarrer
+    /// Annule les requêtes en cours, principalement pour annuler une requête auto-fill avant de démarrer
     /// une requête modale (sinon cette dernière échouerait). Chaque annulation déclenche
     /// `didCompleteWithError(.canceled)` pour son controller, ce qui résout sa continuation en `.AuthCanceled`.
     private func cancelInFlightRequests() {
@@ -75,38 +81,26 @@ public class CredentialManager: NSObject {
 
     /// Crée le controller, enregistre le contexte de la requête PUIS lance la requête système via `perform` :
     /// comme tout se passe sur le main actor, la continuation est en place avant que le delegate puisse tirer.
-    private func start(_ pending: RequestContext.Pending,
-                       requests: [ASAuthorizationRequest],
-                       reachFive: ReachFive,
-                       anchor: ASPresentationAnchor,
-                       scopes: [String]?,
-                       originR5: String?,
-                       passkeyCreationType: PasskeyCreationType? = nil,
-                       nonce: Pkce? = nil,
-                       appleProvider: ConfiguredAppleProvider? = nil,
-                       perform: (ASAuthorizationController) -> Void) {
-        let controller = ASAuthorizationController(authorizationRequests: requests)
-        controller.delegate = self
-        controller.presentationContextProvider = self
-        contexts[ObjectIdentifier(controller)] = RequestContext(controller: controller, reachFive: reachFive, pending: pending, anchor: anchor, scopes: scopes, originR5: originR5, passkeyCreationType: passkeyCreationType, nonce: nonce, appleProvider: appleProvider)
-        perform(controller)
-    }
-
-    private func awaitAuthToken(requests: [ASAuthorizationRequest], reachFive: ReachFive, anchor: ASPresentationAnchor, scopes: [String]?, originR5: String?, passkeyCreationType: PasskeyCreationType? = nil, perform: (ASAuthorizationController) -> Void) async throws -> AuthToken {
-        try await withCheckedThrowingContinuation { continuation in
-            start(.authToken(continuation), requests: requests, reachFive: reachFive, anchor: anchor, scopes: scopes, originR5: originR5, passkeyCreationType: passkeyCreationType, perform: perform)
-        }
-    }
-
-    private func awaitLoginFlow(requests: [ASAuthorizationRequest], reachFive: ReachFive, anchor: ASPresentationAnchor, scopes: [String]?, originR5: String?, nonce: Pkce? = nil, appleProvider: ConfiguredAppleProvider? = nil, perform: (ASAuthorizationController) -> Void) async throws -> LoginFlow {
-        try await withCheckedThrowingContinuation { continuation in
-            start(.loginFlow(continuation), requests: requests, reachFive: reachFive, anchor: anchor, scopes: scopes, originR5: originR5, nonce: nonce, appleProvider: appleProvider, perform: perform)
-        }
-    }
-
-    private func awaitRegistration(requests: [ASAuthorizationRequest], reachFive: ReachFive, anchor: ASPresentationAnchor, originR5: String?, passkeyCreationType: PasskeyCreationType, perform: (ASAuthorizationController) -> Void) async throws {
-        try await withCheckedThrowingContinuation { continuation in
-            start(.registration(continuation), requests: requests, reachFive: reachFive, anchor: anchor, scopes: nil, originR5: originR5, passkeyCreationType: passkeyCreationType, perform: perform)
+    ///
+    /// Le case de `Pending` à construire est passé comme fonction (`RequestContext.Pending.authToken`, etc.),
+    /// ce qui fixe le type de retour `T` de la requête. Internal pour être testable : un test pilote la méthode
+    /// avec un `perform` inerte puis simule les callbacks du delegate.
+    func perform<T>(
+        _ makePending: (CheckedContinuation<T, Error>) -> RequestContext.Pending,
+        requests: [ASAuthorizationRequest],
+        reachFive: ReachFive,
+        anchor: ASPresentationAnchor,
+        scopes: [String]?,
+        originR5: String?,
+        extra: RequestContext.Extra = .none,
+        using perform: (ASAuthorizationController) -> Void
+    ) async throws -> T {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<T, Error>) in
+            let controller = ASAuthorizationController(authorizationRequests: requests)
+            controller.delegate = self
+            controller.presentationContextProvider = self
+            contexts[ObjectIdentifier(controller)] = RequestContext(controller: controller, reachFive: reachFive, pending: makePending(continuation), anchor: anchor, scopes: scopes, originR5: originR5, extra: extra)
+            perform(controller)
         }
     }
 
@@ -122,7 +116,7 @@ public class CredentialManager: NSObject {
         // sans dupliquer la valeur en paramètre, un token de scope OAuth ne pouvant pas contenir d'espace.
         let scopes = request.scope.components(separatedBy: " ")
 
-        return try await awaitAuthToken(requests: [registrationRequest], reachFive: reachFive, anchor: anchor, scopes: scopes, originR5: originR5, passkeyCreationType: .Signup(signupOptions: options)) {
+        return try await perform(RequestContext.Pending.authToken, requests: [registrationRequest], reachFive: reachFive, anchor: anchor, scopes: scopes, originR5: originR5, extra: .passkeyCreation(.Signup(signupOptions: options))) {
             $0.performRequests()
         }
     }
@@ -137,7 +131,7 @@ public class CredentialManager: NSObject {
         let options = try await reachFive.reachFiveApi.createWebAuthnRegistrationOptions(authToken: authToken, registrationRequest: RegistrationRequest(origin: request.originWebAuthn!, friendlyName: request.friendlyName))
         let registrationRequest = try makeCredentialRegistrationRequest(from: options, friendlyName: request.friendlyName)
 
-        try await awaitRegistration(requests: [registrationRequest], reachFive: reachFive, anchor: request.anchor, originR5: request.origin, passkeyCreationType: .AddPasskey(authToken: authToken)) {
+        try await perform(RequestContext.Pending.registration, requests: [registrationRequest], reachFive: reachFive, anchor: request.anchor, scopes: nil, originR5: request.origin, extra: .passkeyCreation(.AddPasskey(authToken: authToken))) {
             $0.performRequests()
         }
     }
@@ -153,7 +147,7 @@ public class CredentialManager: NSObject {
         let options = try await reachFive.reachFiveApi.createWebAuthnResetOptions(resetOptions: resetOptions)
         let registrationRequest = try makeCredentialRegistrationRequest(from: options, friendlyName: request.friendlyName)
 
-        try await awaitRegistration(requests: [registrationRequest], reachFive: reachFive, anchor: request.anchor, originR5: request.origin, passkeyCreationType: .ResetPasskey(resetOptions: resetOptions)) {
+        try await perform(RequestContext.Pending.registration, requests: [registrationRequest], reachFive: reachFive, anchor: request.anchor, scopes: nil, originR5: request.origin, extra: .passkeyCreation(.ResetPasskey(resetOptions: resetOptions))) {
             $0.performRequests()
         }
     }
@@ -176,7 +170,7 @@ public class CredentialManager: NSObject {
         }
 
         // AutoFill-assisted requests only support ASAuthorizationPlatformPublicKeyCredentialAssertionRequest.
-        return try await awaitAuthToken(requests: [authorizationRequest], reachFive: reachFive, anchor: request.anchor, scopes: request.scopes, originR5: request.origin) {
+        return try await perform(RequestContext.Pending.authToken, requests: [authorizationRequest], reachFive: reachFive, anchor: request.anchor, scopes: request.scopes, originR5: request.origin) {
             $0.performAutoFillAssistedRequests()
         }
     }
@@ -217,7 +211,7 @@ public class CredentialManager: NSObject {
             return assertionRequest
         }
 
-        return try await awaitAuthToken(requests: built.requests, reachFive: reachFive, anchor: request.anchor, scopes: request.scopes, originR5: request.origin) {
+        return try await perform(RequestContext.Pending.authToken, requests: built.requests, reachFive: reachFive, anchor: request.anchor, scopes: request.scopes, originR5: request.origin, extra: built.extra) {
             performRequests(on: $0, mode: mode)
         }
     }
@@ -234,23 +228,24 @@ public class CredentialManager: NSObject {
             return try self.createCredentialAssertionRequest(authenticationOptions)
         }
 
-        return try await awaitLoginFlow(requests: built.requests, reachFive: reachFive, anchor: request.anchor, scopes: request.scopes, originR5: request.origin, nonce: built.nonce, appleProvider: built.appleProvider) {
+        return try await perform(RequestContext.Pending.loginFlow, requests: built.requests, reachFive: reachFive, anchor: request.anchor, scopes: request.scopes, originR5: request.origin, extra: built.extra) {
             performRequests(on: $0, mode: mode)
         }
     }
 
-    private struct BuiltRequests {
+    // Internal pour être testable
+    struct BuiltRequests {
         let requests: [ASAuthorizationRequest]
-        // renseignés uniquement si une requête Sign In With Apple fait partie du lot
-        let nonce: Pkce?
-        let appleProvider: ConfiguredAppleProvider?
+        // .signInWithApple si une requête Sign In With Apple fait partie du lot, sinon .none
+        let extra: RequestContext.Extra
     }
 
     /// Construit les `ASAuthorizationRequest` pour les types demandés, sans toucher à l'état de la classe.
-    private func buildAuthorizationRequests(_ webAuthnLoginRequest: WebAuthnLoginRequest, reachFive: ReachFive, authorizing requestTypes: [ModalAuthorization], appleProvider: ConfiguredAppleProvider? = nil, makeAuthorization: (AuthenticationOptions) throws -> ASAuthorizationRequest) async throws -> BuiltRequests {
+    /// `fetchAuthenticationOptions` fait l'appel réseau par défaut ; un test peut le substituer pour
+    /// construire les requêtes sans réseau.
+    func buildAuthorizationRequests(_ webAuthnLoginRequest: WebAuthnLoginRequest, reachFive: ReachFive,authorizing requestTypes: [ModalAuthorization], appleProvider: ConfiguredAppleProvider? = nil, fetchAuthenticationOptions: (ReachFive, WebAuthnLoginRequest) async throws -> AuthenticationOptions = { try await $0.reachFiveApi.createWebAuthnAuthenticationOptions(webAuthnLoginRequest: $1) }, makeAuthorization: (AuthenticationOptions) throws -> ASAuthorizationRequest) async throws -> BuiltRequests {
         var requests: [ASAuthorizationRequest] = []
-        var nonce: Pkce?
-        var usedAppleProvider: ConfiguredAppleProvider?
+        var extra: RequestContext.Extra = .none
 
         for type in requestTypes {
             switch type {
@@ -274,15 +269,16 @@ public class CredentialManager: NSObject {
                 appleIDRequest.requestedScopes = appleScopes
                 let siwaNonce = Pkce.generate()
                 appleIDRequest.nonce = siwaNonce.codeChallenge
-                nonce = siwaNonce
-                usedAppleProvider = appleProvider
+                if let appleProvider {
+                    extra = .signInWithApple(nonce: siwaNonce, provider: appleProvider)
+                }
 
                 requests.append(appleIDRequest)
 
             case .Passkey:
                 do {
                     // Allow the user to use a saved passkey, if they have one.
-                    let authOptions = try await reachFive.reachFiveApi.createWebAuthnAuthenticationOptions(webAuthnLoginRequest: webAuthnLoginRequest)
+                    let authOptions = try await fetchAuthenticationOptions(reachFive, webAuthnLoginRequest)
                     let passkeyRequest = try makeAuthorization(authOptions)
                     requests.append(passkeyRequest)
                 } catch let error where requestTypes.count > 1 {
@@ -292,7 +288,7 @@ public class CredentialManager: NSObject {
             }
         }
 
-        return BuiltRequests(requests: requests, nonce: nonce, appleProvider: usedAppleProvider)
+        return BuiltRequests(requests: requests, extra: extra)
     }
 
     private func performRequests(on controller: ASAuthorizationController, mode: Mode) {
@@ -402,7 +398,7 @@ extension CredentialManager: ASAuthorizationControllerDelegate {
             guard case let .loginFlow(continuation) = context.pending else {
                 throw ReachFiveError.TechnicalError(reason: "didCompleteWithAuthorization: unexpected Sign In With Apple credential for this request")
             }
-            guard let nonce = context.nonce, let scope = context.scope, let appleProvider = context.appleProvider else {
+            guard case let .signInWithApple(nonce, appleProvider) = context.extra, let scope = context.scope else {
                 throw ReachFiveError.TechnicalError(reason: "didCompleteWithAuthorization: no scope, no nonce, no apple provider")
             }
 
@@ -443,8 +439,8 @@ extension CredentialManager: ASAuthorizationControllerDelegate {
             let id = credentialRegistration.credentialID.toBase64Url()
             let registrationPublicKeyCredential = RegistrationPublicKeyCredential(id: id, rawId: id, type: "public-key", response: r5AuthenticatorAttestationResponse)
 
-            guard let passkeyCreationType = context.passkeyCreationType else {
-                throw ReachFiveError.TechnicalError(reason: "didCompleteWithAuthorization: no signupOptions")
+            guard case let .passkeyCreation(passkeyCreationType) = context.extra else {
+                throw ReachFiveError.TechnicalError(reason: "didCompleteWithAuthorization: no passkey creation data")
             }
 
             switch passkeyCreationType {
@@ -459,13 +455,13 @@ extension CredentialManager: ASAuthorizationControllerDelegate {
                 guard case let .authToken(continuation) = context.pending else {
                     throw ReachFiveError.TechnicalError(reason: "didCompleteWithAuthorization: unexpected passkey registration for this request")
                 }
-                guard context.scopes != nil else {
+                guard let scopes = context.scopes else {
                     throw ReachFiveError.TechnicalError(reason: "didCompleteWithAuthorization: no scope")
                 }
 
                 let webauthnSignupCredential = WebauthnSignupCredential(webauthnId: signupOptions.options.publicKey.user.id, publicKeyCredential: registrationPublicKeyCredential)
                 let authenticationToken = try await reachFiveApi.signupWithWebAuthn(webauthnSignupCredential: webauthnSignupCredential, originR5: context.originR5)
-                let authToken = try await context.reachFive.loginCallback(tkn: authenticationToken.tkn, scopes: context.scopes, origin: context.originR5)
+                let authToken = try await context.reachFive.loginCallback(tkn: authenticationToken.tkn, scopes: scopes, origin: context.originR5)
                 continuation.resume(returning: authToken)
 
             case let .ResetPasskey(resetOptions):
@@ -479,7 +475,7 @@ extension CredentialManager: ASAuthorizationControllerDelegate {
         } else if #available(iOS 16.0, *), let credentialAssertion = authorization.credential as? ASAuthorizationPlatformPublicKeyCredentialAssertion {
             // A passkey was selected to sign in
 
-            guard context.scopes != nil else {
+            guard let scopes = context.scopes else {
                 throw ReachFiveError.TechnicalError(reason: "didCompleteWithAuthorization: no scope")
             }
 
@@ -492,7 +488,7 @@ extension CredentialManager: ASAuthorizationControllerDelegate {
             let response = R5AuthenticatorAssertionResponse(authenticatorData: authenticatorData, clientDataJSON: clientDataJSON, signature: signature, userHandle: userID)
 
             let authenticationToken = try await reachFiveApi.authenticateWithWebAuthn(authenticationPublicKeyCredential: AuthenticationPublicKeyCredential(id: id, rawId: id, type: "public-key", response: response))
-            let authToken = try await context.reachFive.loginCallback(tkn: authenticationToken.tkn, scopes: context.scopes, origin: context.originR5)
+            let authToken = try await context.reachFive.loginCallback(tkn: authenticationToken.tkn, scopes: scopes, origin: context.originR5)
 
             switch context.pending {
             case let .authToken(continuation):

--- a/Sources/Core/Classes/ReachFive.swift
+++ b/Sources/Core/Classes/ReachFive.swift
@@ -41,7 +41,7 @@ public class ReachFive: NSObject {
         self.providersCreators = providersCreators
         self.storage = storage ?? UserDefaultsStorage()
         self.reachFiveApi = ReachFiveApi(sdkConfig: sdkConfig)
-        self.credentialManager = CredentialManager(reachFiveApi: reachFiveApi, storage: self.storage)
+        self.credentialManager = CredentialManager(reachFiveApi: reachFiveApi)
         self.webAuthSession = WebAuthenticationSession(baseScheme: sdkConfig.customScheme, sdkRedirectUri: sdkConfig.redirectUri)
 
         if let sdkInternalConfig {

--- a/Sources/Core/Classes/ReachFive.swift
+++ b/Sources/Core/Classes/ReachFive.swift
@@ -16,7 +16,6 @@ public typealias EmailVerificationCallback = (_ result: Result<(), ReachFiveErro
 //TODO:
 // Tester One-tap account upgrade : https://developer.apple.com/videos/play/wwdc2020/10666/
 // Tester le MFA avec "Securing Logins with iCloud Keychain Verification Codes" https://developer.apple.com/documentation/authenticationservices/securing_logins_with_icloud_keychain_verification_codes
-// Voir si je peux améliorer l'init/rétention du CredentialManager
 /// ReachFive identity SDK
 public class ReachFive: NSObject {
     var passwordlessCallback: PasswordlessCallback? = nil

--- a/Sources/Core/Classes/ReachFive.swift
+++ b/Sources/Core/Classes/ReachFive.swift
@@ -41,7 +41,7 @@ public class ReachFive: NSObject {
         self.providersCreators = providersCreators
         self.storage = storage ?? UserDefaultsStorage()
         self.reachFiveApi = ReachFiveApi(sdkConfig: sdkConfig)
-        self.credentialManager = CredentialManager(reachFiveApi: reachFiveApi)
+        self.credentialManager = CredentialManager()
         self.webAuthSession = WebAuthenticationSession(baseScheme: sdkConfig.customScheme, sdkRedirectUri: sdkConfig.redirectUri)
 
         if let sdkInternalConfig {

--- a/Sources/Core/Classes/ReachFiveLogin.swift
+++ b/Sources/Core/Classes/ReachFiveLogin.swift
@@ -1,8 +1,7 @@
 import Foundation
 
-public extension ReachFive {
-
-    func logout(webSessionLogout request: WebSessionLogoutRequest? = nil, revoke token: AuthToken? = nil) async throws {
+extension ReachFive {
+    public func logout(webSessionLogout request: WebSessionLogoutRequest? = nil, revoke token: AuthToken? = nil) async throws {
         // Don't stop for errors along the way
 
         for provider in providers {
@@ -15,7 +14,7 @@ public extension ReachFive {
                 "origin": request.origin,
             ]
 
-            let _ = try? await webAuthSession.start(
+            _ = try? await webAuthSession.start(
                 url: reachFiveApi.buildLogoutURL(queryParams: options),
                 mode: .customScheme,
                 // A logout callback carries no `code` and is intercepted by the sheet, so the out-of-band
@@ -23,25 +22,26 @@ public extension ReachFive {
                 // and be swallowed (the logout's continuation ignores the URL).
                 expectsAuthorizationCode: false,
                 presentationContextProvider: request.presentationContextProvider,
-                prefersEphemeralWebBrowserSession: false)
+                prefersEphemeralWebBrowserSession: false
+            )
         }
 
         if let token {
             try? await revokeToken(authToken: token)
         }
 
-        try await self.reachFiveApi.logout()
+        try await reachFiveApi.logout()
     }
 
-    func loginCallback(tkn: String, scopes: [String]?, origin: String? = nil) async throws -> AuthToken {
+    public func loginCallback(tkn: String, scopes: [String]?, origin: String? = nil) async throws -> AuthToken {
         let pkce = Pkce.generate()
         let scope = (scopes ?? scope).joined(separator: " ")
 
         let code = try await reachFiveApi.loginCallback(loginCallback: LoginCallback(sdkConfig: sdkConfig, scope: scope, pkce: pkce, tkn: tkn, origin: origin))
-        return try await self.authWithCode(code: code, pkce: pkce)
+        return try await authWithCode(code: code, pkce: pkce)
     }
 
-    func buildAuthorizeURL(pkce: Pkce, state: String? = nil, nonce: String? = nil, scope: [String]? = nil, origin: String? = nil, provider: String? = nil, redirectUri: URL? = nil, loginUrlFragment: [String: String]? = nil) -> URL {
+    public func buildAuthorizeURL(pkce: Pkce, state: String? = nil, nonce: String? = nil, scope: [String]? = nil, origin: String? = nil, provider: String? = nil, redirectUri: URL? = nil, loginUrlFragment: [String: String]? = nil) -> URL {
         let scope = (scope ?? self.scope).joined(separator: " ")
         let options = [
             "provider": provider,
@@ -76,12 +76,13 @@ public extension ReachFive {
         return components.url ?? url
     }
 
-    func authWithCode(code: String, pkce: Pkce, redirectUri: URL? = nil) async throws -> AuthToken {
+    public func authWithCode(code: String, pkce: Pkce, redirectUri: URL? = nil) async throws -> AuthToken {
         let authCodeRequest = AuthCodeRequest(
             clientId: sdkConfig.clientId,
             code: code,
             redirectUri: redirectUri ?? sdkConfig.redirectUri,
-            pkce: pkce)
+            pkce: pkce
+        )
         let token = try await reachFiveApi.authWithCode(authCodeRequest: authCodeRequest)
         return try AuthToken.fromOpenIdTokenResponse(token)
     }

--- a/Sources/Core/Classes/ReachFiveNative.swift
+++ b/Sources/Core/Classes/ReachFiveNative.swift
@@ -17,15 +17,16 @@ public extension ReachFive {
     @available(iOS 16.0, *)
     func signup(withRequest request: PasskeySignupRequest) async throws -> AuthToken {
         let domain = sdkConfig.domain
+        let scopes = request.scopes ?? scope
         let signupOptions = SignupOptions(
             origin: request.originWebAuthn ?? "https://\(domain)",
             friendlyName: request.friendlyName,
             profile: request.passkeyProfile,
             clientId: sdkConfig.clientId,
-            scope: request.scopes ?? scope
+            scope: scopes
         )
 
-        return try await credentialManager.signUp(withRequest: signupOptions, anchor: request.anchor, originR5: request.origin)
+        return try await credentialManager.signUp(withRequest: signupOptions, scopes: scopes, anchor: request.anchor, originR5: request.origin, reachFive: self)
     }
 
     /// Starts an auto-fill assisted passkey login request.
@@ -37,7 +38,7 @@ public extension ReachFive {
     @available(macCatalyst, unavailable)
     @available(iOS 16.0, *)
     func beginAutoFillAssistedPasskeyLogin(withRequest request: NativeLoginRequest) async throws -> AuthToken {
-        try await credentialManager.beginAutoFillAssistedPasskeySignIn(request: adapt(request))
+        try await credentialManager.beginAutoFillAssistedPasskeySignIn(request: adapt(request), reachFive: self)
     }
 
     /// Signs in the user using credentials stored in the keychain, letting the system display all credentials available to choose from in a modal sheet.
@@ -48,7 +49,7 @@ public extension ReachFive {
     /// - Returns: an AuthToken when the user was successfully logged in, ReachFiveError.AuthCanceled when the user cancelled the modal sheet or when there was no credentials available, or other kinds of ReachFiveError
     func login(withRequest request: NativeLoginRequest, usingModalAuthorizationFor requestTypes: [ModalAuthorization], display mode: Mode) async throws -> LoginFlow {
         let appleProvider = providers.first { $0.name == AppleProvider.NAME } as? ConfiguredAppleProvider
-        return try await credentialManager.login(withRequest: adapt(request), usingModalAuthorizationFor: requestTypes, display: mode, appleProvider: appleProvider)
+        return try await credentialManager.login(withRequest: adapt(request), usingModalAuthorizationFor: requestTypes, display: mode, appleProvider: appleProvider, reachFive: self)
     }
 
     /// Signs in the user using credentials stored in the keychain, letting the system display the credentials corresponding to the given username in a modal sheet.
@@ -59,7 +60,7 @@ public extension ReachFive {
     ///   - mode: choose the behavior when there are no credentials available
     /// - Returns: an AuthToken when the user was successfully logged in, ReachFiveError.AuthCanceled when the user cancelled the modal sheet or when there was no credentials available, or other kinds of ReachFiveError
     func login(withNonDiscoverableUsername username: Username, forRequest request: NativeLoginRequest, usingModalAuthorizationFor requestTypes: [NonDiscoverableAuthorization], display mode: Mode) async throws -> AuthToken {
-        try await credentialManager.login(withNonDiscoverableUsername: username, forRequest: adapt(request), usingModalAuthorizationFor: requestTypes, display: mode)
+        try await credentialManager.login(withNonDiscoverableUsername: username, forRequest: adapt(request), usingModalAuthorizationFor: requestTypes, display: mode, reachFive: self)
     }
 
     /// Registers a new passkey for an existing user which currently has none in the keychain, or replace the existing passkey by a new one
@@ -72,14 +73,14 @@ public extension ReachFive {
         let domain = sdkConfig.domain
         let originWebAuthn = request.originWebAuthn ?? "https://\(domain)"
         //TODO supprimer l'ancienne clé du server
-        return try await credentialManager.registerNewPasskey(withRequest: NewPasskeyRequest(anchor: request.anchor, friendlyName: request.friendlyName, originWebAuthn: originWebAuthn, origin: request.origin), authToken: authToken)
+        return try await credentialManager.registerNewPasskey(withRequest: NewPasskeyRequest(anchor: request.anchor, friendlyName: request.friendlyName, originWebAuthn: originWebAuthn, origin: request.origin), authToken: authToken, reachFive: self)
     }
 
     @available(iOS 16.0, *)
     func resetPasskeys(withRequest request: ResetPasskeyRequest) async throws {
         let domain = sdkConfig.domain
         let originWebAuthn = request.originWebAuthn ?? "https://\(domain)"
-        return try await credentialManager.resetPasskeys(withRequest: ResetPasskeyRequest(verificationCode: request.verificationCode, friendlyName: request.friendlyName, anchor: request.anchor, email: request.email, phoneNumber: request.phoneNumber, originWebAuthn: originWebAuthn, origin: request.origin))
+        return try await credentialManager.resetPasskeys(withRequest: ResetPasskeyRequest(verificationCode: request.verificationCode, friendlyName: request.friendlyName, anchor: request.anchor, email: request.email, phoneNumber: request.phoneNumber, originWebAuthn: originWebAuthn, origin: request.origin), reachFive: self)
     }
 
     private func adapt(_ request: NativeLoginRequest) -> NativeLoginRequest {

--- a/Sources/Core/Classes/ReachFiveNative.swift
+++ b/Sources/Core/Classes/ReachFiveNative.swift
@@ -17,16 +17,15 @@ public extension ReachFive {
     @available(iOS 16.0, *)
     func signup(withRequest request: PasskeySignupRequest) async throws -> AuthToken {
         let domain = sdkConfig.domain
-        let scopes = request.scopes ?? scope
         let signupOptions = SignupOptions(
             origin: request.originWebAuthn ?? "https://\(domain)",
             friendlyName: request.friendlyName,
             profile: request.passkeyProfile,
             clientId: sdkConfig.clientId,
-            scope: scopes
+            scope: request.scopes ?? scope
         )
 
-        return try await credentialManager.signUp(withRequest: signupOptions, scopes: scopes, anchor: request.anchor, originR5: request.origin, reachFive: self)
+        return try await credentialManager.signUp(withRequest: signupOptions, anchor: request.anchor, originR5: request.origin, reachFive: self)
     }
 
     /// Starts an auto-fill assisted passkey login request.

--- a/Sources/Core/Classes/ReachFiveNative.swift
+++ b/Sources/Core/Classes/ReachFiveNative.swift
@@ -6,8 +6,8 @@ extension ReachFive {
     // first argument indicates modality to distinguish the two primary way UI is shown to user: Modal and AutoFill
     // first argument label contains "with" instead of the method name in conformance to https://www.swift.org/documentation/api-design-guidelines/#give-prepositional-phrase-argument-label
     // non-discoverable methods also take a requestType parameter even though there is only one such type:
-//      1. to make it very clear that we are using passkeys
-//      2. to be future proof. For non-discoverable, there is already Security Keys that exist and that we could support.
+    //      1. to make it very clear that we are using passkeys
+    //      2. to be future proof. For non-discoverable, there is already Security Keys that exist and that we could support.
     // AutoFill is @available(iOS 16.0, *) because ASAuthorizationController.performAutoFillAssistedRequests() itself is.
     // The other methods control version availability with their respective Authorization enum to increase flexibility.
     // For example the non-discoverable cannot be declared @available(iOS 16.0, *)
@@ -17,15 +17,16 @@ extension ReachFive {
     @available(iOS 16.0, *)
     public func signup(withRequest request: PasskeySignupRequest) async throws -> AuthToken {
         let domain = sdkConfig.domain
+        let scopes = request.scopes ?? scope
         let signupOptions = SignupOptions(
             origin: request.originWebAuthn ?? "https://\(domain)",
             friendlyName: request.friendlyName,
             profile: request.passkeyProfile,
             clientId: sdkConfig.clientId,
-            scope: request.scopes ?? scope
+            scope: scopes
         )
 
-        return try await credentialManager.signUp(withRequest: signupOptions, anchor: request.anchor, originR5: request.origin, reachFive: self)
+        return try await credentialManager.signUp(withRequest: signupOptions, scopes: scopes, anchor: request.anchor, originR5: request.origin, reachFive: self)
     }
 
     /// Starts an auto-fill assisted passkey login request.
@@ -69,7 +70,7 @@ extension ReachFive {
     /// - Returns: A ReachFiveError, or nothing when the Registration was successfull.
     @available(iOS 16.0, *)
     public func registerNewPasskey(withRequest request: NewPasskeyRequest, authToken: AuthToken) async throws {
-        // TODO: supprimer l'ancienne clé du server
+        // TODO: delete the former key from the server
         try await credentialManager.registerNewPasskey(withRequest: request, originWebAuthn: request.originWebAuthn ?? "https://\(sdkConfig.domain)", authToken: authToken, reachFive: self)
     }
 

--- a/Sources/Core/Classes/ReachFiveNative.swift
+++ b/Sources/Core/Classes/ReachFiveNative.swift
@@ -95,6 +95,16 @@ public enum Username {
     case Unspecified(_ username: String)
     case Email(_ email: String)
     case PhoneNumber(_ phoneNumber: String)
+
+    /// The two identifier fields the server expects. `.Unspecified` is split by the only heuristic the SDK
+    /// has: an identifier containing "@" is an email, anything else is a phone number.
+    var identifiers: (email: String?, phoneNumber: String?) {
+        switch self {
+        case let .Unspecified(username): username.contains("@") ? (username, nil) : (nil, username)
+        case let .Email(email): (email, nil)
+        case let .PhoneNumber(phoneNumber): (nil, phoneNumber)
+        }
+    }
 }
 
 public enum ModalAuthorization: Equatable {

--- a/Sources/Core/Classes/ReachFiveNative.swift
+++ b/Sources/Core/Classes/ReachFiveNative.swift
@@ -37,7 +37,7 @@ extension ReachFive {
     @available(macCatalyst, unavailable)
     @available(iOS 16.0, *)
     public func beginAutoFillAssistedPasskeyLogin(withRequest request: NativeLoginRequest) async throws -> AuthToken {
-        try await credentialManager.beginAutoFillAssistedPasskeySignIn(request: adapt(request), reachFive: self)
+        try await credentialManager.beginAutoFillAssistedPasskeySignIn(request: resolve(request), reachFive: self)
     }
 
     /// Signs in the user using credentials stored in the keychain, letting the system display all credentials available to choose from in a modal sheet.
@@ -48,7 +48,7 @@ extension ReachFive {
     /// - Returns: an AuthToken when the user was successfully logged in, ReachFiveError.AuthCanceled when the user cancelled the modal sheet or when there was no credentials available, or other kinds of ReachFiveError
     public func login(withRequest request: NativeLoginRequest, usingModalAuthorizationFor requestTypes: [ModalAuthorization], display mode: Mode) async throws -> LoginFlow {
         let appleProvider = providers.first { $0.name == AppleProvider.NAME } as? ConfiguredAppleProvider
-        return try await credentialManager.login(withRequest: adapt(request), usingModalAuthorizationFor: requestTypes, display: mode, appleProvider: appleProvider, reachFive: self)
+        return try await credentialManager.login(withRequest: resolve(request), usingModalAuthorizationFor: requestTypes, display: mode, appleProvider: appleProvider, reachFive: self)
     }
 
     /// Signs in the user using credentials stored in the keychain, letting the system display the credentials corresponding to the given username in a modal sheet.
@@ -59,7 +59,7 @@ extension ReachFive {
     ///   - mode: choose the behavior when there are no credentials available
     /// - Returns: an AuthToken when the user was successfully logged in, ReachFiveError.AuthCanceled when the user cancelled the modal sheet or when there was no credentials available, or other kinds of ReachFiveError
     public func login(withNonDiscoverableUsername username: Username, forRequest request: NativeLoginRequest, usingModalAuthorizationFor requestTypes: [NonDiscoverableAuthorization], display mode: Mode) async throws -> AuthToken {
-        try await credentialManager.login(withNonDiscoverableUsername: username, forRequest: adapt(request), usingModalAuthorizationFor: requestTypes, display: mode, reachFive: self)
+        try await credentialManager.login(withNonDiscoverableUsername: username, forRequest: resolve(request), usingModalAuthorizationFor: requestTypes, display: mode, reachFive: self)
     }
 
     /// Registers a new passkey for an existing user which currently has none in the keychain, or replace the existing passkey by a new one
@@ -69,25 +69,22 @@ extension ReachFive {
     /// - Returns: A ReachFiveError, or nothing when the Registration was successfull.
     @available(iOS 16.0, *)
     public func registerNewPasskey(withRequest request: NewPasskeyRequest, authToken: AuthToken) async throws {
-        let domain = sdkConfig.domain
-        let originWebAuthn = request.originWebAuthn ?? "https://\(domain)"
         // TODO: supprimer l'ancienne clé du server
-        return try await credentialManager.registerNewPasskey(withRequest: NewPasskeyRequest(anchor: request.anchor, friendlyName: request.friendlyName, originWebAuthn: originWebAuthn, origin: request.origin), authToken: authToken, reachFive: self)
+        try await credentialManager.registerNewPasskey(withRequest: request, originWebAuthn: request.originWebAuthn ?? "https://\(sdkConfig.domain)", authToken: authToken, reachFive: self)
     }
 
     @available(iOS 16.0, *)
     public func resetPasskeys(withRequest request: ResetPasskeyRequest) async throws {
-        let domain = sdkConfig.domain
-        let originWebAuthn = request.originWebAuthn ?? "https://\(domain)"
-        return try await credentialManager.resetPasskeys(withRequest: ResetPasskeyRequest(verificationCode: request.verificationCode, friendlyName: request.friendlyName, anchor: request.anchor, email: request.email, phoneNumber: request.phoneNumber, originWebAuthn: originWebAuthn, origin: request.origin), reachFive: self)
+        try await credentialManager.resetPasskeys(withRequest: request, originWebAuthn: request.originWebAuthn ?? "https://\(sdkConfig.domain)", reachFive: self)
     }
 
-    private func adapt(_ request: NativeLoginRequest) -> NativeLoginRequest {
-        let domain = sdkConfig.domain
-        let originWebAuthn = request.originWebAuthn ?? "https://\(domain)"
-        let scopes = request.scopes ?? scope
-
-        return NativeLoginRequest(anchor: request.anchor, originWebAuthn: originWebAuthn, scopes: scopes, origin: request.origin)
+    private func resolve(_ request: NativeLoginRequest) -> ResolvedNativeLoginRequest {
+        ResolvedNativeLoginRequest(
+            anchor: request.anchor,
+            originWebAuthn: request.originWebAuthn ?? "https://\(sdkConfig.domain)",
+            scopes: request.scopes ?? scope,
+            origin: request.origin
+        )
     }
 }
 

--- a/Sources/Core/Classes/ReachFiveNative.swift
+++ b/Sources/Core/Classes/ReachFiveNative.swift
@@ -1,21 +1,21 @@
-import Foundation
 import AuthenticationServices
+import Foundation
 
-public extension ReachFive {
-// On naming and signature for methods:
-// first argument indicates modality to distinguish the two primary way UI is shown to user: Modal and AutoFill
-// first argument label contains "with" instead of the method name in conformance to https://www.swift.org/documentation/api-design-guidelines/#give-prepositional-phrase-argument-label
-// non-discoverable methods also take a requestType parameter even though there is only one such type:
+extension ReachFive {
+    // On naming and signature for methods:
+    // first argument indicates modality to distinguish the two primary way UI is shown to user: Modal and AutoFill
+    // first argument label contains "with" instead of the method name in conformance to https://www.swift.org/documentation/api-design-guidelines/#give-prepositional-phrase-argument-label
+    // non-discoverable methods also take a requestType parameter even though there is only one such type:
 //      1. to make it very clear that we are using passkeys
 //      2. to be future proof. For non-discoverable, there is already Security Keys that exist and that we could support.
-// AutoFill is @available(iOS 16.0, *) because ASAuthorizationController.performAutoFillAssistedRequests() itself is.
-// The other methods control version availability with their respective Authorization enum to increase flexibility.
-// For example the non-discoverable cannot be declared @available(iOS 16.0, *)
-// because in the future we could support Security Keys, which are available since iOS 15
+    // AutoFill is @available(iOS 16.0, *) because ASAuthorizationController.performAutoFillAssistedRequests() itself is.
+    // The other methods control version availability with their respective Authorization enum to increase flexibility.
+    // For example the non-discoverable cannot be declared @available(iOS 16.0, *)
+    // because in the future we could support Security Keys, which are available since iOS 15
 
     /// Signup with a passkey
     @available(iOS 16.0, *)
-    func signup(withRequest request: PasskeySignupRequest) async throws -> AuthToken {
+    public func signup(withRequest request: PasskeySignupRequest) async throws -> AuthToken {
         let domain = sdkConfig.domain
         let signupOptions = SignupOptions(
             origin: request.originWebAuthn ?? "https://\(domain)",
@@ -36,7 +36,7 @@ public extension ReachFive {
     /// - Returns: an AuthToken when the user was successfully logged in, or a ReachFiveError
     @available(macCatalyst, unavailable)
     @available(iOS 16.0, *)
-    func beginAutoFillAssistedPasskeyLogin(withRequest request: NativeLoginRequest) async throws -> AuthToken {
+    public func beginAutoFillAssistedPasskeyLogin(withRequest request: NativeLoginRequest) async throws -> AuthToken {
         try await credentialManager.beginAutoFillAssistedPasskeySignIn(request: adapt(request), reachFive: self)
     }
 
@@ -46,7 +46,7 @@ public extension ReachFive {
     ///   - requestTypes: choose between Password and/or Passkey
     ///   - mode: choose the behavior when there are no credentials available
     /// - Returns: an AuthToken when the user was successfully logged in, ReachFiveError.AuthCanceled when the user cancelled the modal sheet or when there was no credentials available, or other kinds of ReachFiveError
-    func login(withRequest request: NativeLoginRequest, usingModalAuthorizationFor requestTypes: [ModalAuthorization], display mode: Mode) async throws -> LoginFlow {
+    public func login(withRequest request: NativeLoginRequest, usingModalAuthorizationFor requestTypes: [ModalAuthorization], display mode: Mode) async throws -> LoginFlow {
         let appleProvider = providers.first { $0.name == AppleProvider.NAME } as? ConfiguredAppleProvider
         return try await credentialManager.login(withRequest: adapt(request), usingModalAuthorizationFor: requestTypes, display: mode, appleProvider: appleProvider, reachFive: self)
     }
@@ -58,7 +58,7 @@ public extension ReachFive {
     ///   - requestTypes: only passkey are supported for now
     ///   - mode: choose the behavior when there are no credentials available
     /// - Returns: an AuthToken when the user was successfully logged in, ReachFiveError.AuthCanceled when the user cancelled the modal sheet or when there was no credentials available, or other kinds of ReachFiveError
-    func login(withNonDiscoverableUsername username: Username, forRequest request: NativeLoginRequest, usingModalAuthorizationFor requestTypes: [NonDiscoverableAuthorization], display mode: Mode) async throws -> AuthToken {
+    public func login(withNonDiscoverableUsername username: Username, forRequest request: NativeLoginRequest, usingModalAuthorizationFor requestTypes: [NonDiscoverableAuthorization], display mode: Mode) async throws -> AuthToken {
         try await credentialManager.login(withNonDiscoverableUsername: username, forRequest: adapt(request), usingModalAuthorizationFor: requestTypes, display: mode, reachFive: self)
     }
 
@@ -68,15 +68,15 @@ public extension ReachFive {
     ///   - authToken: the token for the currently logged-in user
     /// - Returns: A ReachFiveError, or nothing when the Registration was successfull.
     @available(iOS 16.0, *)
-    func registerNewPasskey(withRequest request: NewPasskeyRequest, authToken: AuthToken) async throws {
+    public func registerNewPasskey(withRequest request: NewPasskeyRequest, authToken: AuthToken) async throws {
         let domain = sdkConfig.domain
         let originWebAuthn = request.originWebAuthn ?? "https://\(domain)"
-        //TODO supprimer l'ancienne clé du server
+        // TODO: supprimer l'ancienne clé du server
         return try await credentialManager.registerNewPasskey(withRequest: NewPasskeyRequest(anchor: request.anchor, friendlyName: request.friendlyName, originWebAuthn: originWebAuthn, origin: request.origin), authToken: authToken, reachFive: self)
     }
 
     @available(iOS 16.0, *)
-    func resetPasskeys(withRequest request: ResetPasskeyRequest) async throws {
+    public func resetPasskeys(withRequest request: ResetPasskeyRequest) async throws {
         let domain = sdkConfig.domain
         let originWebAuthn = request.originWebAuthn ?? "https://\(domain)"
         return try await credentialManager.resetPasskeys(withRequest: ResetPasskeyRequest(verificationCode: request.verificationCode, friendlyName: request.friendlyName, anchor: request.anchor, email: request.email, phoneNumber: request.phoneNumber, originWebAuthn: originWebAuthn, origin: request.origin), reachFive: self)

--- a/Sources/Core/Classes/ReachFivePassword.swift
+++ b/Sources/Core/Classes/ReachFivePassword.swift
@@ -47,15 +47,23 @@ public extension ReachFive {
             origin: origin
         )
         let resp = try await reachFiveApi.loginWithPassword(loginRequest: loginRequest)
+        return try await loginFlow(afterPasswordGrant: resp, scopes: scope, origin: origin)
+    }
 
-        if resp.mfaRequired != true {
-            let token = try await self.loginCallback(tkn: resp.tkn, scopes: scope, origin: origin)
+    /// Poursuit un login par mot de passe une fois la réponse du serveur reçue :
+    /// démarre un step-up MFA si le serveur l'exige, sinon termine le login.
+    /// Partagé entre ``loginWithPassword(email:phoneNumber:customIdentifier:password:scope:origin:)``
+    /// et le login par mot de passe du trousseau (`CredentialManager`).
+    /// Non testable unitairement tant que ReachFiveApi n'est pas abstrait derrière un protocole (appels réseau directs).
+    internal func loginFlow(afterPasswordGrant resp: TknMfa, scopes: [String]?, origin: String?) async throws -> LoginFlow {
+        guard resp.mfaRequired == true else {
+            let token = try await loginCallback(tkn: resp.tkn, scopes: scopes, origin: origin)
             return .AchievedLogin(authToken: token)
         }
 
         let pkce = Pkce.generate()
-        self.storage.save(key: self.pkceKey, value: pkce)
-        let stepUpResponse = try await self.reachFiveApi.startMfaStepUp(StartMfaStepUpRequest(clientId: self.sdkConfig.clientId, redirectUri: self.sdkConfig.redirectUri, pkce: pkce, scope: strScope, tkn: resp.tkn))
+        storage.save(key: pkceKey, value: pkce)
+        let stepUpResponse = try await reachFiveApi.startMfaStepUp(StartMfaStepUpRequest(clientId: sdkConfig.clientId, redirectUri: sdkConfig.redirectUri, pkce: pkce, scope: (scopes ?? scope).joined(separator: " "), tkn: resp.tkn))
         return LoginFlow.OngoingStepUp(token: stepUpResponse.token, availableMfaCredentialItemTypes: stepUpResponse.amr)
     }
 }

--- a/Sources/Core/Classes/ReachFivePassword.swift
+++ b/Sources/Core/Classes/ReachFivePassword.swift
@@ -10,8 +10,8 @@ public enum SignupFlow {
     case AwaitingIdentifierVerification
 }
 
-public extension ReachFive {
-    func signup(profile: ProfileSignupRequest, redirectUrl: URL? = nil, scope: [String]? = nil, origin: String? = nil) async throws -> SignupFlow {
+extension ReachFive {
+    public func signup(profile: ProfileSignupRequest, redirectUrl: URL? = nil, scope: [String]? = nil, origin: String? = nil) async throws -> SignupFlow {
         let signupRequest = SignupRequest(
             clientId: sdkConfig.clientId,
             data: profile,
@@ -22,12 +22,11 @@ public extension ReachFive {
         let token = try await reachFiveApi.signupWithPassword(signupRequest: signupRequest)
         guard let accessToken = token.accessToken else {
             return .AwaitingIdentifierVerification
-
         }
         return try .AchievedLogin(authToken: AuthToken.fromOpenIdTokenResponse(AccessTokenResponse(idToken: token.idToken, accessToken: accessToken, refreshToken: token.refreshToken, code: nil, tokenType: token.tokenType, expiresIn: token.expiresIn, error: nil, errorDescription: nil)))
     }
 
-    func loginWithPassword(
+    public func loginWithPassword(
         email: String? = nil,
         phoneNumber: String? = nil,
         customIdentifier: String? = nil,
@@ -55,7 +54,7 @@ public extension ReachFive {
     /// Partagé entre ``loginWithPassword(email:phoneNumber:customIdentifier:password:scope:origin:)``
     /// et le login par mot de passe du trousseau (`CredentialManager`).
     /// Non testable unitairement tant que ReachFiveApi n'est pas abstrait derrière un protocole (appels réseau directs).
-    internal func loginFlow(afterPasswordGrant resp: TknMfa, scopes: [String]?, origin: String?) async throws -> LoginFlow {
+    func loginFlow(afterPasswordGrant resp: TknMfa, scopes: [String]?, origin: String?) async throws -> LoginFlow {
         guard resp.mfaRequired == true else {
             let token = try await loginCallback(tkn: resp.tkn, scopes: scopes, origin: origin)
             return .AchievedLogin(authToken: token)

--- a/Sources/Core/Classes/ReachFivePassword.swift
+++ b/Sources/Core/Classes/ReachFivePassword.swift
@@ -49,11 +49,11 @@ extension ReachFive {
         return try await loginFlow(afterPasswordGrant: resp, scopes: scope, origin: origin)
     }
 
-    /// Poursuit un login par mot de passe une fois la réponse du serveur reçue :
-    /// démarre un step-up MFA si le serveur l'exige, sinon termine le login.
-    /// Partagé entre ``loginWithPassword(email:phoneNumber:customIdentifier:password:scope:origin:)``
-    /// et le login par mot de passe du trousseau (`CredentialManager`).
-    /// Non testable unitairement tant que ReachFiveApi n'est pas abstrait derrière un protocole (appels réseau directs).
+    /// Continues a password login once the server's response has been received: starts an MFA step-up if
+    /// the server requires one, otherwise completes the login.
+    /// Shared between ``loginWithPassword(email:phoneNumber:customIdentifier:password:scope:origin:)``
+    /// and the keychain password login (`CredentialManager`).
+    /// Not unit-testable until `ReachFiveApi` is abstracted behind a protocol (direct network calls).
     func loginFlow(afterPasswordGrant resp: TknMfa, scopes: [String]?, origin: String?) async throws -> LoginFlow {
         guard resp.mfaRequired == true else {
             let token = try await loginCallback(tkn: resp.tkn, scopes: scopes, origin: origin)

--- a/Sources/Core/Classes/models/requests/webAuthn/NativeLoginRequest.swift
+++ b/Sources/Core/Classes/models/requests/webAuthn/NativeLoginRequest.swift
@@ -1,12 +1,12 @@
-import Foundation
 import AuthenticationServices
+import Foundation
 
 public class NativeLoginRequest {
     public let originWebAuthn: String?
     public let scopes: [String]?
     public let anchor: ASPresentationAnchor
     public let origin: String?
-    
+
     public init(anchor: ASPresentationAnchor, originWebAuthn: String? = nil, scopes: [String]? = nil, origin: String? = nil) {
         self.originWebAuthn = originWebAuthn
         self.scopes = scopes

--- a/Sources/Core/Classes/models/requests/webAuthn/NativeLoginRequest.swift
+++ b/Sources/Core/Classes/models/requests/webAuthn/NativeLoginRequest.swift
@@ -14,3 +14,16 @@ public class NativeLoginRequest {
         self.origin = origin
     }
 }
+
+/// A ``NativeLoginRequest`` with the SDK defaults applied: neither the WebAuthn origin nor the scopes are
+/// optional here. The three native login flows only ever handle this type, which removes the force-unwraps
+/// the public request imposed. Counterpart of the resolved models of the registration flows
+/// (``SignupOptions``, ``RegistrationRequest``, ``ResetOptions``).
+struct ResolvedNativeLoginRequest {
+    let anchor: ASPresentationAnchor
+    let originWebAuthn: String
+    /// The requested scopes, or the SDK's own when none were requested.
+    let scopes: [String]
+    /// The ReachFive analytics origin, optional by nature.
+    let origin: String?
+}

--- a/Sources/Core/Classes/models/requests/webAuthn/NativeLoginRequest.swift
+++ b/Sources/Core/Classes/models/requests/webAuthn/NativeLoginRequest.swift
@@ -15,10 +15,6 @@ public class NativeLoginRequest {
     }
 }
 
-/// A ``NativeLoginRequest`` with the SDK defaults applied: neither the WebAuthn origin nor the scopes are
-/// optional here. The three native login flows only ever handle this type, which removes the force-unwraps
-/// the public request imposed. Counterpart of the resolved models of the registration flows
-/// (``SignupOptions``, ``RegistrationRequest``, ``ResetOptions``).
 struct ResolvedNativeLoginRequest {
     let anchor: ASPresentationAnchor
     let originWebAuthn: String

--- a/Sources/Core/Classes/models/requests/webAuthn/WebAuthnLoginRequest.swift
+++ b/Sources/Core/Classes/models/requests/webAuthn/WebAuthnLoginRequest.swift
@@ -1,15 +1,20 @@
 import Foundation
 
-public class WebAuthnLoginRequest: Codable, DictionaryEncodable {
-    public var clientId: String
-    public var origin: String
-    public var email: String?
-    public var phoneNumber: String?
-    public var scope: String
+public struct WebAuthnLoginRequest: Codable, DictionaryEncodable {
+    public let clientId: String
+    public let origin: String
+    public let email: String?
+    public let phoneNumber: String?
+    public let scope: String
 
-    public init(clientId: String, origin: String, scope: [String]? = nil) {
+    /// - Parameter username: the identifier the server needs for a non-discoverable login. Stays nil for
+    ///   the flows where the user picks a credential (auto-fill, modal sheet).
+    public init(clientId: String, origin: String, username: Username? = nil, scope: [String]? = nil) {
         self.clientId = clientId
         self.origin = origin
+        let identifiers = username?.identifiers ?? (email: nil, phoneNumber: nil)
+        email = identifiers.email
+        phoneNumber = identifiers.phoneNumber
         self.scope = (scope ?? []).joined(separator: " ")
     }
 }

--- a/Sources/Core/Classes/models/requests/webAuthn/WebAuthnLoginRequest.swift
+++ b/Sources/Core/Classes/models/requests/webAuthn/WebAuthnLoginRequest.swift
@@ -6,11 +6,10 @@ public class WebAuthnLoginRequest: Codable, DictionaryEncodable {
     public var email: String?
     public var phoneNumber: String?
     public var scope: String
-    
+
     public init(clientId: String, origin: String, scope: [String]? = nil) {
         self.clientId = clientId
         self.origin = origin
         self.scope = (scope ?? []).joined(separator: " ")
     }
 }
-

--- a/Tests/Reach5Tests/CredentialManagerLifecycleTests.swift
+++ b/Tests/Reach5Tests/CredentialManagerLifecycleTests.swift
@@ -1,0 +1,103 @@
+import XCTest
+import AuthenticationServices
+@testable import Reach5
+
+/// Le cycle de vie des requêtes, piloté sans UI système : la méthode générique `perform` est lancée
+/// avec une closure `using` inerte (la requête n'est jamais soumise au système), puis les callbacks
+/// du delegate sont simulés à la main. C'est le contrat central du refactor : une continuation par
+/// requête, résolue exactement une fois, sans interférence entre requêtes entrelacées.
+@MainActor
+final class CredentialManagerLifecycleTests: XCTestCase {
+
+    private func makeReachFive() -> ReachFive {
+        ReachFive(sdkConfig: SdkConfig(domain: "example.reach5.net", clientId: "testclient"))
+    }
+
+    /// Démarre une requête `authToken` inerte et rend la main une fois le contexte enregistré.
+    private func startRequest(on manager: CredentialManager, anchor: ASPresentationAnchor = ASPresentationAnchor()) async -> (controller: ASAuthorizationController, result: Task<AuthToken, Error>) {
+        var controller: ASAuthorizationController?
+        let task = Task { @MainActor in
+            try await manager.perform(
+                CredentialManager.RequestContext.Pending.authToken,
+                requests: [ASAuthorizationPasswordProvider().createRequest()],
+                reachFive: makeReachFive(),
+                anchor: anchor,
+                scopes: nil,
+                originR5: nil
+            ) { controller = $0 }
+        }
+        // perform s'exécute sur le main actor : céder la main jusqu'à ce que le contexte soit en place
+        while controller == nil {
+            await Task.yield()
+        }
+        return (controller!, task)
+    }
+
+    func testCanceledRequestThrowsAuthCanceledThenSecondCallbackIsIgnored() async {
+        let manager = CredentialManager()
+        let (controller, result) = await startRequest(on: manager)
+
+        manager.authorizationController(controller: controller, didCompleteWithError: ASAuthorizationError(.canceled))
+
+        do {
+            _ = try await result.value
+            XCTFail("expected .AuthCanceled")
+        } catch {
+            guard case ReachFiveError.AuthCanceled = error else {
+                return XCTFail("expected .AuthCanceled, got \(error)")
+            }
+        }
+
+        // Le contexte a été retiré à la complétion : un second callback pour le même controller
+        // est ignoré (une continuation reprise deux fois ferait crasher le test).
+        manager.authorizationController(controller: controller, didCompleteWithError: ASAuthorizationError(.failed))
+    }
+
+    func testCallbackForUnknownControllerIsIgnored() {
+        let manager = CredentialManager()
+        let stranger = ASAuthorizationController(authorizationRequests: [ASAuthorizationPasswordProvider().createRequest()])
+
+        // Aucune requête en cours : rien à résoudre, et surtout pas de crash
+        manager.authorizationController(controller: stranger, didCompleteWithError: ASAuthorizationError(.canceled))
+    }
+
+    func testInterleavedRequestsFailIndependently() async {
+        let manager = CredentialManager()
+        let first = await startRequest(on: manager)
+        let second = await startRequest(on: manager)
+
+        manager.authorizationController(controller: first.controller, didCompleteWithError: ASAuthorizationError(.canceled))
+
+        do {
+            _ = try await first.result.value
+            XCTFail("expected .AuthCanceled")
+        } catch {
+            guard case ReachFiveError.AuthCanceled = error else {
+                return XCTFail("expected .AuthCanceled, got \(error)")
+            }
+        }
+
+        // La seconde requête est restée en cours et se résout indépendamment, avec sa propre erreur
+        manager.authorizationController(controller: second.controller, didCompleteWithError: ASAuthorizationError(.failed))
+
+        do {
+            _ = try await second.result.value
+            XCTFail("expected .TechnicalError")
+        } catch {
+            guard case ReachFiveError.TechnicalError = error else {
+                return XCTFail("expected .TechnicalError, got \(error)")
+            }
+        }
+    }
+
+    func testPresentationAnchorIsTheOneOfTheRequest() async {
+        let manager = CredentialManager()
+        let anchor = ASPresentationAnchor()
+        let (controller, result) = await startRequest(on: manager, anchor: anchor)
+
+        XCTAssertTrue(manager.presentationAnchor(for: controller) === anchor)
+
+        manager.authorizationController(controller: controller, didCompleteWithError: ASAuthorizationError(.canceled))
+        _ = try? await result.value
+    }
+}

--- a/Tests/Reach5Tests/CredentialManagerLifecycleTests.swift
+++ b/Tests/Reach5Tests/CredentialManagerLifecycleTests.swift
@@ -18,11 +18,10 @@ final class CredentialManagerLifecycleTests: XCTestCase {
         var controller: ASAuthorizationController?
         let task = Task { @MainActor in
             try await manager.perform(
-                CredentialManager.RequestContext.Pending.authToken,
+                { .passkeyLogin(scopes: nil, $0) },
                 requests: [ASAuthorizationPasswordProvider().createRequest()],
                 reachFive: makeReachFive(),
                 anchor: anchor,
-                scopes: nil,
                 originR5: nil
             ) { controller = $0 }
         }

--- a/Tests/Reach5Tests/CredentialManagerLifecycleTests.swift
+++ b/Tests/Reach5Tests/CredentialManagerLifecycleTests.swift
@@ -176,7 +176,7 @@ final class CredentialManagerLifecycleTests: XCTestCase {
 
     /// `ASAuthorizationController` exige au moins une requête ; sans garde, le système ne rappellerait
     /// jamais le delegate et l'appelant resterait suspendu. Atteignable via l'API publique avec
-    /// `usingModalAuthorizationFor: []`, ou avec `[.Passkey]` sous iOS 15.
+    /// `usingModalAuthorizationFor: []`.
     func testEmptyRequestsThrowsInsteadOfHanging() async {
         let manager = CredentialManager()
         do {

--- a/Tests/Reach5Tests/CredentialManagerLifecycleTests.swift
+++ b/Tests/Reach5Tests/CredentialManagerLifecycleTests.swift
@@ -1,5 +1,5 @@
-import XCTest
 import AuthenticationServices
+import XCTest
 @testable import Reach5
 
 /// Le cycle de vie des requêtes, piloté sans UI système : `perform` est lancée avec une closure de
@@ -16,7 +16,6 @@ import AuthenticationServices
 /// derrière un protocole.
 @MainActor
 final class CredentialManagerLifecycleTests: XCTestCase {
-
     /// La closure de soumission de `perform` y dépose le controller de la requête pour le test.
     @MainActor
     private final class ControllerBox {
@@ -42,7 +41,7 @@ final class CredentialManagerLifecycleTests: XCTestCase {
         }
 
         await fulfillment(of: [submitted], timeout: 1)
-        return (try XCTUnwrap(box.controller), task)
+        return try (XCTUnwrap(box.controller), task)
     }
 
     /// Attend la fin d'une requête et rend l'erreur levée. Aucun test ne peut légitimement aboutir : une

--- a/Tests/Reach5Tests/CredentialManagerLifecycleTests.swift
+++ b/Tests/Reach5Tests/CredentialManagerLifecycleTests.swift
@@ -2,101 +2,194 @@ import XCTest
 import AuthenticationServices
 @testable import Reach5
 
-/// Le cycle de vie des requêtes, piloté sans UI système : la méthode générique `perform` est lancée
-/// avec une closure `using` inerte (la requête n'est jamais soumise au système), puis les callbacks
-/// du delegate sont simulés à la main. C'est le contrat central du refactor : une continuation par
-/// requête, résolue exactement une fois, sans interférence entre requêtes entrelacées.
+/// Le cycle de vie des requêtes, piloté sans UI système : `perform` est lancée avec une closure de
+/// soumission inerte (la requête n'est jamais soumise au système), puis les callbacks du delegate sont
+/// simulés à la main.
+///
+/// Couvert ici : une continuation par requête, reprise exactement une fois, sur tous les chemins d'échec
+/// (annulation utilisateur, erreur technique, annulation par une nouvelle requête, annulation de la tâche
+/// appelante, requête vide), et l'isolation de l'état entre une requête annulée et celle qui la remplace.
+///
+/// Non couvert, et pas couvrable ici : le chemin de succès. `ASAuthorization` n'a pas d'initialiseur
+/// public, il est donc impossible de fabriquer une autorisation de test ; et le post-traitement qui la
+/// suit dans chaque point d'entrée fait des appels réseau directs, `ReachFiveApi` n'étant pas abstrait
+/// derrière un protocole.
 @MainActor
 final class CredentialManagerLifecycleTests: XCTestCase {
 
-    private func makeReachFive() -> ReachFive {
-        ReachFive(sdkConfig: SdkConfig(domain: "example.reach5.net", clientId: "testclient"))
-    }
-
-    /// Démarre une requête `authToken` inerte et rend la main une fois le contexte enregistré.
-    private func startRequest(on manager: CredentialManager, anchor: ASPresentationAnchor = ASPresentationAnchor()) async -> (controller: ASAuthorizationController, result: Task<AuthToken, Error>) {
+    /// La closure de soumission de `perform` y dépose le controller de la requête pour le test.
+    @MainActor
+    private final class ControllerBox {
         var controller: ASAuthorizationController?
-        let task = Task { @MainActor in
-            try await manager.perform(
-                { .passkeyLogin(scopes: nil, $0) },
-                requests: [ASAuthorizationPasswordProvider().createRequest()],
-                reachFive: makeReachFive(),
-                anchor: anchor,
-                originR5: nil
-            ) { controller = $0 }
-        }
-        // perform s'exécute sur le main actor : céder la main jusqu'à ce que le contexte soit en place
-        while controller == nil {
-            await Task.yield()
-        }
-        return (controller!, task)
     }
 
-    func testCanceledRequestThrowsAuthCanceledThenSecondCallbackIsIgnored() async {
-        let manager = CredentialManager()
-        let (controller, result) = await startRequest(on: manager)
+    private struct UnexpectedSuccess: Error {}
 
-        manager.authorizationController(controller: controller, didCompleteWithError: ASAuthorizationError(.canceled))
+    /// Démarre une requête inerte et rend la main une fois le contexte enregistré et la requête soumise.
+    ///
+    /// La tâche est typée `Task<Void, Error>` et non `Task<ASAuthorization, Error>` : l'autorisation n'est
+    /// jamais inspectée (elle n'est pas fabricable en test) et la conformité de `ASAuthorization` à
+    /// `Sendable`, exigée par le paramètre `Success` d'une tâche, n'existe qu'à partir d'iOS 16.4.
+    private func startRequest(on manager: CredentialManager, anchor: ASPresentationAnchor) async throws -> (controller: ASAuthorizationController, result: Task<Void, Error>) {
+        let box = ControllerBox()
+        let submitted = expectation(description: "requête soumise")
 
-        do {
-            _ = try await result.value
-            XCTFail("expected .AuthCanceled")
-        } catch {
-            guard case ReachFiveError.AuthCanceled = error else {
-                return XCTFail("expected .AuthCanceled, got \(error)")
+        let task = Task { @MainActor in
+            _ = try await manager.perform(requests: [ASAuthorizationPasswordProvider().createRequest()], anchor: anchor) {
+                box.controller = $0
+                submitted.fulfill()
             }
         }
 
-        // Le contexte a été retiré à la complétion : un second callback pour le même controller
-        // est ignoré (une continuation reprise deux fois ferait crasher le test).
+        await fulfillment(of: [submitted], timeout: 1)
+        return (try XCTUnwrap(box.controller), task)
+    }
+
+    /// Attend la fin d'une requête et rend l'erreur levée. Aucun test ne peut légitimement aboutir : une
+    /// reprise en succès signifierait qu'une continuation a été résolue avec une autorisation fabriquée.
+    private func failure(of result: Task<Void, Error>) async throws -> Error {
+        do {
+            _ = try await result.value
+        } catch {
+            return error
+        }
+        XCTFail("la requête devait échouer")
+        throw UnexpectedSuccess()
+    }
+
+    func testCanceledRequestThrowsAuthCanceledThenSecondCallbackIsIgnored() async throws {
+        let manager = CredentialManager()
+        let (controller, result) = try await startRequest(on: manager, anchor: ASPresentationAnchor())
+
+        manager.authorizationController(controller: controller, didCompleteWithError: ASAuthorizationError(.canceled))
+
+        let thrown = try await failure(of: result)
+        guard case ReachFiveError.AuthCanceled = thrown else {
+            return XCTFail("expected .AuthCanceled, got \(thrown)")
+        }
+
+        // Le contexte a été retiré à la complétion : un second callback pour le même controller est ignoré
+        // (une continuation reprise deux fois ferait crasher le test).
         manager.authorizationController(controller: controller, didCompleteWithError: ASAuthorizationError(.failed))
     }
 
-    func testCallbackForUnknownControllerIsIgnored() {
+    func testStrayCallbackIsIgnoredAndLeavesLaterRequestsIntact() async throws {
         let manager = CredentialManager()
         let stranger = ASAuthorizationController(authorizationRequests: [ASAuthorizationPasswordProvider().createRequest()])
 
         // Aucune requête en cours : rien à résoudre, et surtout pas de crash
         manager.authorizationController(controller: stranger, didCompleteWithError: ASAuthorizationError(.canceled))
-    }
 
-    func testInterleavedRequestsFailIndependently() async {
-        let manager = CredentialManager()
-        let first = await startRequest(on: manager)
-        let second = await startRequest(on: manager)
-
-        manager.authorizationController(controller: first.controller, didCompleteWithError: ASAuthorizationError(.canceled))
-
-        do {
-            _ = try await first.result.value
-            XCTFail("expected .AuthCanceled")
-        } catch {
-            guard case ReachFiveError.AuthCanceled = error else {
-                return XCTFail("expected .AuthCanceled, got \(error)")
-            }
-        }
-
-        // La seconde requête est restée en cours et se résout indépendamment, avec sa propre erreur
-        manager.authorizationController(controller: second.controller, didCompleteWithError: ASAuthorizationError(.failed))
-
-        do {
-            _ = try await second.result.value
-            XCTFail("expected .TechnicalError")
-        } catch {
-            guard case ReachFiveError.TechnicalError = error else {
-                return XCTFail("expected .TechnicalError, got \(error)")
-            }
-        }
-    }
-
-    func testPresentationAnchorIsTheOneOfTheRequest() async {
-        let manager = CredentialManager()
+        // Le dictionnaire de contextes n'a pas été corrompu : une vraie requête se déroule normalement
         let anchor = ASPresentationAnchor()
-        let (controller, result) = await startRequest(on: manager, anchor: anchor)
-
+        let (controller, result) = try await startRequest(on: manager, anchor: anchor)
         XCTAssertTrue(manager.presentationAnchor(for: controller) === anchor)
 
+        manager.authorizationController(controller: controller, didCompleteWithError: ASAuthorizationError(.failed))
+        let thrown = try await failure(of: result)
+        guard case ReachFiveError.TechnicalError = thrown else {
+            return XCTFail("expected .TechnicalError, got \(thrown)")
+        }
+    }
+
+    /// Le contrat central du refactor : une nouvelle requête annule celle en cours, et l'état de la
+    /// requête annulée disparaît sans jamais toucher à celui de la nouvelle.
+    func testNewRequestCancelsTheInFlightOneWithoutDisturbingItsOwnState() async throws {
+        let manager = CredentialManager()
+        let autoFillAnchor = ASPresentationAnchor()
+        let modalAnchor = ASPresentationAnchor()
+
+        let autoFill = try await startRequest(on: manager, anchor: autoFillAnchor)
+        XCTAssertTrue(manager.presentationAnchor(for: autoFill.controller) === autoFillAnchor)
+
+        // La requête modale annule l'auto-fill en cours, sans attendre de callback système
+        let modal = try await startRequest(on: manager, anchor: modalAnchor)
+
+        let thrown = try await failure(of: autoFill.result)
+        guard case ReachFiveError.AuthCanceled = thrown else {
+            return XCTFail("expected .AuthCanceled, got \(thrown)")
+        }
+
+        // L'état de la requête annulée a disparu, celui de la nouvelle est intact
+        XCTAssertFalse(manager.presentationAnchor(for: autoFill.controller) === autoFillAnchor)
+        XCTAssertTrue(manager.presentationAnchor(for: modal.controller) === modalAnchor)
+
+        // Le callback système tardif de la requête annulée n'a aucun effet : la modale reste en course
+        manager.authorizationController(controller: autoFill.controller, didCompleteWithError: ASAuthorizationError(.canceled))
+
+        manager.authorizationController(controller: modal.controller, didCompleteWithError: ASAuthorizationError(.failed))
+        let modalThrown = try await failure(of: modal.result)
+        guard case ReachFiveError.TechnicalError = modalThrown else {
+            return XCTFail("expected .TechnicalError, got \(modalThrown)")
+        }
+    }
+
+    /// `cancelInFlightRequests` résout elle-même les continuations : elle ne dépend pas d'un
+    /// `didCompleteWithError(.canceled)` que le système ne promet que si un flux tournait vraiment.
+    func testCancelInFlightRequestsResolvesTheRequestWithoutSystemCallback() async throws {
+        let manager = CredentialManager()
+        let anchor = ASPresentationAnchor()
+        let (controller, result) = try await startRequest(on: manager, anchor: anchor)
+
+        manager.cancelInFlightRequests()
+
+        let thrown = try await failure(of: result)
+        guard case ReachFiveError.AuthCanceled = thrown else {
+            return XCTFail("expected .AuthCanceled, got \(thrown)")
+        }
+        XCTAssertFalse(manager.presentationAnchor(for: controller) === anchor, "le contexte doit avoir été libéré")
+    }
+
+    /// L'appelant qui annule sa tâche (écran quitté, `async let` abandonné) reçoit `CancellationError` et
+    /// non `.AuthCanceled` : cette dernière pousse les applications à relancer une requête auto-fill.
+    func testCallerCancellationResumesWithCancellationErrorAndFreesTheContext() async throws {
+        let manager = CredentialManager()
+        let anchor = ASPresentationAnchor()
+        let (controller, result) = try await startRequest(on: manager, anchor: anchor)
+
+        result.cancel()
+
+        let thrown = try await failure(of: result)
+        XCTAssertTrue(thrown is CancellationError, "expected CancellationError, got \(thrown)")
+        XCTAssertFalse(manager.presentationAnchor(for: controller) === anchor, "le contexte doit avoir été libéré")
+
+        // Le callback système tardif ne trouve plus de contexte : pas de double reprise
         manager.authorizationController(controller: controller, didCompleteWithError: ASAuthorizationError(.canceled))
-        _ = try? await result.value
+    }
+
+    func testAlreadyCanceledCallerSubmitsNothing() async throws {
+        let manager = CredentialManager()
+        let notSubmitted = expectation(description: "aucune requête soumise")
+        notSubmitted.isInverted = true
+
+        let task = Task { @MainActor in
+            _ = try await manager.perform(requests: [ASAuthorizationPasswordProvider().createRequest()], anchor: ASPresentationAnchor()) { _ in
+                notSubmitted.fulfill()
+            }
+        }
+        // La tâche est isolée sur le main actor, qui exécute ce test : son corps n'a pas encore démarré
+        task.cancel()
+
+        let thrown = try await failure(of: task)
+        XCTAssertTrue(thrown is CancellationError, "expected CancellationError, got \(thrown)")
+        await fulfillment(of: [notSubmitted], timeout: 0.2)
+    }
+
+    /// `ASAuthorizationController` exige au moins une requête ; sans garde, le système ne rappellerait
+    /// jamais le delegate et l'appelant resterait suspendu. Atteignable via l'API publique avec
+    /// `usingModalAuthorizationFor: []`, ou avec `[.Passkey]` sous iOS 15.
+    func testEmptyRequestsThrowsInsteadOfHanging() async {
+        let manager = CredentialManager()
+        do {
+            _ = try await manager.perform(requests: [], anchor: ASPresentationAnchor()) { _ in
+                XCTFail("aucune requête ne doit être soumise")
+            }
+            XCTFail("expected a .TechnicalError")
+        } catch {
+            guard case let ReachFiveError.TechnicalError(reason, _) = error else {
+                return XCTFail("expected .TechnicalError, got \(error)")
+            }
+            XCTAssertTrue(reason.contains("No authorization request"))
+        }
     }
 }

--- a/Tests/Reach5Tests/CredentialManagerLifecycleTests.swift
+++ b/Tests/Reach5Tests/CredentialManagerLifecycleTests.swift
@@ -68,7 +68,7 @@ final class CredentialManagerLifecycleTests: XCTestCase {
         let manager = CredentialManager()
         let stranger = ASAuthorizationController(authorizationRequests: [ASAuthorizationPasswordProvider().createRequest()])
 
-        // No request in flight: nothing to resolve, and above all no crash
+        // No ongoing request: nothing to resolve, and above all no crash
         manager.authorizationController(controller: stranger, didCompleteWithError: ASAuthorizationError(.canceled))
 
         let anchor = ASPresentationAnchor()
@@ -82,9 +82,9 @@ final class CredentialManagerLifecycleTests: XCTestCase {
         }
     }
 
-    /// The refactor's central contract: a new request cancels the one in flight, and the canceled
+    /// The refactor's central contract: a new request cancels the ongoing one, and the canceled
     /// request's state disappears without ever touching the new one's.
-    func testNewRequestCancelsTheInFlightOneWithoutDisturbingItsOwnState() async throws {
+    func testNewRequestCancelsTheOngoingOneWithoutDisturbingItsOwnState() async throws {
         let manager = CredentialManager()
         let autoFillAnchor = ASPresentationAnchor()
         let modalAnchor = ASPresentationAnchor()
@@ -92,7 +92,7 @@ final class CredentialManagerLifecycleTests: XCTestCase {
         let autoFill = try await startRequest(on: manager, anchor: autoFillAnchor)
         XCTAssertTrue(manager.presentationAnchor(for: autoFill.controller) === autoFillAnchor)
 
-        // The modal request cancels the in-flight auto-fill, without waiting for a system callback
+        // The modal request cancels the ongoing auto-fill, without waiting for a system callback
         let modal = try await startRequest(on: manager, anchor: modalAnchor)
 
         let thrown = try await failure(of: autoFill.result)
@@ -113,14 +113,14 @@ final class CredentialManagerLifecycleTests: XCTestCase {
         }
     }
 
-    /// `cancelInFlightRequests` resolves the continuations itself: it does not depend on a
+    /// `cancelOngoingRequests` resolves the continuations itself: it does not depend on a
     /// `didCompleteWithError(.canceled)` the system only promises if a flow was really running.
-    func testCancelInFlightRequestsResolvesTheRequestWithoutSystemCallback() async throws {
+    func testCancelOngoingRequestsResolvesTheRequestWithoutSystemCallback() async throws {
         let manager = CredentialManager()
         let anchor = ASPresentationAnchor()
         let (controller, result) = try await startRequest(on: manager, anchor: anchor)
 
-        manager.cancelInFlightRequests()
+        manager.cancelOngoingRequests()
 
         let thrown = try await failure(of: result)
         guard case ReachFiveError.AuthCanceled = thrown else {

--- a/Tests/Reach5Tests/CredentialManagerLifecycleTests.swift
+++ b/Tests/Reach5Tests/CredentialManagerLifecycleTests.swift
@@ -2,21 +2,14 @@ import AuthenticationServices
 import XCTest
 @testable import Reach5
 
-/// Le cycle de vie des requêtes, piloté sans UI système : `perform` est lancée avec une closure de
-/// soumission inerte (la requête n'est jamais soumise au système), puis les callbacks du delegate sont
-/// simulés à la main.
+/// Request lifecycle, driven without any system UI: `perform` runs with an inert submit closure, then the
+/// delegate callbacks are simulated by hand.
 ///
-/// Couvert ici : une continuation par requête, reprise exactement une fois, sur tous les chemins d'échec
-/// (annulation utilisateur, erreur technique, annulation par une nouvelle requête, annulation de la tâche
-/// appelante, requête vide), et l'isolation de l'état entre une requête annulée et celle qui la remplace.
-///
-/// Non couvert, et pas couvrable ici : le chemin de succès. `ASAuthorization` n'a pas d'initialiseur
-/// public, il est donc impossible de fabriquer une autorisation de test ; et le post-traitement qui la
-/// suit dans chaque point d'entrée fait des appels réseau directs, `ReachFiveApi` n'étant pas abstrait
-/// derrière un protocole.
+/// The success path is out of reach here: `ASAuthorization` has no public initializer, and the
+/// post-processing that follows it makes direct network calls.
 @MainActor
 final class CredentialManagerLifecycleTests: XCTestCase {
-    /// La closure de soumission de `perform` y dépose le controller de la requête pour le test.
+    /// Where `perform`'s submit closure drops the request's controller for the test.
     @MainActor
     private final class ControllerBox {
         var controller: ASAuthorizationController?
@@ -24,14 +17,14 @@ final class CredentialManagerLifecycleTests: XCTestCase {
 
     private struct UnexpectedSuccess: Error {}
 
-    /// Démarre une requête inerte et rend la main une fois le contexte enregistré et la requête soumise.
+    /// Starts an inert request and returns once its context is registered and the request submitted.
     ///
-    /// La tâche est typée `Task<Void, Error>` et non `Task<ASAuthorization, Error>` : l'autorisation n'est
-    /// jamais inspectée (elle n'est pas fabricable en test) et la conformité de `ASAuthorization` à
-    /// `Sendable`, exigée par le paramètre `Success` d'une tâche, n'existe qu'à partir d'iOS 16.4.
+    /// Typed `Task<Void, Error>` rather than `Task<ASAuthorization, Error>`: the authorization is never
+    /// inspected, and its `Sendable` conformance — required by a task's `Success` — only exists from
+    /// iOS 16.4.
     private func startRequest(on manager: CredentialManager, anchor: ASPresentationAnchor) async throws -> (controller: ASAuthorizationController, result: Task<Void, Error>) {
         let box = ControllerBox()
-        let submitted = expectation(description: "requête soumise")
+        let submitted = expectation(description: "request submitted")
 
         let task = Task { @MainActor in
             _ = try await manager.perform(requests: [ASAuthorizationPasswordProvider().createRequest()], anchor: anchor) {
@@ -44,15 +37,15 @@ final class CredentialManagerLifecycleTests: XCTestCase {
         return try (XCTUnwrap(box.controller), task)
     }
 
-    /// Attend la fin d'une requête et rend l'erreur levée. Aucun test ne peut légitimement aboutir : une
-    /// reprise en succès signifierait qu'une continuation a été résolue avec une autorisation fabriquée.
+    /// Waits for a request to end and returns the error thrown. No test can legitimately succeed: that
+    /// would mean a continuation was resumed with a fabricated authorization.
     private func failure(of result: Task<Void, Error>) async throws -> Error {
         do {
             _ = try await result.value
         } catch {
             return error
         }
-        XCTFail("la requête devait échouer")
+        XCTFail("the request should have failed")
         throw UnexpectedSuccess()
     }
 
@@ -67,8 +60,7 @@ final class CredentialManagerLifecycleTests: XCTestCase {
             return XCTFail("expected .AuthCanceled, got \(thrown)")
         }
 
-        // Le contexte a été retiré à la complétion : un second callback pour le même controller est ignoré
-        // (une continuation reprise deux fois ferait crasher le test).
+        // Context removed on completion, so a second callback is ignored — resuming twice would crash.
         manager.authorizationController(controller: controller, didCompleteWithError: ASAuthorizationError(.failed))
     }
 
@@ -76,10 +68,9 @@ final class CredentialManagerLifecycleTests: XCTestCase {
         let manager = CredentialManager()
         let stranger = ASAuthorizationController(authorizationRequests: [ASAuthorizationPasswordProvider().createRequest()])
 
-        // Aucune requête en cours : rien à résoudre, et surtout pas de crash
+        // No request in flight: nothing to resolve, and above all no crash
         manager.authorizationController(controller: stranger, didCompleteWithError: ASAuthorizationError(.canceled))
 
-        // Le dictionnaire de contextes n'a pas été corrompu : une vraie requête se déroule normalement
         let anchor = ASPresentationAnchor()
         let (controller, result) = try await startRequest(on: manager, anchor: anchor)
         XCTAssertTrue(manager.presentationAnchor(for: controller) === anchor)
@@ -91,8 +82,8 @@ final class CredentialManagerLifecycleTests: XCTestCase {
         }
     }
 
-    /// Le contrat central du refactor : une nouvelle requête annule celle en cours, et l'état de la
-    /// requête annulée disparaît sans jamais toucher à celui de la nouvelle.
+    /// The refactor's central contract: a new request cancels the one in flight, and the canceled
+    /// request's state disappears without ever touching the new one's.
     func testNewRequestCancelsTheInFlightOneWithoutDisturbingItsOwnState() async throws {
         let manager = CredentialManager()
         let autoFillAnchor = ASPresentationAnchor()
@@ -101,7 +92,7 @@ final class CredentialManagerLifecycleTests: XCTestCase {
         let autoFill = try await startRequest(on: manager, anchor: autoFillAnchor)
         XCTAssertTrue(manager.presentationAnchor(for: autoFill.controller) === autoFillAnchor)
 
-        // La requête modale annule l'auto-fill en cours, sans attendre de callback système
+        // The modal request cancels the in-flight auto-fill, without waiting for a system callback
         let modal = try await startRequest(on: manager, anchor: modalAnchor)
 
         let thrown = try await failure(of: autoFill.result)
@@ -109,11 +100,10 @@ final class CredentialManagerLifecycleTests: XCTestCase {
             return XCTFail("expected .AuthCanceled, got \(thrown)")
         }
 
-        // L'état de la requête annulée a disparu, celui de la nouvelle est intact
         XCTAssertFalse(manager.presentationAnchor(for: autoFill.controller) === autoFillAnchor)
         XCTAssertTrue(manager.presentationAnchor(for: modal.controller) === modalAnchor)
 
-        // Le callback système tardif de la requête annulée n'a aucun effet : la modale reste en course
+        // The canceled request's late system callback has no effect: the modal stays in the race
         manager.authorizationController(controller: autoFill.controller, didCompleteWithError: ASAuthorizationError(.canceled))
 
         manager.authorizationController(controller: modal.controller, didCompleteWithError: ASAuthorizationError(.failed))
@@ -123,8 +113,8 @@ final class CredentialManagerLifecycleTests: XCTestCase {
         }
     }
 
-    /// `cancelInFlightRequests` résout elle-même les continuations : elle ne dépend pas d'un
-    /// `didCompleteWithError(.canceled)` que le système ne promet que si un flux tournait vraiment.
+    /// `cancelInFlightRequests` resolves the continuations itself: it does not depend on a
+    /// `didCompleteWithError(.canceled)` the system only promises if a flow was really running.
     func testCancelInFlightRequestsResolvesTheRequestWithoutSystemCallback() async throws {
         let manager = CredentialManager()
         let anchor = ASPresentationAnchor()
@@ -136,12 +126,12 @@ final class CredentialManagerLifecycleTests: XCTestCase {
         guard case ReachFiveError.AuthCanceled = thrown else {
             return XCTFail("expected .AuthCanceled, got \(thrown)")
         }
-        XCTAssertFalse(manager.presentationAnchor(for: controller) === anchor, "le contexte doit avoir été libéré")
+        XCTAssertFalse(manager.presentationAnchor(for: controller) === anchor, "the context should have been released")
     }
 
-    /// L'appelant qui annule sa tâche (écran quitté, `async let` abandonné) reçoit `CancellationError` et
-    /// non `.AuthCanceled` : cette dernière pousse les applications à relancer une requête auto-fill.
-    func testCallerCancellationResumesWithCancellationErrorAndFreesTheContext() async throws {
+    /// A caller that cancels its task (screen dismissed, `async let` abandoned) gets a technical error and
+    /// not `.AuthCanceled`, which pushes apps to restart an auto-fill request.
+    func testCallerCancellationResumesWithTechnicalErrorAndFreesTheContext() async throws {
         let manager = CredentialManager()
         let anchor = ASPresentationAnchor()
         let (controller, result) = try await startRequest(on: manager, anchor: anchor)
@@ -149,16 +139,19 @@ final class CredentialManagerLifecycleTests: XCTestCase {
         result.cancel()
 
         let thrown = try await failure(of: result)
-        XCTAssertTrue(thrown is CancellationError, "expected CancellationError, got \(thrown)")
-        XCTAssertFalse(manager.presentationAnchor(for: controller) === anchor, "le contexte doit avoir été libéré")
+        guard case let ReachFiveError.TechnicalError(reason, _) = thrown else {
+            return XCTFail("expected .TechnicalError, got \(thrown)")
+        }
+        XCTAssertTrue(reason.contains("calling task was canceled"))
+        XCTAssertFalse(manager.presentationAnchor(for: controller) === anchor, "the context should have been released")
 
-        // Le callback système tardif ne trouve plus de contexte : pas de double reprise
+        // The late system callback finds no context left: no double resumption
         manager.authorizationController(controller: controller, didCompleteWithError: ASAuthorizationError(.canceled))
     }
 
     func testAlreadyCanceledCallerSubmitsNothing() async throws {
         let manager = CredentialManager()
-        let notSubmitted = expectation(description: "aucune requête soumise")
+        let notSubmitted = expectation(description: "no request submitted")
         notSubmitted.isInverted = true
 
         let task = Task { @MainActor in
@@ -166,22 +159,23 @@ final class CredentialManagerLifecycleTests: XCTestCase {
                 notSubmitted.fulfill()
             }
         }
-        // La tâche est isolée sur le main actor, qui exécute ce test : son corps n'a pas encore démarré
+        // The task is isolated on the main actor, which runs this test: its body has not started yet
         task.cancel()
 
         let thrown = try await failure(of: task)
-        XCTAssertTrue(thrown is CancellationError, "expected CancellationError, got \(thrown)")
+        guard case let ReachFiveError.TechnicalError(reason, _) = thrown else {
+            return XCTFail("expected .TechnicalError, got \(thrown)")
+        }
+        XCTAssertTrue(reason.contains("calling task was canceled"))
         await fulfillment(of: [notSubmitted], timeout: 0.2)
     }
 
-    /// `ASAuthorizationController` exige au moins une requête ; sans garde, le système ne rappellerait
-    /// jamais le delegate et l'appelant resterait suspendu. Atteignable via l'API publique avec
-    /// `usingModalAuthorizationFor: []`.
+    /// Reachable through the public API with `usingModalAuthorizationFor: []`.
     func testEmptyRequestsThrowsInsteadOfHanging() async {
         let manager = CredentialManager()
         do {
             _ = try await manager.perform(requests: [], anchor: ASPresentationAnchor()) { _ in
-                XCTFail("aucune requête ne doit être soumise")
+                XCTFail("no request should be submitted")
             }
             XCTFail("expected a .TechnicalError")
         } catch {

--- a/Tests/Reach5Tests/CredentialManagerTests.swift
+++ b/Tests/Reach5Tests/CredentialManagerTests.swift
@@ -40,10 +40,6 @@ final class CredentialManagerErrorMappingTests: XCTestCase {
 @MainActor
 final class CredentialManagerRegistrationRequestTests: XCTestCase {
 
-    private func makeManager() -> CredentialManager {
-        CredentialManager(reachFiveApi: ReachFiveApi(sdkConfig: SdkConfig(domain: "example.reach5.net", clientId: "9DKRdQyDLpaJqQQQAR9K")))
-    }
-
     private func makeOptions(challenge: String, userID: String) -> RegistrationOptions {
         RegistrationOptions(
             friendlyName: "iPhone de Test",
@@ -64,9 +60,7 @@ final class CredentialManagerRegistrationRequestTests: XCTestCase {
 
     @available(iOS 16.0, *)
     func testNominalCaseBuildsRequestWithRelyingParty() throws {
-        let manager = makeManager()
-
-        let request = try manager.makeCredentialRegistrationRequest(from: makeOptions(challenge: "AQID", userID: "BAUG"), friendlyName: "iPhone de Test")
+        let request = try CredentialManager().makeCredentialRegistrationRequest(from: makeOptions(challenge: "AQID", userID: "BAUG"), friendlyName: "iPhone de Test")
 
         let registrationRequest = try XCTUnwrap(request as? ASAuthorizationPlatformPublicKeyCredentialRegistrationRequest)
         XCTAssertEqual(registrationRequest.relyingPartyIdentifier, "example.reach5.net")
@@ -75,9 +69,7 @@ final class CredentialManagerRegistrationRequestTests: XCTestCase {
 
     @available(iOS 16.0, *)
     func testUnreadableChallengeThrowsTechnicalError() {
-        let manager = makeManager()
-
-        XCTAssertThrowsError(try manager.makeCredentialRegistrationRequest(from: makeOptions(challenge: "%%%", userID: "BAUG"), friendlyName: "iPhone de Test")) { error in
+        XCTAssertThrowsError(try CredentialManager().makeCredentialRegistrationRequest(from: makeOptions(challenge: "%%%", userID: "BAUG"), friendlyName: "iPhone de Test")) { error in
             guard case let ReachFiveError.TechnicalError(reason, _) = error else {
                 return XCTFail("expected .TechnicalError, got \(error)")
             }
@@ -87,9 +79,7 @@ final class CredentialManagerRegistrationRequestTests: XCTestCase {
 
     @available(iOS 16.0, *)
     func testUnreadableUserIDThrowsTechnicalError() {
-        let manager = makeManager()
-
-        XCTAssertThrowsError(try manager.makeCredentialRegistrationRequest(from: makeOptions(challenge: "AQID", userID: "%%%"), friendlyName: "iPhone de Test")) { error in
+        XCTAssertThrowsError(try CredentialManager().makeCredentialRegistrationRequest(from: makeOptions(challenge: "AQID", userID: "%%%"), friendlyName: "iPhone de Test")) { error in
             guard case let ReachFiveError.TechnicalError(reason, _) = error else {
                 return XCTFail("expected .TechnicalError, got \(error)")
             }

--- a/Tests/Reach5Tests/CredentialManagerTests.swift
+++ b/Tests/Reach5Tests/CredentialManagerTests.swift
@@ -77,9 +77,7 @@ final class CredentialManagerAuthorizationRequestsTests: XCTestCase {
 
         XCTAssertEqual(built.requests.count, 1)
         XCTAssertTrue(built.requests.first is ASAuthorizationPasswordRequest)
-        guard case .none = built.extra else {
-            return XCTFail("expected .none, got \(built.extra)")
-        }
+        XCTAssertNil(built.siwa)
     }
 
     func testSignInWithAppleCarriesProviderScopesAndNonce() async throws {
@@ -91,12 +89,10 @@ final class CredentialManagerAuthorizationRequestsTests: XCTestCase {
         let appleRequest = try XCTUnwrap(built.requests.first as? ASAuthorizationAppleIDRequest)
         XCTAssertEqual(appleRequest.requestedScopes, [.email, .fullName])
 
-        guard case let .signInWithApple(nonce, provider) = built.extra else {
-            return XCTFail("expected .signInWithApple, got \(built.extra)")
-        }
+        let siwa = try XCTUnwrap(built.siwa)
         // le nonce envoyé à Apple est le code challenge ; le verifier correspondant partira au serveur
-        XCTAssertEqual(appleRequest.nonce, nonce.codeChallenge)
-        XCTAssertTrue(provider === appleProvider)
+        XCTAssertEqual(appleRequest.nonce, siwa.nonce.codeChallenge)
+        XCTAssertTrue(siwa.provider === appleProvider)
     }
 
     @available(iOS 16.0, *)

--- a/Tests/Reach5Tests/CredentialManagerTests.swift
+++ b/Tests/Reach5Tests/CredentialManagerTests.swift
@@ -2,41 +2,6 @@ import XCTest
 import AuthenticationServices
 @testable import Reach5
 
-final class CredentialManagerErrorMappingTests: XCTestCase {
-
-    func testCanceledBecomesAuthCanceled() {
-        let error = ASAuthorizationError(.canceled)
-
-        let result = CredentialManager.adapt(error)
-
-        guard case .AuthCanceled = result else {
-            return XCTFail("expected .AuthCanceled, got \(result)")
-        }
-    }
-
-    func testOtherASAuthorizationErrorBecomesTechnicalErrorWithCode() {
-        let error = ASAuthorizationError(.failed)
-
-        let result = CredentialManager.adapt(error)
-
-        guard case let .TechnicalError(reason, _) = result else {
-            return XCTFail("expected .TechnicalError, got \(result)")
-        }
-        XCTAssertTrue(reason.contains("ASAuthorizationError \(ASAuthorizationError.Code.failed.rawValue)"), "le code de l'erreur doit apparaître dans la raison : \(reason)")
-    }
-
-    func testNonASAuthorizationErrorBecomesTechnicalError() {
-        let error = NSError(domain: "test", code: 42, userInfo: [NSLocalizedDescriptionKey: "boom"])
-
-        let result = CredentialManager.adapt(error)
-
-        guard case let .TechnicalError(reason, _) = result else {
-            return XCTFail("expected .TechnicalError, got \(result)")
-        }
-        XCTAssertEqual(reason, "boom")
-    }
-}
-
 @MainActor
 final class CredentialManagerRegistrationRequestTests: XCTestCase {
 
@@ -85,5 +50,87 @@ final class CredentialManagerRegistrationRequestTests: XCTestCase {
             }
             XCTAssertTrue(reason.contains("unreadable userID"))
         }
+    }
+}
+
+/// La construction des requêtes système pour le login modal, testée sans réseau : le réseau est
+/// coupé en substituant `fetchAuthenticationOptions` (appel réel par défaut, cf. signature de
+/// `buildAuthorizationRequests`).
+@MainActor
+final class CredentialManagerAuthorizationRequestsTests: XCTestCase {
+
+    private let reachFive = ReachFive(sdkConfig: SdkConfig(domain: "example.reach5.net", clientId: "testclient"))
+    private lazy var webAuthnLoginRequest = WebAuthnLoginRequest(clientId: reachFive.sdkConfig.clientId, origin: "https://example.reach5.net", scope: nil)
+
+    private func failFetch(_: ReachFive, _: WebAuthnLoginRequest) async throws -> AuthenticationOptions {
+        XCTFail("fetchAuthenticationOptions ne doit pas être appelé")
+        throw ReachFiveError.TechnicalError(reason: "unexpected fetch")
+    }
+
+    private func failMake(_ options: AuthenticationOptions) throws -> ASAuthorizationRequest {
+        XCTFail("makeAuthorization ne doit pas être appelé")
+        throw ReachFiveError.TechnicalError(reason: "unexpected make")
+    }
+
+    func testPasswordBuildsASinglePasswordRequest() async throws {
+        let built = try await CredentialManager().buildAuthorizationRequests(webAuthnLoginRequest, reachFive: reachFive, authorizing: [.Password],fetchAuthenticationOptions: failFetch, makeAuthorization: failMake)
+
+        XCTAssertEqual(built.requests.count, 1)
+        XCTAssertTrue(built.requests.first is ASAuthorizationPasswordRequest)
+        guard case .none = built.extra else {
+            return XCTFail("expected .none, got \(built.extra)")
+        }
+    }
+
+    func testSignInWithAppleCarriesProviderScopesAndNonce() async throws {
+        let providerConfig = try JSONDecoder().decode(ProviderConfig.self, from: Data(#"{"provider": "apple", "variant": "native", "scope": ["email", "name"]}"#.utf8))
+        let appleProvider = ConfiguredAppleProvider(reachFive: reachFive, providerConfig: providerConfig, clientConfigResponse: ClientConfigResponse(scope: "openid profile", sms: false))
+
+        let built = try await CredentialManager().buildAuthorizationRequests(webAuthnLoginRequest, reachFive: reachFive, authorizing: [.SignInWithApple], appleProvider: appleProvider, fetchAuthenticationOptions: failFetch, makeAuthorization: failMake)
+
+        let appleRequest = try XCTUnwrap(built.requests.first as? ASAuthorizationAppleIDRequest)
+        XCTAssertEqual(appleRequest.requestedScopes, [.email, .fullName])
+
+        guard case let .signInWithApple(nonce, provider) = built.extra else {
+            return XCTFail("expected .signInWithApple, got \(built.extra)")
+        }
+        // le nonce envoyé à Apple est le code challenge ; le verifier correspondant partira au serveur
+        XCTAssertEqual(appleRequest.nonce, nonce.codeChallenge)
+        XCTAssertTrue(provider === appleProvider)
+    }
+
+    @available(iOS 16.0, *)
+    func testPasskeyAloneFailureThrows() async {
+        do {
+            _ = try await CredentialManager().buildAuthorizationRequests(webAuthnLoginRequest, reachFive: reachFive, authorizing: [.Passkey], fetchAuthenticationOptions: { _, _ in throw ReachFiveError.TechnicalError(reason: "network down") }, makeAuthorization: failMake)
+            XCTFail("expected the fetch error to propagate")
+        } catch {
+            guard case let ReachFiveError.TechnicalError(reason, _) = error else {
+                return XCTFail("expected .TechnicalError, got \(error)")
+            }
+            XCTAssertEqual(reason, "network down")
+        }
+    }
+
+    @available(iOS 16.0, *)
+    func testPasskeyFailureIsSwallowedWhenCombinedWithAnotherType() async throws {
+        let built = try await CredentialManager().buildAuthorizationRequests(webAuthnLoginRequest, reachFive: reachFive, authorizing: [.Passkey, .Password], fetchAuthenticationOptions: { _, _ in throw ReachFiveError.TechnicalError(reason: "network down") }, makeAuthorization: failMake)
+
+        XCTAssertEqual(built.requests.count, 1, "la requête password doit survivre à l'échec passkey")
+        XCTAssertTrue(built.requests.first is ASAuthorizationPasswordRequest)
+    }
+
+    @available(iOS 16.0, *)
+    func testPasskeyPassesFetchedOptionsToMakeAuthorization() async throws {
+        let options = AuthenticationOptions(publicKey: R5PublicKeyCredentialRequestOptions(challenge: "AQID", timeout: nil, rpId: "example.reach5.net", allowCredentials: nil, userVerification: "preferred"))
+        let placeholder = ASAuthorizationPasswordProvider().createRequest()
+
+        let built = try await CredentialManager().buildAuthorizationRequests(webAuthnLoginRequest, reachFive: reachFive, authorizing: [.Passkey], fetchAuthenticationOptions: { _, _ in options }, makeAuthorization: { received in
+            XCTAssertTrue(received === options)
+            return placeholder
+        })
+
+        XCTAssertEqual(built.requests.count, 1)
+        XCTAssertTrue(built.requests.first === placeholder)
     }
 }

--- a/Tests/Reach5Tests/CredentialManagerTests.swift
+++ b/Tests/Reach5Tests/CredentialManagerTests.swift
@@ -1,0 +1,99 @@
+import XCTest
+import AuthenticationServices
+@testable import Reach5
+
+final class CredentialManagerErrorMappingTests: XCTestCase {
+
+    func testCanceledBecomesAuthCanceled() {
+        let error = ASAuthorizationError(.canceled)
+
+        let result = CredentialManager.adapt(error)
+
+        guard case .AuthCanceled = result else {
+            return XCTFail("expected .AuthCanceled, got \(result)")
+        }
+    }
+
+    func testOtherASAuthorizationErrorBecomesTechnicalErrorWithCode() {
+        let error = ASAuthorizationError(.failed)
+
+        let result = CredentialManager.adapt(error)
+
+        guard case let .TechnicalError(reason, _) = result else {
+            return XCTFail("expected .TechnicalError, got \(result)")
+        }
+        XCTAssertTrue(reason.contains("ASAuthorizationError \(ASAuthorizationError.Code.failed.rawValue)"), "le code de l'erreur doit apparaître dans la raison : \(reason)")
+    }
+
+    func testNonASAuthorizationErrorBecomesTechnicalError() {
+        let error = NSError(domain: "test", code: 42, userInfo: [NSLocalizedDescriptionKey: "boom"])
+
+        let result = CredentialManager.adapt(error)
+
+        guard case let .TechnicalError(reason, _) = result else {
+            return XCTFail("expected .TechnicalError, got \(result)")
+        }
+        XCTAssertEqual(reason, "boom")
+    }
+}
+
+@MainActor
+final class CredentialManagerRegistrationRequestTests: XCTestCase {
+
+    private func makeManager() -> CredentialManager {
+        CredentialManager(reachFiveApi: ReachFiveApi(sdkConfig: SdkConfig(domain: "example.reach5.net", clientId: "9DKRdQyDLpaJqQQQAR9K")))
+    }
+
+    private func makeOptions(challenge: String, userID: String) -> RegistrationOptions {
+        RegistrationOptions(
+            friendlyName: "iPhone de Test",
+            options: CredentialCreationOptions(
+                publicKey: R5PublicKeyCredentialCreationOptions(
+                    rp: R5PublicKeyCredentialRpEntity(id: "example.reach5.net", name: "Example"),
+                    user: R5PublicKeyCredentialUserEntity(id: userID, displayName: "Test", name: "test@example.com"),
+                    challenge: challenge,
+                    pubKeyCredParams: [R5PublicKeyCredentialParameter(alg: -7, type: "public-key")],
+                    timeout: nil,
+                    excludeCredentials: nil,
+                    authenticatorSelection: nil,
+                    attestation: "none"
+                )
+            )
+        )
+    }
+
+    @available(iOS 16.0, *)
+    func testNominalCaseBuildsRequestWithRelyingParty() throws {
+        let manager = makeManager()
+
+        let request = try manager.makeCredentialRegistrationRequest(from: makeOptions(challenge: "AQID", userID: "BAUG"), friendlyName: "iPhone de Test")
+
+        let registrationRequest = try XCTUnwrap(request as? ASAuthorizationPlatformPublicKeyCredentialRegistrationRequest)
+        XCTAssertEqual(registrationRequest.relyingPartyIdentifier, "example.reach5.net")
+        XCTAssertEqual(registrationRequest.name, "iPhone de Test")
+    }
+
+    @available(iOS 16.0, *)
+    func testUnreadableChallengeThrowsTechnicalError() {
+        let manager = makeManager()
+
+        XCTAssertThrowsError(try manager.makeCredentialRegistrationRequest(from: makeOptions(challenge: "%%%", userID: "BAUG"), friendlyName: "iPhone de Test")) { error in
+            guard case let ReachFiveError.TechnicalError(reason, _) = error else {
+                return XCTFail("expected .TechnicalError, got \(error)")
+            }
+            XCTAssertTrue(reason.contains("unreadable challenge"))
+        }
+    }
+
+    @available(iOS 16.0, *)
+    func testUnreadableUserIDThrowsTechnicalError() {
+        let manager = makeManager()
+
+        XCTAssertThrowsError(try manager.makeCredentialRegistrationRequest(from: makeOptions(challenge: "AQID", userID: "%%%"), friendlyName: "iPhone de Test")) { error in
+            guard case let ReachFiveError.TechnicalError(reason, _) = error else {
+                return XCTFail("expected .TechnicalError, got \(error)")
+            }
+            XCTAssertTrue(reason.contains("unreadable userID"))
+        }
+    }
+}

--- a/Tests/Reach5Tests/CredentialManagerTests.swift
+++ b/Tests/Reach5Tests/CredentialManagerTests.swift
@@ -1,12 +1,11 @@
-import XCTest
 import AuthenticationServices
+import XCTest
 @testable import Reach5
 
 @MainActor
 final class CredentialManagerRegistrationRequestTests: XCTestCase {
-
-    // Le friendlyName des options est volontairement différent de celui demandé par l'application :
-    // c'est l'intention de l'application qui doit nommer la passkey, pas l'écho du serveur.
+    /// Le friendlyName des options est volontairement différent de celui demandé par l'application :
+    /// c'est l'intention de l'application qui doit nommer la passkey, pas l'écho du serveur.
     private func makeOptions(challenge: String, userID: String) -> RegistrationOptions {
         RegistrationOptions(
             friendlyName: "nom renvoyé par le serveur",
@@ -58,7 +57,6 @@ final class CredentialManagerRegistrationRequestTests: XCTestCase {
 /// La construction des requêtes d'assertion, pendant symétrique de l'enregistrement.
 @MainActor
 final class CredentialManagerAssertionRequestTests: XCTestCase {
-
     private func makeOptions(challenge: String = "AQID", allowCredentials: [R5PublicKeyCredentialDescriptor]? = nil) -> AuthenticationOptions {
         AuthenticationOptions(publicKey: R5PublicKeyCredentialRequestOptions(challenge: challenge, timeout: nil, rpId: "example.reach5.net", allowCredentials: allowCredentials, userVerification: "preferred"))
     }
@@ -106,7 +104,6 @@ final class CredentialManagerAssertionRequestTests: XCTestCase {
 /// `buildAuthorizationRequests`).
 @MainActor
 final class CredentialManagerAuthorizationRequestsTests: XCTestCase {
-
     private let reachFive = ReachFive(sdkConfig: SdkConfig(domain: "example.reach5.net", clientId: "testclient"))
     private lazy var webAuthnLoginRequest = WebAuthnLoginRequest(clientId: reachFive.sdkConfig.clientId, origin: "https://example.reach5.net", scope: nil)
 

--- a/Tests/Reach5Tests/CredentialManagerTests.swift
+++ b/Tests/Reach5Tests/CredentialManagerTests.swift
@@ -181,6 +181,14 @@ final class CredentialManagerAuthorizationRequestsTests: XCTestCase {
         XCTAssertTrue(built.requests.first is ASAuthorizationPasswordRequest)
     }
 
+    @available(iOS 16.0, *)
+    func testSignInWithAppleIsDroppedAndPasskeyFailureIsSwallowedWhenCombinedWithAnotherType() async throws {
+        let built = try await CredentialManager().buildAuthorizationRequests(webAuthnLoginRequest, reachFive: reachFive, authorizing: [.SignInWithApple, .Passkey, .Password], fetchAuthenticationOptions: { _, _ in throw ReachFiveError.TechnicalError(reason: "network down") })
+
+        XCTAssertEqual(built.requests.count, 1, "la requête password doit survivre à l'échec passkey & Sign in with Apple")
+        XCTAssertTrue(built.requests.first is ASAuthorizationPasswordRequest)
+    }
+
     /// Les options récupérées auprès du serveur sont bien celles qui construisent la requête d'assertion.
     @available(iOS 16.0, *)
     func testPasskeyBuildsAnAssertionRequestFromTheFetchedOptions() async throws {

--- a/Tests/Reach5Tests/CredentialManagerTests.swift
+++ b/Tests/Reach5Tests/CredentialManagerTests.swift
@@ -156,16 +156,14 @@ final class CredentialManagerAuthorizationRequestsTests: XCTestCase {
         XCTAssertTrue(built.requests.first is ASAuthorizationPasswordRequest)
     }
 
-    /// Les options récupérées auprès du serveur sont bien celles qui construisent la requête d'assertion,
-    /// et la restriction aux credentials autorisés est propagée.
+    /// Les options récupérées auprès du serveur sont bien celles qui construisent la requête d'assertion.
     @available(iOS 16.0, *)
     func testPasskeyBuildsAnAssertionRequestFromTheFetchedOptions() async throws {
-        let options = AuthenticationOptions(publicKey: R5PublicKeyCredentialRequestOptions(challenge: "AQID", timeout: nil, rpId: "fetched.reach5.net", allowCredentials: [R5PublicKeyCredentialDescriptor(type: "public-key", id: "AQID")], userVerification: "preferred"))
+        let options = AuthenticationOptions(publicKey: R5PublicKeyCredentialRequestOptions(challenge: "AQID", timeout: nil, rpId: "fetched.reach5.net", allowCredentials: nil, userVerification: "preferred"))
 
-        let built = try await CredentialManager().buildAuthorizationRequests(webAuthnLoginRequest, reachFive: reachFive, authorizing: [.Passkey], restrictingPasskeysToAllowedCredentials: true, fetchAuthenticationOptions: { _, _ in options })
+        let built = try await CredentialManager().buildAuthorizationRequests(webAuthnLoginRequest, reachFive: reachFive, authorizing: [.Passkey], fetchAuthenticationOptions: { _, _ in options })
 
         let assertionRequest = try XCTUnwrap(built.requests.first as? ASAuthorizationPlatformPublicKeyCredentialAssertionRequest)
         XCTAssertEqual(assertionRequest.relyingPartyIdentifier, "fetched.reach5.net")
-        XCTAssertEqual(assertionRequest.allowedCredentials.map(\.credentialID), [Data([0x01, 0x02, 0x03])])
     }
 }

--- a/Tests/Reach5Tests/CredentialManagerTests.swift
+++ b/Tests/Reach5Tests/CredentialManagerTests.swift
@@ -4,11 +4,11 @@ import XCTest
 
 @MainActor
 final class CredentialManagerRegistrationRequestTests: XCTestCase {
-    /// Le friendlyName des options est volontairement différent de celui demandé par l'application :
-    /// c'est l'intention de l'application qui doit nommer la passkey, pas l'écho du serveur.
+    /// The options' friendlyName deliberately differs from the one the app asked for: the app's intent
+    /// should name the passkey, not the server's echo.
     private func makeOptions(challenge: String, userID: String) -> RegistrationOptions {
         RegistrationOptions(
-            friendlyName: "nom renvoyé par le serveur",
+            friendlyName: "name returned by the server",
             options: CredentialCreationOptions(
                 publicKey: R5PublicKeyCredentialCreationOptions(
                     rp: R5PublicKeyCredentialRpEntity(id: "example.reach5.net", name: "Example"),
@@ -26,16 +26,16 @@ final class CredentialManagerRegistrationRequestTests: XCTestCase {
 
     @available(iOS 16.0, *)
     func testNominalCaseBuildsRequestWithRelyingPartyAndRequestedName() throws {
-        let request = try CredentialManager().makeCredentialRegistrationRequest(from: makeOptions(challenge: "AQID", userID: "BAUG"), friendlyName: "iPhone de Test")
+        let request = try CredentialManager().makeCredentialRegistrationRequest(from: makeOptions(challenge: "AQID", userID: "BAUG"), friendlyName: "Test iPhone")
 
         let registrationRequest = try XCTUnwrap(request as? ASAuthorizationPlatformPublicKeyCredentialRegistrationRequest)
         XCTAssertEqual(registrationRequest.relyingPartyIdentifier, "example.reach5.net")
-        XCTAssertEqual(registrationRequest.name, "iPhone de Test")
+        XCTAssertEqual(registrationRequest.name, "Test iPhone")
     }
 
     @available(iOS 16.0, *)
     func testUnreadableChallengeThrowsTechnicalError() {
-        XCTAssertThrowsError(try CredentialManager().makeCredentialRegistrationRequest(from: makeOptions(challenge: "%%%", userID: "BAUG"), friendlyName: "iPhone de Test")) { error in
+        XCTAssertThrowsError(try CredentialManager().makeCredentialRegistrationRequest(from: makeOptions(challenge: "%%%", userID: "BAUG"), friendlyName: "Test iPhone")) { error in
             guard case let ReachFiveError.TechnicalError(reason, _) = error else {
                 return XCTFail("expected .TechnicalError, got \(error)")
             }
@@ -45,7 +45,7 @@ final class CredentialManagerRegistrationRequestTests: XCTestCase {
 
     @available(iOS 16.0, *)
     func testUnreadableUserIDThrowsTechnicalError() {
-        XCTAssertThrowsError(try CredentialManager().makeCredentialRegistrationRequest(from: makeOptions(challenge: "AQID", userID: "%%%"), friendlyName: "iPhone de Test")) { error in
+        XCTAssertThrowsError(try CredentialManager().makeCredentialRegistrationRequest(from: makeOptions(challenge: "AQID", userID: "%%%"), friendlyName: "Test iPhone")) { error in
             guard case let ReachFiveError.TechnicalError(reason, _) = error else {
                 return XCTFail("expected .TechnicalError, got \(error)")
             }
@@ -54,14 +54,14 @@ final class CredentialManagerRegistrationRequestTests: XCTestCase {
     }
 }
 
-/// La construction des requêtes d'assertion, pendant symétrique de l'enregistrement.
+/// Assertion request construction, the symmetric counterpart of registration.
 @MainActor
 final class CredentialManagerAssertionRequestTests: XCTestCase {
     private func makeOptions(challenge: String = "AQID", allowCredentials: [R5PublicKeyCredentialDescriptor]? = nil) -> AuthenticationOptions {
         AuthenticationOptions(publicKey: R5PublicKeyCredentialRequestOptions(challenge: challenge, timeout: nil, rpId: "example.reach5.net", allowCredentials: allowCredentials, userVerification: "preferred"))
     }
 
-    /// Auto-fill et connexion modale : l'utilisateur choisit parmi toutes ses passkeys du relying party.
+    /// Auto-fill and modal sign-in: the user picks among all their passkeys for the relying party.
     @available(iOS 16.0, *)
     func testUnrestrictedRequestListsNoAllowedCredential() throws {
         let request = try CredentialManager().makePasskeyAssertionRequest(makeOptions(allowCredentials: [R5PublicKeyCredentialDescriptor(type: "public-key", id: "AQID")]), restrictedToAllowedCredentials: false)
@@ -71,7 +71,7 @@ final class CredentialManagerAssertionRequestTests: XCTestCase {
         XCTAssertTrue(assertionRequest.allowedCredentials.isEmpty)
     }
 
-    /// Connexion non-discoverable : le compte est connu, la requête est restreinte aux credentials du serveur.
+    /// Non-discoverable sign-in: the account is known, so the request is restricted to the server's credentials.
     @available(iOS 16.0, *)
     func testRestrictedRequestCarriesTheDecodedAllowedCredentials() throws {
         let request = try CredentialManager().makePasskeyAssertionRequest(makeOptions(allowCredentials: [R5PublicKeyCredentialDescriptor(type: "public-key", id: "AQID")]), restrictedToAllowedCredentials: true)
@@ -101,16 +101,15 @@ final class CredentialManagerAssertionRequestTests: XCTestCase {
     }
 }
 
-/// La construction des requêtes système pour le login modal, testée sans réseau : le réseau est
-/// coupé en substituant `fetchAuthenticationOptions` (appel réel par défaut, cf. signature de
-/// `buildAuthorizationRequests`).
+/// System request construction for the modal login, tested without network by substituting
+/// `fetchAuthenticationOptions`.
 @MainActor
 final class CredentialManagerAuthorizationRequestsTests: XCTestCase {
     private let reachFive = ReachFive(sdkConfig: SdkConfig(domain: "example.reach5.net", clientId: "testclient"))
     private lazy var webAuthnLoginRequest = WebAuthnLoginRequest(clientId: reachFive.sdkConfig.clientId, origin: "https://example.reach5.net", scope: nil)
 
     private func failFetch(_: ReachFive, _: WebAuthnLoginRequest) async throws -> AuthenticationOptions {
-        XCTFail("fetchAuthenticationOptions ne doit pas être appelé")
+        XCTFail("fetchAuthenticationOptions should not be called")
         throw ReachFiveError.TechnicalError(reason: "unexpected fetch")
     }
 
@@ -132,13 +131,13 @@ final class CredentialManagerAuthorizationRequestsTests: XCTestCase {
         XCTAssertEqual(appleRequest.requestedScopes, [.email, .fullName])
 
         let siwa = try XCTUnwrap(built.siwa)
-        // le nonce envoyé à Apple est le code challenge ; le verifier correspondant partira au serveur
+        // the nonce sent to Apple is the code challenge; the matching verifier goes to the server
         XCTAssertEqual(appleRequest.nonce, siwa.nonce.codeChallenge)
         XCTAssertTrue(siwa.provider === appleProvider)
     }
 
-    /// Sans provider Apple, la requête ne pourrait pas être complétée : seule demandée, elle doit échouer
-    /// avant toute présentation à l'utilisateur, pas après Face ID.
+    /// Without an Apple provider the request could not be completed: requested alone, it must fail
+    /// before anything is presented to the user, not after Face ID.
     func testSignInWithAppleAloneSurfacesTheMissingProvider() async {
         do {
             _ = try await CredentialManager().buildAuthorizationRequests(webAuthnLoginRequest, reachFive: reachFive, authorizing: [.SignInWithApple], fetchAuthenticationOptions: failFetch)
@@ -151,11 +150,11 @@ final class CredentialManagerAuthorizationRequestsTests: XCTestCase {
         }
     }
 
-    /// Combinée à un autre type, l'absence de provider Apple est écartée : le mot de passe suffit encore.
+    /// Combined with another type, the missing Apple provider is dropped: the password still suffices.
     func testSignInWithAppleIsDroppedWhenAnotherTypeCanStillSucceed() async throws {
         let built = try await CredentialManager().buildAuthorizationRequests(webAuthnLoginRequest, reachFive: reachFive, authorizing: [.SignInWithApple, .Password], fetchAuthenticationOptions: failFetch)
 
-        XCTAssertEqual(built.requests.count, 1, "la requête password doit survivre à l'absence de provider Apple")
+        XCTAssertEqual(built.requests.count, 1, "the password request must survive the missing Apple provider")
         XCTAssertTrue(built.requests.first is ASAuthorizationPasswordRequest)
         XCTAssertNil(built.siwa)
     }
@@ -177,7 +176,7 @@ final class CredentialManagerAuthorizationRequestsTests: XCTestCase {
     func testPasskeyFailureIsSwallowedWhenCombinedWithAnotherType() async throws {
         let built = try await CredentialManager().buildAuthorizationRequests(webAuthnLoginRequest, reachFive: reachFive, authorizing: [.Passkey, .Password], fetchAuthenticationOptions: { _, _ in throw ReachFiveError.TechnicalError(reason: "network down") })
 
-        XCTAssertEqual(built.requests.count, 1, "la requête password doit survivre à l'échec passkey")
+        XCTAssertEqual(built.requests.count, 1, "the password request must survive the passkey failure")
         XCTAssertTrue(built.requests.first is ASAuthorizationPasswordRequest)
     }
 
@@ -185,11 +184,11 @@ final class CredentialManagerAuthorizationRequestsTests: XCTestCase {
     func testSignInWithAppleIsDroppedAndPasskeyFailureIsSwallowedWhenCombinedWithAnotherType() async throws {
         let built = try await CredentialManager().buildAuthorizationRequests(webAuthnLoginRequest, reachFive: reachFive, authorizing: [.SignInWithApple, .Passkey, .Password], fetchAuthenticationOptions: { _, _ in throw ReachFiveError.TechnicalError(reason: "network down") })
 
-        XCTAssertEqual(built.requests.count, 1, "la requête password doit survivre à l'échec passkey & Sign in with Apple")
+        XCTAssertEqual(built.requests.count, 1, "the password request must survive both the passkey and Sign In With Apple failures")
         XCTAssertTrue(built.requests.first is ASAuthorizationPasswordRequest)
     }
 
-    /// Les options récupérées auprès du serveur sont bien celles qui construisent la requête d'assertion.
+    /// The options fetched from the server are the ones that build the assertion request.
     @available(iOS 16.0, *)
     func testPasskeyBuildsAnAssertionRequestFromTheFetchedOptions() async throws {
         let options = AuthenticationOptions(publicKey: R5PublicKeyCredentialRequestOptions(challenge: "AQID", timeout: nil, rpId: "fetched.reach5.net", allowCredentials: nil, userVerification: "preferred"))

--- a/Tests/Reach5Tests/CredentialManagerTests.swift
+++ b/Tests/Reach5Tests/CredentialManagerTests.swift
@@ -80,6 +80,7 @@ final class CredentialManagerAssertionRequestTests: XCTestCase {
         XCTAssertEqual(assertionRequest.allowedCredentials.map(\.credentialID), [Data([0x01, 0x02, 0x03])])
     }
 
+    @available(iOS 16.0, *)
     func testRestrictedRequestWithoutAllowedCredentialsThrowsAuthFailure() {
         XCTAssertThrowsError(try CredentialManager().makePasskeyAssertionRequest(makeOptions(allowCredentials: nil), restrictedToAllowedCredentials: true)) { error in
             guard case let ReachFiveError.AuthFailure(reason, _) = error else {
@@ -89,6 +90,7 @@ final class CredentialManagerAssertionRequestTests: XCTestCase {
         }
     }
 
+    @available(iOS 16.0, *)
     func testUnreadableChallengeThrowsTechnicalError() {
         XCTAssertThrowsError(try CredentialManager().makePasskeyAssertionRequest(makeOptions(challenge: "%%%"), restrictedToAllowedCredentials: false)) { error in
             guard case let ReachFiveError.TechnicalError(reason, _) = error else {

--- a/Tests/Reach5Tests/CredentialManagerTests.swift
+++ b/Tests/Reach5Tests/CredentialManagerTests.swift
@@ -137,6 +137,29 @@ final class CredentialManagerAuthorizationRequestsTests: XCTestCase {
         XCTAssertTrue(siwa.provider === appleProvider)
     }
 
+    /// Sans provider Apple, la requête ne pourrait pas être complétée : seule demandée, elle doit échouer
+    /// avant toute présentation à l'utilisateur, pas après Face ID.
+    func testSignInWithAppleAloneSurfacesTheMissingProvider() async {
+        do {
+            _ = try await CredentialManager().buildAuthorizationRequests(webAuthnLoginRequest, reachFive: reachFive, authorizing: [.SignInWithApple], fetchAuthenticationOptions: failFetch)
+            XCTFail("expected the missing provider to surface")
+        } catch {
+            guard case let ReachFiveError.TechnicalError(reason, _) = error else {
+                return XCTFail("expected .TechnicalError, got \(error)")
+            }
+            XCTAssertTrue(reason.contains("no Apple provider"))
+        }
+    }
+
+    /// Combinée à un autre type, l'absence de provider Apple est écartée : le mot de passe suffit encore.
+    func testSignInWithAppleIsDroppedWhenAnotherTypeCanStillSucceed() async throws {
+        let built = try await CredentialManager().buildAuthorizationRequests(webAuthnLoginRequest, reachFive: reachFive, authorizing: [.SignInWithApple, .Password], fetchAuthenticationOptions: failFetch)
+
+        XCTAssertEqual(built.requests.count, 1, "la requête password doit survivre à l'absence de provider Apple")
+        XCTAssertTrue(built.requests.first is ASAuthorizationPasswordRequest)
+        XCTAssertNil(built.siwa)
+    }
+
     @available(iOS 16.0, *)
     func testPasskeyAloneFailureThrows() async {
         do {

--- a/Tests/Reach5Tests/CredentialManagerTests.swift
+++ b/Tests/Reach5Tests/CredentialManagerTests.swift
@@ -5,9 +5,11 @@ import AuthenticationServices
 @MainActor
 final class CredentialManagerRegistrationRequestTests: XCTestCase {
 
+    // Le friendlyName des options est volontairement différent de celui demandé par l'application :
+    // c'est l'intention de l'application qui doit nommer la passkey, pas l'écho du serveur.
     private func makeOptions(challenge: String, userID: String) -> RegistrationOptions {
         RegistrationOptions(
-            friendlyName: "iPhone de Test",
+            friendlyName: "nom renvoyé par le serveur",
             options: CredentialCreationOptions(
                 publicKey: R5PublicKeyCredentialCreationOptions(
                     rp: R5PublicKeyCredentialRpEntity(id: "example.reach5.net", name: "Example"),
@@ -24,7 +26,7 @@ final class CredentialManagerRegistrationRequestTests: XCTestCase {
     }
 
     @available(iOS 16.0, *)
-    func testNominalCaseBuildsRequestWithRelyingParty() throws {
+    func testNominalCaseBuildsRequestWithRelyingPartyAndRequestedName() throws {
         let request = try CredentialManager().makeCredentialRegistrationRequest(from: makeOptions(challenge: "AQID", userID: "BAUG"), friendlyName: "iPhone de Test")
 
         let registrationRequest = try XCTUnwrap(request as? ASAuthorizationPlatformPublicKeyCredentialRegistrationRequest)
@@ -53,6 +55,52 @@ final class CredentialManagerRegistrationRequestTests: XCTestCase {
     }
 }
 
+/// La construction des requêtes d'assertion, pendant symétrique de l'enregistrement.
+@MainActor
+final class CredentialManagerAssertionRequestTests: XCTestCase {
+
+    private func makeOptions(challenge: String = "AQID", allowCredentials: [R5PublicKeyCredentialDescriptor]? = nil) -> AuthenticationOptions {
+        AuthenticationOptions(publicKey: R5PublicKeyCredentialRequestOptions(challenge: challenge, timeout: nil, rpId: "example.reach5.net", allowCredentials: allowCredentials, userVerification: "preferred"))
+    }
+
+    /// Auto-fill et connexion modale : l'utilisateur choisit parmi toutes ses passkeys du relying party.
+    @available(iOS 16.0, *)
+    func testUnrestrictedRequestListsNoAllowedCredential() throws {
+        let request = try CredentialManager().makePasskeyAssertionRequest(makeOptions(allowCredentials: [R5PublicKeyCredentialDescriptor(type: "public-key", id: "AQID")]), restrictedToAllowedCredentials: false)
+
+        let assertionRequest = try XCTUnwrap(request as? ASAuthorizationPlatformPublicKeyCredentialAssertionRequest)
+        XCTAssertEqual(assertionRequest.relyingPartyIdentifier, "example.reach5.net")
+        XCTAssertTrue(assertionRequest.allowedCredentials.isEmpty)
+    }
+
+    /// Connexion non-discoverable : le compte est connu, la requête est restreinte aux credentials du serveur.
+    @available(iOS 16.0, *)
+    func testRestrictedRequestCarriesTheDecodedAllowedCredentials() throws {
+        let request = try CredentialManager().makePasskeyAssertionRequest(makeOptions(allowCredentials: [R5PublicKeyCredentialDescriptor(type: "public-key", id: "AQID")]), restrictedToAllowedCredentials: true)
+
+        let assertionRequest = try XCTUnwrap(request as? ASAuthorizationPlatformPublicKeyCredentialAssertionRequest)
+        XCTAssertEqual(assertionRequest.allowedCredentials.map(\.credentialID), [Data([0x01, 0x02, 0x03])])
+    }
+
+    func testRestrictedRequestWithoutAllowedCredentialsThrowsAuthFailure() {
+        XCTAssertThrowsError(try CredentialManager().makePasskeyAssertionRequest(makeOptions(allowCredentials: nil), restrictedToAllowedCredentials: true)) { error in
+            guard case let ReachFiveError.AuthFailure(reason, _) = error else {
+                return XCTFail("expected .AuthFailure, got \(error)")
+            }
+            XCTAssertTrue(reason.contains("no allowCredentials returned"))
+        }
+    }
+
+    func testUnreadableChallengeThrowsTechnicalError() {
+        XCTAssertThrowsError(try CredentialManager().makePasskeyAssertionRequest(makeOptions(challenge: "%%%"), restrictedToAllowedCredentials: false)) { error in
+            guard case let ReachFiveError.TechnicalError(reason, _) = error else {
+                return XCTFail("expected .TechnicalError, got \(error)")
+            }
+            XCTAssertTrue(reason.contains("unreadable challenge"))
+        }
+    }
+}
+
 /// La construction des requêtes système pour le login modal, testée sans réseau : le réseau est
 /// coupé en substituant `fetchAuthenticationOptions` (appel réel par défaut, cf. signature de
 /// `buildAuthorizationRequests`).
@@ -67,13 +115,8 @@ final class CredentialManagerAuthorizationRequestsTests: XCTestCase {
         throw ReachFiveError.TechnicalError(reason: "unexpected fetch")
     }
 
-    private func failMake(_ options: AuthenticationOptions) throws -> ASAuthorizationRequest {
-        XCTFail("makeAuthorization ne doit pas être appelé")
-        throw ReachFiveError.TechnicalError(reason: "unexpected make")
-    }
-
     func testPasswordBuildsASinglePasswordRequest() async throws {
-        let built = try await CredentialManager().buildAuthorizationRequests(webAuthnLoginRequest, reachFive: reachFive, authorizing: [.Password],fetchAuthenticationOptions: failFetch, makeAuthorization: failMake)
+        let built = try await CredentialManager().buildAuthorizationRequests(webAuthnLoginRequest, reachFive: reachFive, authorizing: [.Password], fetchAuthenticationOptions: failFetch)
 
         XCTAssertEqual(built.requests.count, 1)
         XCTAssertTrue(built.requests.first is ASAuthorizationPasswordRequest)
@@ -84,7 +127,7 @@ final class CredentialManagerAuthorizationRequestsTests: XCTestCase {
         let providerConfig = try JSONDecoder().decode(ProviderConfig.self, from: Data(#"{"provider": "apple", "variant": "native", "scope": ["email", "name"]}"#.utf8))
         let appleProvider = ConfiguredAppleProvider(reachFive: reachFive, providerConfig: providerConfig, clientConfigResponse: ClientConfigResponse(scope: "openid profile", sms: false))
 
-        let built = try await CredentialManager().buildAuthorizationRequests(webAuthnLoginRequest, reachFive: reachFive, authorizing: [.SignInWithApple], appleProvider: appleProvider, fetchAuthenticationOptions: failFetch, makeAuthorization: failMake)
+        let built = try await CredentialManager().buildAuthorizationRequests(webAuthnLoginRequest, reachFive: reachFive, authorizing: [.SignInWithApple], appleProvider: appleProvider, fetchAuthenticationOptions: failFetch)
 
         let appleRequest = try XCTUnwrap(built.requests.first as? ASAuthorizationAppleIDRequest)
         XCTAssertEqual(appleRequest.requestedScopes, [.email, .fullName])
@@ -98,7 +141,7 @@ final class CredentialManagerAuthorizationRequestsTests: XCTestCase {
     @available(iOS 16.0, *)
     func testPasskeyAloneFailureThrows() async {
         do {
-            _ = try await CredentialManager().buildAuthorizationRequests(webAuthnLoginRequest, reachFive: reachFive, authorizing: [.Passkey], fetchAuthenticationOptions: { _, _ in throw ReachFiveError.TechnicalError(reason: "network down") }, makeAuthorization: failMake)
+            _ = try await CredentialManager().buildAuthorizationRequests(webAuthnLoginRequest, reachFive: reachFive, authorizing: [.Passkey], fetchAuthenticationOptions: { _, _ in throw ReachFiveError.TechnicalError(reason: "network down") })
             XCTFail("expected the fetch error to propagate")
         } catch {
             guard case let ReachFiveError.TechnicalError(reason, _) = error else {
@@ -110,23 +153,22 @@ final class CredentialManagerAuthorizationRequestsTests: XCTestCase {
 
     @available(iOS 16.0, *)
     func testPasskeyFailureIsSwallowedWhenCombinedWithAnotherType() async throws {
-        let built = try await CredentialManager().buildAuthorizationRequests(webAuthnLoginRequest, reachFive: reachFive, authorizing: [.Passkey, .Password], fetchAuthenticationOptions: { _, _ in throw ReachFiveError.TechnicalError(reason: "network down") }, makeAuthorization: failMake)
+        let built = try await CredentialManager().buildAuthorizationRequests(webAuthnLoginRequest, reachFive: reachFive, authorizing: [.Passkey, .Password], fetchAuthenticationOptions: { _, _ in throw ReachFiveError.TechnicalError(reason: "network down") })
 
         XCTAssertEqual(built.requests.count, 1, "la requête password doit survivre à l'échec passkey")
         XCTAssertTrue(built.requests.first is ASAuthorizationPasswordRequest)
     }
 
+    /// Les options récupérées auprès du serveur sont bien celles qui construisent la requête d'assertion,
+    /// et la restriction aux credentials autorisés est propagée.
     @available(iOS 16.0, *)
-    func testPasskeyPassesFetchedOptionsToMakeAuthorization() async throws {
-        let options = AuthenticationOptions(publicKey: R5PublicKeyCredentialRequestOptions(challenge: "AQID", timeout: nil, rpId: "example.reach5.net", allowCredentials: nil, userVerification: "preferred"))
-        let placeholder = ASAuthorizationPasswordProvider().createRequest()
+    func testPasskeyBuildsAnAssertionRequestFromTheFetchedOptions() async throws {
+        let options = AuthenticationOptions(publicKey: R5PublicKeyCredentialRequestOptions(challenge: "AQID", timeout: nil, rpId: "fetched.reach5.net", allowCredentials: [R5PublicKeyCredentialDescriptor(type: "public-key", id: "AQID")], userVerification: "preferred"))
 
-        let built = try await CredentialManager().buildAuthorizationRequests(webAuthnLoginRequest, reachFive: reachFive, authorizing: [.Passkey], fetchAuthenticationOptions: { _, _ in options }, makeAuthorization: { received in
-            XCTAssertTrue(received === options)
-            return placeholder
-        })
+        let built = try await CredentialManager().buildAuthorizationRequests(webAuthnLoginRequest, reachFive: reachFive, authorizing: [.Passkey], restrictingPasskeysToAllowedCredentials: true, fetchAuthenticationOptions: { _, _ in options })
 
-        XCTAssertEqual(built.requests.count, 1)
-        XCTAssertTrue(built.requests.first === placeholder)
+        let assertionRequest = try XCTUnwrap(built.requests.first as? ASAuthorizationPlatformPublicKeyCredentialAssertionRequest)
+        XCTAssertEqual(assertionRequest.relyingPartyIdentifier, "fetched.reach5.net")
+        XCTAssertEqual(assertionRequest.allowedCredentials.map(\.credentialID), [Data([0x01, 0x02, 0x03])])
     }
 }

--- a/Tests/Reach5Tests/UsernameTests.swift
+++ b/Tests/Reach5Tests/UsernameTests.swift
@@ -1,0 +1,20 @@
+import XCTest
+@testable import Reach5
+
+final class UsernameTests: XCTestCase {
+    func testUnspecifiedIsSplitByTheAtSign() {
+        XCTAssertEqual(Username.Unspecified("jane@example.com").identifiers.email, "jane@example.com")
+        XCTAssertNil(Username.Unspecified("jane@example.com").identifiers.phoneNumber)
+
+        XCTAssertEqual(Username.Unspecified("+33600000000").identifiers.phoneNumber, "+33600000000")
+        XCTAssertNil(Username.Unspecified("+33600000000").identifiers.email)
+    }
+
+    func testExplicitIdentifiersAreCarriedAsIs() {
+        XCTAssertEqual(Username.Email("jane@example.com").identifiers.email, "jane@example.com")
+        XCTAssertNil(Username.Email("jane@example.com").identifiers.phoneNumber)
+
+        XCTAssertEqual(Username.PhoneNumber("+33600000000").identifiers.phoneNumber, "+33600000000")
+        XCTAssertNil(Username.PhoneNumber("+33600000000").identifiers.email)
+    }
+}

--- a/Tests/Reach5Tests/WebAuthnLoginRequestTests.swift
+++ b/Tests/Reach5Tests/WebAuthnLoginRequestTests.swift
@@ -1,0 +1,21 @@
+import XCTest
+@testable import Reach5
+
+/// Le contrat réseau de `WebAuthnLoginRequest` : `dictionary()` (utilisé par `ReachFiveApi`) doit omettre
+/// les champs non renseignés plutôt que les envoyer à `null`.
+final class WebAuthnLoginRequestTests: XCTestCase {
+    func testEmailIdentifierIsSentAloneInSnakeCase() throws {
+        let dict = try XCTUnwrap(WebAuthnLoginRequest(clientId: "testclient", origin: "https://example.reach5.net", username: .Email("jane@example.com")).dictionary())
+
+        XCTAssertEqual(dict["client_id"] as? String, "testclient")
+        XCTAssertEqual(dict["email"] as? String, "jane@example.com")
+        XCTAssertNil(dict["phone_number"])
+    }
+
+    func testWithoutUsernameNoIdentifierIsSent() throws {
+        let dict = try XCTUnwrap(WebAuthnLoginRequest(clientId: "testclient", origin: "https://example.reach5.net").dictionary())
+
+        XCTAssertNil(dict["email"])
+        XCTAssertNil(dict["phone_number"])
+    }
+}

--- a/Tests/Reach5Tests/WebAuthnLoginRequestTests.swift
+++ b/Tests/Reach5Tests/WebAuthnLoginRequestTests.swift
@@ -1,8 +1,8 @@
 import XCTest
 @testable import Reach5
 
-/// Le contrat réseau de `WebAuthnLoginRequest` : `dictionary()` (utilisé par `ReachFiveApi`) doit omettre
-/// les champs non renseignés plutôt que les envoyer à `null`.
+/// `WebAuthnLoginRequest`'s wire contract: `dictionary()` must omit the fields left unset rather than
+/// send them as `null`.
 final class WebAuthnLoginRequestTests: XCTestCase {
     func testEmailIdentifierIsSentAloneInSnakeCase() throws {
         let dict = try XCTUnwrap(WebAuthnLoginRequest(clientId: "testclient", origin: "https://example.reach5.net", username: .Email("jane@example.com")).dictionary())


### PR DESCRIPTION
Réécriture complète du cycle de vie
- le code est réécrit comme si l'API Apple était async/await nativement, donc chaque méthode de connexion/inscription contient toute la logique du début à la fin ; chaque flow était précédemment découpe en deux, avec la deuxième partie dans le delegate, ce qui compliquait la compréhension et obligeait à créer des états partagés au niveau de la classe, ce qui était bancal.
- Le contexte de chaque flow vit dans un RequestContext indexé par controller ; il n'est plus partagé, donc il n'y a plus de risque de mélange comme avant.
- CredentialManager utilise maintenant ReachFive pour éviter la duplication de certaines méthodes de login/step-up

Il y a d'autres petites amélioration du code attenant au Credential Manager, comme une meilleure gestion des Username
