### PR TITLE
Sandbox : corrige les alertes en double (observateurs NotificationCenter non retirés)

### DIFF
--- a/Sandbox/Sandbox/Controllers/Password/LoginWithPasswordController.swift
+++ b/Sandbox/Sandbox/Controllers/Password/LoginWithPasswordController.swift
@@ -28,15 +28,22 @@ class LoginWithPasswordController: UIViewController {
 
         loadScopes()
 
-        tokenNotification = NotificationCenter.default.addObserver(forName: .DidReceiveLoginCallback, object: nil, queue: nil) { note in
+        tokenNotification = NotificationCenter.default.addObserver(forName: .DidReceiveLoginCallback, object: nil, queue: nil) { [weak self] note in
             if let result = note.userInfo?["result"], let result = result as? Result<AuthToken, ReachFiveError> {
                 Task { @MainActor in
+                    guard let self else { return }
                     self.dismiss(animated: true)
                     await self.handleAuthToken(errorMessage: "Step up failed") {
                         try result.get()
                     }
                 }
             }
+        }
+    }
+
+    deinit {
+        if let tokenNotification {
+            NotificationCenter.default.removeObserver(tokenNotification)
         }
     }
 

--- a/Sandbox/Sandbox/Controllers/Password/NativePasswordController.swift
+++ b/Sandbox/Sandbox/Controllers/Password/NativePasswordController.swift
@@ -9,15 +9,22 @@ class NativePasswordController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        tokenNotification = NotificationCenter.default.addObserver(forName: .DidReceiveLoginCallback, object: nil, queue: nil) { note in
+        tokenNotification = NotificationCenter.default.addObserver(forName: .DidReceiveLoginCallback, object: nil, queue: nil) { [weak self] note in
             if let result = note.userInfo?["result"], let result = result as? Result<AuthToken, ReachFiveError> {
                 Task { @MainActor in
+                    guard let self else { return }
                     self.dismiss(animated: true)
                     await self.handleAuthToken(errorMessage: "Step up failed") {
                         try result.get()
                     }
                 }
             }
+        }
+    }
+
+    deinit {
+        if let tokenNotification {
+            NotificationCenter.default.removeObserver(tokenNotification)
         }
     }
 

--- a/Sandbox/Sandbox/Controllers/Password/SignupController.swift
+++ b/Sandbox/Sandbox/Controllers/Password/SignupController.swift
@@ -14,8 +14,9 @@ class SignupController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         emailInput.text = initialEmail
-        emailVerificationNotification = NotificationCenter.default.addObserver(forName: .DidReceiveEmailVerificationCallback, object: nil, queue: nil) { note in
+        emailVerificationNotification = NotificationCenter.default.addObserver(forName: .DidReceiveEmailVerificationCallback, object: nil, queue: nil) { [weak self] note in
             Task { @MainActor in
+                guard let self else { return }
                 if let result = note.userInfo?["result"], let result = result as? Result<(), ReachFiveError> {
                     self.dismiss(animated: true)
                     switch result {
@@ -26,6 +27,12 @@ class SignupController: UIViewController {
                     }
                 }
             }
+        }
+    }
+
+    deinit {
+        if let emailVerificationNotification {
+            NotificationCenter.default.removeObserver(emailVerificationNotification)
         }
     }
     

--- a/Sandbox/Sandbox/Controllers/Passwordless/PasswordlessController.swift
+++ b/Sandbox/Sandbox/Controllers/Passwordless/PasswordlessController.swift
@@ -13,14 +13,21 @@ class PasswordlessController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        tokenNotification = NotificationCenter.default.addObserver(forName: .DidReceiveLoginCallback, object: nil, queue: nil) { (note) in
+        tokenNotification = NotificationCenter.default.addObserver(forName: .DidReceiveLoginCallback, object: nil, queue: nil) { [weak self] (note) in
             if let result = note.userInfo?["result"], let result = result as? Result<AuthToken, ReachFiveError> {
                 Task {
+                    guard let self else { return }
                     await self.handleAuthToken(errorMessage: "Passwordless failed") {
                         try result.get()
                     }
                 }
             }
+        }
+    }
+
+    deinit {
+        if let tokenNotification {
+            NotificationCenter.default.removeObserver(tokenNotification)
         }
     }
 

--- a/Sandbox/Sandbox/Controllers/Profile subviews/MfaController.swift
+++ b/Sandbox/Sandbox/Controllers/Profile subviews/MfaController.swift
@@ -46,8 +46,9 @@ class MfaController: UIViewController {
         trustedDevicesTableView.register(trustedDeviceCellNib, forCellReuseIdentifier: TrustedDeviceCell.reuseIdentifier)
 
 
-        tokenNotification = NotificationCenter.default.addObserver(forName: .DidReceiveLoginCallback, object: nil, queue: nil) { note in
+        tokenNotification = NotificationCenter.default.addObserver(forName: .DidReceiveLoginCallback, object: nil, queue: nil) { [weak self] note in
             Task { @MainActor in
+                guard let self else { return }
                 if let result = note.userInfo?["result"] as? Result<AuthToken, ReachFiveError> {
                     self.dismiss(animated: true)
                     switch result {
@@ -64,6 +65,12 @@ class MfaController: UIViewController {
         Task {
             try await fetchMfaCredentials()
             try await fetchTrustedDevices()
+        }
+    }
+
+    deinit {
+        if let tokenNotification {
+            NotificationCenter.default.removeObserver(tokenNotification)
         }
     }
 

--- a/Sandbox/Sandbox/Tabs/ActionController.swift
+++ b/Sandbox/Sandbox/Tabs/ActionController.swift
@@ -6,6 +6,27 @@ import AuthenticationServices
 class ActionController: UITableViewController {
     var tokenNotification: NSObjectProtocol?
 
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        tokenNotification = NotificationCenter.default.addObserver(forName: .DidReceiveLoginCallback, object: nil, queue: nil) { [weak self] note in
+            if let result = note.userInfo?["result"], let result = result as? Result<AuthToken, ReachFiveError> {
+                Task { @MainActor in
+                    guard let self else { return }
+                    self.dismiss(animated: true)
+                    await self.handleAuthToken(errorMessage: "Step up failed") {
+                        try result.get()
+                    }
+                }
+            }
+        }
+    }
+
+    deinit {
+        if let tokenNotification {
+            NotificationCenter.default.removeObserver(tokenNotification)
+        }
+    }
+
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         Task { @MainActor in
             tableView.deselectRow(at: indexPath, animated: true)
@@ -48,16 +69,6 @@ class ActionController: UITableViewController {
             if indexPath.section == 3 {
                 // standard webview
                 if indexPath.row == 0 {
-                    tokenNotification = NotificationCenter.default.addObserver(forName: .DidReceiveLoginCallback, object: nil, queue: nil) { note in
-                        if let result = note.userInfo?["result"], let result = result as? Result<AuthToken, ReachFiveError> {
-                            Task { @MainActor in
-                                self.dismiss(animated: true)
-                                await self.handleAuthToken(errorMessage: "Step up failed") {
-                                    try result.get()
-                                }
-                            }
-                        }
-                    }
                     await handleAuthToken {
                         try await AppDelegate.reachfive().webviewLogin(WebviewLoginRequest(presentationContextProvider: self, origin: "ActionController.webviewLogin"))
                     }

--- a/Sandbox/Sandbox/Tabs/DemoController.swift
+++ b/Sandbox/Sandbox/Tabs/DemoController.swift
@@ -15,9 +15,10 @@ class DemoController: UIViewController {
     override func viewDidLoad() {
         print("DemoController.viewDidLoad")
         super.viewDidLoad()
-        tokenNotification = NotificationCenter.default.addObserver(forName: .DidReceiveLoginCallback, object: nil, queue: nil) { note in
+        tokenNotification = NotificationCenter.default.addObserver(forName: .DidReceiveLoginCallback, object: nil, queue: nil) { [weak self] note in
             if let result = note.userInfo?["result"], let result = result as? Result<AuthToken, ReachFiveError> {
                 Task { @MainActor in
+                    guard let self else { return }
                     self.dismiss(animated: true)
                     await self.handleAuthToken(errorMessage: "Step up failed") {
                         try result.get()
@@ -31,6 +32,12 @@ class DemoController: UIViewController {
         // set delegates to manage the keyboard Return/Done button behavior
         usernameField.delegate = self
         passwordField.delegate = self
+    }
+
+    deinit {
+        if let tokenNotification {
+            NotificationCenter.default.removeObserver(tokenNotification)
+        }
     }
 
     override func viewWillAppear(_ animated: Bool) {

--- a/Sandbox/Sandbox/Tabs/ProfileController.swift
+++ b/Sandbox/Sandbox/Tabs/ProfileController.swift
@@ -59,8 +59,9 @@ class ProfileController: UIViewController {
         print("ProfileController.viewDidLoad")
         super.viewDidLoad()
         emailMfaVerifyNotification = NotificationCenter.default.addObserver(forName: .DidReceiveMfaVerifyEmail, object: nil, queue: nil) {
-            (note) in
+            [weak self] (note) in
             Task { @MainActor in
+                guard let self else { return }
                 if let result = note.userInfo?["result"], let result = result as? Result<(), ReachFiveError> {
                     self.dismiss(animated: true)
                     switch result {
@@ -74,8 +75,9 @@ class ProfileController: UIViewController {
             }
         }
         emailVerificationNotification = NotificationCenter.default.addObserver(forName: .DidReceiveEmailVerificationCallback, object: nil, queue: nil) {
-            (note) in
+            [weak self] (note) in
             Task { @MainActor in
+                guard let self else { return }
                 if let result = note.userInfo?["result"], let result = result as? Result<(), ReachFiveError> {
                     self.dismiss(animated: true)
                     switch result {
@@ -89,13 +91,12 @@ class ProfileController: UIViewController {
             }
         }
 
-        //TODO: mieux gérer les notifications pour ne pas en avoir plusieurs qui se déclenche pour le même évènement
-        clearTokenObserver = NotificationCenter.default.addObserver(forName: .DidClearAuthToken, object: nil, queue: nil) { _ in
-            self.didLogout()
+        clearTokenObserver = NotificationCenter.default.addObserver(forName: .DidClearAuthToken, object: nil, queue: nil) { [weak self] _ in
+            self?.didLogout()
         }
 
-        setTokenObserver = NotificationCenter.default.addObserver(forName: .DidSetAuthToken, object: nil, queue: nil) { _ in
-            self.didLogin()
+        setTokenObserver = NotificationCenter.default.addObserver(forName: .DidSetAuthToken, object: nil, queue: nil) { [weak self] _ in
+            self?.didLogin()
         }
 
         authToken = AppDelegate.storage.getToken()
@@ -114,6 +115,13 @@ class ProfileController: UIViewController {
         //TODO: supprimer le logout qui n'a jamais marché
         //        self.navigationItem.rightBarButtonItem = UIBarButtonItem(title: "Edit", style: .plain, target: self, action: #selector(toggleEditMode))
 
+    }
+
+    deinit {
+        let center = NotificationCenter.default
+        [emailMfaVerifyNotification, emailVerificationNotification, clearTokenObserver, setTokenObserver]
+            .compactMap { $0 }
+            .forEach { center.removeObserver($0) }
     }
 
     //TODO:

--- a/Sandbox/Sandbox/Tabs/SandboxTabBarController.swift
+++ b/Sandbox/Sandbox/Tabs/SandboxTabBarController.swift
@@ -59,15 +59,15 @@ class SandboxTabBarController: UITabBarController {
             mode = .tabBar
         }
 
-        clearTokenObserver = NotificationCenter.default.addObserver(forName: .DidClearAuthToken, object: nil, queue: nil) { _ in
+        clearTokenObserver = NotificationCenter.default.addObserver(forName: .DidClearAuthToken, object: nil, queue: nil) { [weak self] _ in
             Task { @MainActor in
-                self.didLogout()
+                self?.didLogout()
             }
         }
 
-        setTokenObserver = NotificationCenter.default.addObserver(forName: .DidSetAuthToken, object: nil, queue: nil) { _ in
+        setTokenObserver = NotificationCenter.default.addObserver(forName: .DidSetAuthToken, object: nil, queue: nil) { [weak self] _ in
             Task { @MainActor in
-                self.didLogin()
+                self?.didLogin()
             }
         }
 
@@ -78,6 +78,15 @@ class SandboxTabBarController: UITabBarController {
         if AppDelegate.storage.getToken() != nil {
             sandboxTabBar?.items?[2].image = SandboxTabBarController.tokenPresent
             sandboxTabBar?.items?[2].selectedImage = SandboxTabBarController.tokenPresent
+        }
+    }
+
+    deinit {
+        if let clearTokenObserver {
+            NotificationCenter.default.removeObserver(clearTokenObserver)
+        }
+        if let setTokenObserver {
+            NotificationCenter.default.removeObserver(setTokenObserver)
         }
     }
 


### PR DESCRIPTION
## Résumé
- Les observateurs `NotificationCenter` enregistrés dans `viewDidLoad` n'étaient jamais retirés (aucun `deinit` dans la cible Sandbox) : `SandboxTabBarController`, `ProfileController`, `DemoController`, `MfaController`, `SignupController`, `LoginWithPasswordController`, `NativePasswordController`, `PasswordlessController`.
- Cas aggravé : `ActionController` ré-enregistrait un observateur `.DidReceiveLoginCallback` à **chaque tap** sur la ligne webview, écrasant la référence précédente (fuite). L'enregistrement est déplacé dans `viewDidLoad`, une seule fois.
- Ajoute `deinit { removeObserver }` et `[weak self]` dans les closures pour tous les contrôleurs concernés, afin qu'une notification postée une fois ne déclenche qu'un seul handler par instance réellement vivante.

## Contexte
PR empilée sur #117 (visibilité du tab bar) et #116 (pile de navigation). Combiné au bug de la pile de navigation (déjà corrigé dans #116), le nombre d'instances vivantes retenant des observateurs pouvait faire apparaître plusieurs alertes pour un seul évènement ; ce PR ferme la fuite indépendamment de ce nombre d'instances.

## Test plan
- [ ] Enchaîner deux logins/logouts sur simulateur iOS et vérifier qu'une seule alerte apparaît par événement
- [ ] Vérifier que le step-up MFA et la vérification email affichent toujours leurs alertes normalement

🤖 Generated with [Claude Code](https://claude.com/claude-code)