### PR TITLE
Sandbox : corrige l'accumulation de la pile de navigation à chaque login

### DIFF
--- a/Sandbox/Sandbox/Application/Base.lproj/Main.storyboard
+++ b/Sandbox/Sandbox/Application/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23727" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Gi6-Pt-F8W">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23727" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="c07-e1-6ON">
     <device id="retina6_3" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
@@ -703,12 +703,10 @@
                             <constraint firstItem="ss7-L2-u8Z" firstAttribute="trailing" secondItem="bMR-fb-yg6" secondAttribute="trailing" id="pTh-NH-ZAy"/>
                         </constraints>
                     </view>
-                    <tabBarItem key="tabBarItem" title="Profile" image="person.crop.circle.badge.xmark" catalog="system" selectedImage="person.crop.circle.fill.badge.xmark" id="ahA-UT-aB7"/>
                     <navigationItem key="navigationItem" title="Profile" id="Bus-r5-WAu"/>
                     <simulatedTabBarMetrics key="simulatedBottomBarMetrics"/>
                     <connections>
                         <outlet property="profileData" destination="bMR-fb-yg6" id="iP6-eD-7E1"/>
-                        <outlet property="profileTabBarItem" destination="ahA-UT-aB7" id="Tce-zb-ua4"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="7u3-k8-15u" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -938,18 +936,16 @@
         <scene sceneID="AT3-nl-Cnu">
             <objects>
                 <tabBarController storyboardIdentifier="Tabs" id="c07-e1-6ON" customClass="SandboxTabBarController" customModule="Sandbox" customModuleProvider="target" sceneMemberID="viewController">
-                    <navigationItem key="navigationItem" id="jpc-pz-4XC"/>
                     <tabBar key="tabBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="diO-3X-FIp">
                         <rect key="frame" x="0.0" y="0.0" width="393" height="49"/>
                         <autoresizingMask key="autoresizingMask"/>
-                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     </tabBar>
                     <connections>
                         <outlet property="sandboxTabBar" destination="diO-3X-FIp" id="ipq-s9-m6L"/>
-                        <segue destination="ZDb-7x-mVl" kind="relationship" relationship="viewControllers" id="Pzw-21-BQx"/>
-                        <segue destination="MTQ-Xb-hzf" kind="relationship" relationship="viewControllers" id="CyL-N2-NK0"/>
-                        <segue destination="85A-IF-9ED" kind="relationship" relationship="viewControllers" id="o6E-CP-l6n"/>
-                        <segue destination="t2d-3p-DRa" kind="relationship" relationship="viewControllers" id="b1e-Wp-g2g"/>
+                        <segue destination="Nav-Fn-001" kind="relationship" relationship="viewControllers" id="Pzw-21-BQx"/>
+                        <segue destination="Nav-De-002" kind="relationship" relationship="viewControllers" id="CyL-N2-NK0"/>
+                        <segue destination="Nav-Pr-003" kind="relationship" relationship="viewControllers" id="o6E-CP-l6n"/>
+                        <segue destination="Nav-Se-004" kind="relationship" relationship="viewControllers" id="b1e-Wp-g2g"/>
                     </connections>
                 </tabBarController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="4MJ-fW-IcH" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
@@ -999,7 +995,6 @@
                             <constraint firstItem="y9X-fU-A2A" firstAttribute="trailing" secondItem="Lw1-0I-Uzr" secondAttribute="trailing" id="Eyj-LD-dd7"/>
                         </constraints>
                     </view>
-                    <tabBarItem key="tabBarItem" title="Settings" image="gearshape" catalog="system" id="h4g-f3-bI9"/>
                     <connections>
                         <outlet property="environmentDomain" destination="C2a-8K-xGf" id="Fde-eR-g0s"/>
                         <outlet property="tableView" destination="Lw1-0I-Uzr" id="XR9-UC-x3a"/>
@@ -1009,23 +1004,73 @@
             </objects>
             <point key="canvasLocation" x="-2504" y="864"/>
         </scene>
-        <!--Navigation Controller-->
-        <scene sceneID="IZ8-Ke-q7Q">
+        <!--Functions Navigation Controller-->
+        <scene sceneID="Scn-Fn-001">
             <objects>
-                <navigationController id="Gi6-Pt-F8W" sceneMemberID="viewController">
-                    <toolbarItems/>
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="2AB-cK-I6M">
-                        <rect key="frame" x="0.0" y="124" width="402" height="44"/>
+                <navigationController id="Nav-Fn-001" sceneMemberID="viewController">
+                    <tabBarItem key="tabBarItem" title="Functions" image="list.bullet.clipboard" catalog="system" id="Tbi-Fn-001"/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="Nbr-Fn-001">
+                        <rect key="frame" x="0.0" y="0.0" width="402" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
-                    <nil name="viewControllers"/>
                     <connections>
