### PR TITLE
Sandbox : rend la barre d'onglets à nouveau visible sur Mac Catalyst

### DIFF
--- a/Sandbox/Sandbox/Tabs/SandboxTabBarController.swift
+++ b/Sandbox/Sandbox/Tabs/SandboxTabBarController.swift
@@ -47,6 +47,18 @@ class SandboxTabBarController: UITabBarController {
         print("SandboxTabBarController.viewDidLoad")
         super.viewDidLoad()
 
+        // Fond opaque : un fond transparent rendait la barre invisible, notamment sur Mac Catalyst
+        let appearance = UITabBarAppearance()
+        appearance.configureWithDefaultBackground()
+        tabBar.standardAppearance = appearance
+        if #available(iOS 15.0, *) {
+            tabBar.scrollEdgeAppearance = appearance
+        }
+        if #available(iOS 18.0, *) {
+            // Garde la barre d'onglets classique en bas (sur Catalyst/iPad, iOS 18 la déplace sinon en sidebar)
+            mode = .tabBar
+        }
+
         clearTokenObserver = NotificationCenter.default.addObserver(forName: .DidClearAuthToken, object: nil, queue: nil) { _ in
             Task { @MainActor in
                 self.didLogout()


### PR DESCRIPTION
## Résumé
- Le fond de la barre d'onglets était entièrement transparent dans `Main.storyboard` (`white=0.0 alpha=0.0`), ce qui la rendait invisible sur Mac Catalyst — probablement aggravé par une régression du rendu du tab bar depuis iOS 18 / Xcode 16 quand aucune apparence explicite n'est définie.
- Ajoute un fond opaque via `UITabBarAppearance` et force `mode = .tabBar` sur iOS 18+ pour garder la barre classique en bas plutôt qu'une sidebar sur Catalyst/iPad.

## Contexte
PR empilée sur #116 (correction de la pile de navigation), qui retire déjà l'imbrication non supportée d'un `UITabBarController` dans un `UINavigationController` — un facteur possible du bug d'affichage sur Catalyst. Ce PR traite le facteur aggravant restant (fond transparent).

## Test plan
- [ ] Lancer le Sandbox sur Mac Catalyst et vérifier que les 4 onglets sont visibles
- [ ] Vérifier que la barre reste en bas (pas de sidebar) sur Catalyst/iPad avec iOS 18+
- [ ] Vérifier l'absence de régression visuelle sur simulateur iOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)