-                        <segue destination="c07-e1-6ON" kind="relationship" relationship="rootViewController" id="3yM-2n-4rD"/>
+                        <segue destination="ZDb-7x-mVl" kind="relationship" relationship="rootViewController" id="Rel-Fn-001"/>
                     </connections>
                 </navigationController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="b1t-2T-73d" userLabel="First Responder" sceneMemberID="firstResponder"/>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Fr0-Fn-001" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-2853" y="113"/>
+            <point key="canvasLocation" x="-2853" y="-500"/>
+        </scene>
+        <!--Demo Navigation Controller-->
+        <scene sceneID="Scn-De-002">
+            <objects>
+                <navigationController id="Nav-De-002" sceneMemberID="viewController">
+                    <tabBarItem key="tabBarItem" title="Demo" image="faceid" catalog="system" id="Tbi-De-002"/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="Nbr-De-002">
+                        <rect key="frame" x="0.0" y="0.0" width="402" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <connections>
+                        <segue destination="MTQ-Xb-hzf" kind="relationship" relationship="rootViewController" id="Rel-De-002"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Fr0-De-002" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-2853" y="-100"/>
+        </scene>
+        <!--Profile Navigation Controller-->
+        <scene sceneID="Scn-Pr-003">
+            <objects>
+                <navigationController id="Nav-Pr-003" sceneMemberID="viewController">
+                    <tabBarItem key="tabBarItem" title="Profile" image="person.crop.circle.badge.xmark" catalog="system" selectedImage="person.crop.circle.fill.badge.xmark" id="Tbi-Pr-003"/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="Nbr-Pr-003">
+                        <rect key="frame" x="0.0" y="0.0" width="402" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <connections>
+                        <segue destination="85A-IF-9ED" kind="relationship" relationship="rootViewController" id="Rel-Pr-003"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Fr0-Pr-003" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-2853" y="300"/>
+        </scene>
+        <!--Settings Navigation Controller-->
+        <scene sceneID="Scn-Se-004">
+            <objects>
+                <navigationController id="Nav-Se-004" sceneMemberID="viewController">
+                    <tabBarItem key="tabBarItem" title="Settings" image="gearshape" catalog="system" id="Tbi-Se-004"/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="Nbr-Se-004">
+                        <rect key="frame" x="0.0" y="0.0" width="402" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <connections>
+                        <segue destination="t2d-3p-DRa" kind="relationship" relationship="rootViewController" id="Rel-Se-004"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Fr0-Se-004" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-2853" y="700"/>
         </scene>
         <!--Sandbox-->
         <scene sceneID="IPB-Mx-ry5">
@@ -1391,7 +1436,6 @@
                             <outlet property="delegate" destination="ZDb-7x-mVl" id="g7A-GS-0xa"/>
                         </connections>
                     </tableView>
-                    <tabBarItem key="tabBarItem" title="Functions" image="list.bullet.clipboard" catalog="system" id="97O-Bc-e0N"/>
                     <navigationItem key="navigationItem" title="Sandbox" id="YWL-5C-3Wy"/>
                     <simulatedTabBarMetrics key="simulatedBottomBarMetrics"/>
                 </tableViewController>
@@ -1817,7 +1861,6 @@
                             <outletCollection property="gestureRecognizers" destination="Eho-lp-dss" appends="YES" id="lZU-h0-P1o"/>
                         </connections>
                     </view>
-                    <tabBarItem key="tabBarItem" title="Demo" image="faceid" catalog="system" id="dmy-Kz-tPi"/>
                     <navigationItem key="navigationItem" id="gqD-0k-3qg"/>
                     <simulatedTabBarMetrics key="simulatedBottomBarMetrics"/>
                     <connections>

--- a/Sandbox/Sandbox/Tabs/SandboxTabBarController.swift
+++ b/Sandbox/Sandbox/Tabs/SandboxTabBarController.swift
@@ -12,84 +12,72 @@ class SandboxTabBarController: UITabBarController {
     // also the notifications are not always available, especially in the profile controller, because the view is not yet loaded
     public static let loggedIn = UIImage(systemName: "person.crop.circle.badge.checkmark")
     public static let loggedOut = UIImage(systemName: "person.crop.circle.badge.xmark")
-    
+
     public static var tokenExpiredButRefreshable: UIImage? {
         guard #available(iOS 15, *) else {
             return UIImage(systemName: "person.crop.circle.badge.minus")
         }
         return UIImage(systemName: "person.crop.circle.badge.moon")
     }
-    
+
     public static var tokenPresent: UIImage? {
         guard #available(iOS 14, *) else {
             return UIImage(systemName: "person.crop.circle")
         }
         return UIImage(systemName: "person.crop.circle.badge.questionmark")
     }
-    
+
     public static var tokenShared: UIImage? {
         return UIImage(systemName: "shared.with.you")
     }
-    
+
     public static var loggedInButNotFresh: UIImage? {
         guard #available(iOS 15, *) else {
             return UIImage(systemName: "person.crop.circle.badge.plus")
         }
         return UIImage(systemName: "person.crop.circle.badge.clock")
     }
-    
+
     @IBOutlet weak var sandboxTabBar: UITabBar?
-    
+
     var clearTokenObserver: NSObjectProtocol?
     var setTokenObserver: NSObjectProtocol?
-    
+
     override func viewDidLoad() {
         print("SandboxTabBarController.viewDidLoad")
         super.viewDidLoad()
-        self.delegate = self
-        
+
         clearTokenObserver = NotificationCenter.default.addObserver(forName: .DidClearAuthToken, object: nil, queue: nil) { _ in
             Task { @MainActor in
                 self.didLogout()
             }
         }
-        
+
         setTokenObserver = NotificationCenter.default.addObserver(forName: .DidSetAuthToken, object: nil, queue: nil) { _ in
             Task { @MainActor in
                 self.didLogin()
             }
         }
-        
+
         if #unavailable(iOS 16.0) {
             sandboxTabBar?.items?[0].image = UIImage(systemName: "list.bullet")
         }
-        
+
         if AppDelegate.storage.getToken() != nil {
             sandboxTabBar?.items?[2].image = SandboxTabBarController.tokenPresent
             sandboxTabBar?.items?[2].selectedImage = SandboxTabBarController.tokenPresent
         }
     }
 
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        self.navigationItem.title = self.selectedViewController?.title
-    }
-    
     func didLogout() {
         print("SandboxTabBarController.didLogout")
         sandboxTabBar?.items?[2].image = SandboxTabBarController.loggedOut
         sandboxTabBar?.items?[2].selectedImage = SandboxTabBarController.loggedOut
     }
-    
+
     func didLogin() {
         print("SandboxTabBarController.didLogin")
         sandboxTabBar?.items?[2].image = SandboxTabBarController.loggedIn
         sandboxTabBar?.items?[2].selectedImage = SandboxTabBarController.loggedIn
-    }
-}
-
-extension SandboxTabBarController: UITabBarControllerDelegate {
-    func tabBarController(_ tabBarController: UITabBarController, didSelect viewController: UIViewController) {
-        self.navigationItem.title = viewController.title
     }
 }

--- a/Sandbox/Sandbox/Utils/UIViewController+Handling.swift
+++ b/Sandbox/Sandbox/Utils/UIViewController+Handling.swift
@@ -15,10 +15,11 @@ extension UIViewController {
     func goToProfile(_ authToken: AuthToken) {
         AppDelegate.storage.setToken(authToken)
 
-        if let tabBarController = storyboard?.instantiateViewController(withIdentifier: "Tabs") as? UITabBarController {
-            tabBarController.selectedIndex = 2 // profile is third from left
-            navigationController?.pushViewController(tabBarController, animated: true)
-        }
+        // Sélectionne l'onglet Profil existant plutôt que d'empiler une nouvelle instance de "Tabs"
+        guard let tabs = tabBarController else { return }
+        // Revient à la racine de l'onglet courant pour ne pas y laisser un parcours de login entamé
+        navigationController?.popToRootViewController(animated: false)
+        tabs.selectedIndex = 2 // profile is third from left
     }
 
     func handleLoginFlow(errorMessage: String = "Login failed", _ body: () async throws -> LoginFlow) async {


### PR DESCRIPTION
## Résumé
- `goToProfile` pushait un nouveau `SandboxTabBarController` (identifiant storyboard « Tabs ») à chaque login réussi au lieu de sélectionner l'onglet Profil existant, ce qui empilait des instances de « Tabs » sur la pile de navigation.
- Conséquences observées : retours arrière fantômes (la pile devient `[Tabs, Tabs, …]`), et N instances vivantes du tab bar controller dont les observateurs `NotificationCenter` ne sont jamais retirés.
- La hiérarchie de vues est inversée pour suivre la structure standard UIKit : `SandboxTabBarController` devient la racine de la fenêtre, avec un `UINavigationController` par onglet. Le login sélectionne désormais l'onglet Profil (`selectedIndex = 2`) au lieu de pousser une nouvelle instance.

## Contexte
Diagnostic complet dans la conversation associée : trois bugs observés (onglets absents sur Mac Catalyst, alertes en double, retours arrière fantômes) partagent cette même cause racine. Ce PR corrige le bug 3 (pile de navigation) ; les bugs 1 et 2 sont traités dans des PR séparées empilées sur celle-ci :
- #fix/sandbox-catalyst-tabbar (barre d'onglets visible sur Catalyst)
- #fix/sandbox-notification-leaks (nettoyage des observateurs NotificationCenter)

## Test plan
- [ ] Lancer le Sandbox sur simulateur iOS, se connecter puis se déconnecter deux fois de suite
- [ ] Vérifier que le bouton retour ne propose plus d'anciennes pages issues de logins précédents
- [ ] Vérifier que l'onglet Profil est bien sélectionné après un login réussi

🤖 Generated with [Claude Code](https://claude.com/claude-code)