### PR TITLE
Remove hidden contract from the Provider.login() method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
   try await provider.login(scope: scope, origin: origin, presenting: Presentation(from: self))
   ```
 
-  The view controller no longer needs to conform to `ASWebAuthenticationPresentationContextProviding` for web providers: the SDK derives the presentation context itself (a conforming view controller keeps precedence if you have one). It must simply be attached to a window at call time — call `login` from `viewDidAppear` or a user interaction, not from `viewDidLoad`. Conformance is still required when calling `webviewLogin` or `logout(webSessionLogout:)` directly, whose requests are unchanged.
+  The view controller no longer needs to conform to `ASWebAuthenticationPresentationContextProviding` for web providers: the SDK derives the presentation context itself (a conforming view controller keeps precedence if you have one). It must simply be attached to a window at call time — call `login` from `viewDidAppear` or a user interaction, not from `viewDidLoad`. When calling `webviewLogin` or `logout(webSessionLogout:)` directly, the existing request initializers are unchanged; `WebviewLoginRequest` and `WebSessionLogoutRequest` also gain a convenience initializer taking `presenting: Presentation`, which lifts the conformance requirement there too.
 
 ### New features
 - New `WebProvider` to register a web provider (e.g. B.connect) with a `variant` and a completion `mode`. See the [ProviderCreator](https://developer.reachfive.com/sdk-ios/providerCreator.html) and [custom provider guide](https://developer.reachfive.com/sdk-ios/guides/custom-provider.html) documentation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,17 @@
 - ProviderCreator : the factory receives the ``ReachFive`` instance instead of sub-components, so that the creator can
   reuse high-level helpers such as `buildAuthorizeURL`,`authWithCode` or `webviewLogin`.
 
+- `Provider.login` takes a `Presentation` instead of a `UIViewController?`:
+
+  ```swift
+  // Before
+  try await provider.login(scope: scope, origin: origin, viewController: self)
+  // After
+  try await provider.login(scope: scope, origin: origin, presenting: Presentation(from: self))
+  ```
+
+  The view controller no longer needs to conform to `ASWebAuthenticationPresentationContextProviding` for web providers: the SDK derives the presentation context itself (a conforming view controller keeps precedence if you have one). It must simply be attached to a window at call time — call `login` from `viewDidAppear` or a user interaction, not from `viewDidLoad`. Conformance is still required when calling `webviewLogin` or `logout(webSessionLogout:)` directly, whose requests are unchanged.
+
 ### New features
 - New `WebProvider` to register a web provider (e.g. B.connect) with a `variant` and a completion `mode`. See the [ProviderCreator](https://developer.reachfive.com/sdk-ios/providerCreator.html) and [custom provider guide](https://developer.reachfive.com/sdk-ios/guides/custom-provider.html) documentation.
 - `webviewLogin` accepts a `webSessionMode` parameter picking how the `ASWebAuthenticationSession` returns: `.sdkScheme`, `.externalAppScheme`, `.externalAppUniversalLink(_:)` or `.inSheetUniversalLink(_:)` (iOS 17.4+). `WebProvider` takes the same choices.

--- a/Sandbox/Sandbox/Controllers/Social/LoginWithProvidersController.swift
+++ b/Sandbox/Sandbox/Controllers/Social/LoginWithProvidersController.swift
@@ -2,9 +2,8 @@ import UIKit
 import Reach5
 //TODO: import Reach5Facebook
 import AppTrackingTransparency
-import AuthenticationServices
 
-class LoginWithProvidersController: UIViewController, UITableViewDataSource, UITableViewDelegate, ASWebAuthenticationPresentationContextProviding {
+class LoginWithProvidersController: UIViewController, UITableViewDataSource, UITableViewDelegate {
     var providers: [Provider] = []
 
     @IBOutlet weak var providersTableView: UITableView!
@@ -55,7 +54,7 @@ class LoginWithProvidersController: UIViewController, UITableViewDataSource, UIT
             let scope = ["openid", "email", "profile", "phone", "full_write", "offline_access"]
             if let provider = AppDelegate.reachfive().getProvider(name: selectedProvider.name) {
                 await handleAuthToken(errorMessage: "Login with provider failed") {
-                    try await provider.login(scope: scope, origin: "LoginWithProvidersController.didSelectRowAt", viewController: self)
+                    try await provider.login(scope: scope, origin: "LoginWithProvidersController.didSelectRowAt", presenting: Presentation(from: self))
                 }
             }
         }
@@ -64,9 +63,5 @@ class LoginWithProvidersController: UIViewController, UITableViewDataSource, UIT
 
     func numberOfSections(in tableView: UITableView) -> Int {
         1
-    }
-
-    func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
-        view.window!
     }
 }

--- a/Sandbox/Sandbox/Tabs/ActionController.swift
+++ b/Sandbox/Sandbox/Tabs/ActionController.swift
@@ -60,31 +60,31 @@ class ActionController: UITableViewController {
                     }
                     await handleAuthToken {
                         // "secret" : Unicode 10.0 (2017) (bloc U+1B170–U+1B2FF)
-                        try await AppDelegate.reachfive().webviewLogin(WebviewLoginRequest(presentationContextProvider: self, origin: "ActionController.webviewLogin", loginUrlFragment: ["LoginURLParameter": "1234", "site": "Gourmet & L'Étudiant #1 / 100% déjanté?", "empty": "", "math": "a=b+c", "treats": "🥐☕️🎉", "secret": "\u{1B170}\u{1B171}\u{1B172}\u{1B173}\u{1B174}"]))
+                        try await AppDelegate.reachfive().webviewLogin(WebviewLoginRequest(presenting: Presentation(from: self), origin: "ActionController.webviewLogin", loginUrlFragment: ["LoginURLParameter": "1234", "site": "Gourmet & L'Étudiant #1 / 100% déjanté?", "empty": "", "math": "a=b+c", "treats": "🥐☕️🎉", "secret": "\u{1B170}\u{1B171}\u{1B172}\u{1B173}\u{1B174}"]))
                     }
                 }
 
-                // secure webview completing IN-BAND via an https universal link (intercepted in the sheet, iOS 17.4+)
+                // secure webview completing in-band via an https universal link (intercepted in the sheet, iOS 17.4+)
                 if indexPath.row == 1 {
                     guard #available(iOS 17.4, *) else { return }
                     let inSheetCallback = URL(string: "https://local-sandbox.og4.me/universal_link_internal")!
                     await handleAuthToken {
-                        try await AppDelegate.reachfive().webviewLogin(WebviewLoginRequest(presentationContextProvider: self, origin: "ActionController.webviewLogin.https", webSessionMode: .inSheetUniversalLink(inSheetCallback)))
+                        try await AppDelegate.reachfive().webviewLogin(WebviewLoginRequest(presenting: Presentation(from: self), origin: "ActionController.webviewLogin.https", webSessionMode: .inSheetUniversalLink(inSheetCallback)))
                     }
                 }
 
-                // secure webview handing off to an external app and returning OUT-OF-BAND via an https universal link
+                // secure webview handing off to an external app and returning out-of-band via an https universal link
                 if indexPath.row == 2 {
                     let externalAppCallback = URL(string: "https://local-sandbox.og4.me/_dev/mobile/callback")!
                     await handleAuthToken {
-                        try await AppDelegate.reachfive().webviewLogin(WebviewLoginRequest(presentationContextProvider: self, origin: "ActionController.webviewLogin.externalApp", webSessionMode: .externalAppUniversalLink(externalAppCallback)))
+                        try await AppDelegate.reachfive().webviewLogin(WebviewLoginRequest(presenting: Presentation(from: self), origin: "ActionController.webviewLogin.externalApp", webSessionMode: .externalAppUniversalLink(externalAppCallback)))
                     }
                 }
 
                 // secure webview handing off to an external app and returning OUT-OF-BAND via the custom scheme
                 if indexPath.row == 3 {
                     await handleAuthToken {
-                        try await AppDelegate.reachfive().webviewLogin(WebviewLoginRequest(presentationContextProvider: self, origin: "ActionController.webviewLogin.externalAppScheme", webSessionMode: .externalAppScheme))
+                        try await AppDelegate.reachfive().webviewLogin(WebviewLoginRequest(presenting: Presentation(from: self), origin: "ActionController.webviewLogin.externalAppScheme", webSessionMode: .externalAppScheme))
                     }
                 }
             }
@@ -122,11 +122,5 @@ class ActionController: UITableViewController {
         }
         #endif
         return indexPath
-    }
-}
-
-extension ActionController: ASWebAuthenticationPresentationContextProviding {
-    func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
-        view.window!
     }
 }

--- a/Sandbox/Sandbox/Tabs/ProfileController.swift
+++ b/Sandbox/Sandbox/Tabs/ProfileController.swift
@@ -1,5 +1,4 @@
 import UIKit
-import AuthenticationServices
 import Reach5
 
 //TODO:
@@ -289,7 +288,7 @@ extension ProfileController {
         Task {
 
             let request: WebSessionLogoutRequest? = if webLogout {
-                WebSessionLogoutRequest(presentationContextProvider: self, origin: "ProfileController.logoutAction")
+                try? WebSessionLogoutRequest(presenting: Presentation(from: self), origin: "ProfileController.logoutAction")
             } else { nil }
 
             let token: AuthToken? = if revoke {
@@ -439,12 +438,6 @@ extension ProfileController {
                 self.presentErrorAlert(title: "Remove identifier failed", error)
             }
         }
-    }
-}
-
-extension ProfileController: ASWebAuthenticationPresentationContextProviding {
-    func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
-        view.window!
     }
 }
 

--- a/Sources/Core/Classes/AppleProvider.swift
+++ b/Sources/Core/Classes/AppleProvider.swift
@@ -44,9 +44,9 @@ class ConfiguredAppleProvider: NSObject, Provider {
     public func login(
         scope: [String]?,
         origin: String,
-        viewController: UIViewController?
+        presenting: Presentation
     ) async throws -> AuthToken {
-        guard let window = await viewController?.view.window else { throw ReachFiveError.TechnicalError(reason: "The view was not in the app's view hierarchy!") }
+        let window = try await presenting.anchor()
 
         let scope: [String] = scope ?? clientConfigResponse.scope.components(separatedBy: " ")
         let request = NativeLoginRequest(anchor: window, originWebAuthn: "https://\(sdkConfig.domain)", scopes: scope, origin: origin)

--- a/Sources/Core/Classes/DefaultProvider.swift
+++ b/Sources/Core/Classes/DefaultProvider.swift
@@ -107,12 +107,10 @@ class DefaultProvider: NSObject, Provider {
     public func login(
         scope: [String]?,
         origin: String,
-        viewController: UIViewController?
+        presenting: Presentation
     ) async throws -> AuthToken {
 
-        guard let presentationContextProvider = viewController as? ASWebAuthenticationPresentationContextProviding else {
-            throw ReachFiveError.TechnicalError(reason: "No presenting viewController")
-        }
+        let presentationContextProvider = try await presenting.webAuthContextProvider()
 
         guard let webSessionMode else {
             throw ReachFiveError.TechnicalError(reason: "No universal link configured for provider \(name)")

--- a/Sources/Core/Classes/Presentation.swift
+++ b/Sources/Core/Classes/Presentation.swift
@@ -1,0 +1,75 @@
+import UIKit
+import AuthenticationServices
+
+/// Where provider UI (authentication sheets, sign-in dialogs) is presented from.
+///
+/// Create it from the view controller initiating the login, once it is attached to a window
+/// (i.e. from `viewDidAppear` or a user interaction, not from `viewDidLoad`):
+///
+/// ```swift
+/// try await provider.login(scope: scope, origin: origin, presenting: Presentation(from: self))
+/// ```
+///
+/// Each provider derives from it the exact form its underlying API needs — the view controller
+/// itself, its window, or an `ASWebAuthenticationSession` context provider. The view controller
+/// is held weakly: `Presentation` never retains it.
+@MainActor
+public struct Presentation {
+    private weak var viewController: UIViewController?
+
+    public init(from viewController: UIViewController) {
+        self.viewController = viewController
+    }
+
+    /// The view controller to present from (e.g. Google Sign-In dialogs).
+    ///
+    /// - Throws: `ReachFiveError.TechnicalError` if the view controller has been deallocated.
+    public func presentingViewController() throws -> UIViewController {
+        guard let viewController else {
+            throw ReachFiveError.TechnicalError(reason: "The presenting view controller no longer exists")
+        }
+        return viewController
+    }
+
+    /// The window the view controller is attached to (Sign In with Apple, passkeys).
+    ///
+    /// - Throws: `ReachFiveError.TechnicalError` if the view controller has been deallocated
+    ///   or is not attached to a window. Call `login()` after the view appeared
+    ///   (e.g. from `viewDidAppear`), not from `viewDidLoad`.
+    public func anchor() throws -> ASPresentationAnchor {
+        guard let window = try presentingViewController().view.window else {
+            throw ReachFiveError.TechnicalError(reason: "The presenting view controller is not attached to a window. Call login() after the view appeared (e.g. from viewDidAppear), not from viewDidLoad.")
+        }
+        return window
+    }
+
+    /// A context provider for `ASWebAuthenticationSession` (web providers).
+    ///
+    /// If the view controller conforms to `ASWebAuthenticationPresentationContextProviding`
+    /// it is returned as-is, so an anchor chosen by the app keeps precedence. Otherwise an
+    /// SDK adapter resolving the view controller's window on demand is returned.
+    ///
+    /// - Throws: `ReachFiveError.TechnicalError` if the view controller has been deallocated.
+    public func webAuthContextProvider() throws -> ASWebAuthenticationPresentationContextProviding {
+        let viewController = try presentingViewController()
+        if let contextProvider = viewController as? ASWebAuthenticationPresentationContextProviding {
+            return contextProvider
+        }
+        return ViewControllerContextProvider(viewController)
+    }
+}
+
+// `ASWebAuthenticationSession.presentationContextProvider` est `weak` : l'adaptateur doit être
+// retenu ailleurs pendant la session. C'est le cas via `WebviewLoginRequest.presentationContextProvider`
+// (`let` fort), vivant pendant tout `webviewLogin` → `webAuthSession.start(...)`.
+private final class ViewControllerContextProvider: NSObject, ASWebAuthenticationPresentationContextProviding {
+    private weak var viewController: UIViewController?
+
+    init(_ viewController: UIViewController) {
+        self.viewController = viewController
+    }
+
+    func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
+        viewController?.view.window ?? ASPresentationAnchor()
+    }
+}

--- a/Sources/Core/Classes/Provider.swift
+++ b/Sources/Core/Classes/Provider.swift
@@ -16,7 +16,17 @@ public protocol ProviderCreator {
 
 public protocol Provider {
     var name: String { get }
-    func login(scope: [String]?, origin: String, viewController: UIViewController?) async throws -> AuthToken
+    /// Starts the provider's login flow and returns the ReachFive token on success.
+    ///
+    /// - Parameters:
+    ///   - scope: The scopes to request; `nil` falls back to the client configuration's scope.
+    ///   - origin: Free-form origin string recorded in user events.
+    ///   - presenting: Where the provider presents its UI, built from the initiating view
+    ///     controller: `Presentation(from: self)`. The view controller must be attached to a
+    ///     window at call time (call from `viewDidAppear` or a user interaction, not
+    ///     `viewDidLoad`), otherwise the login fails with a `TechnicalError`. Providers that
+    ///     present no UI of their own ignore it.
+    func login(scope: [String]?, origin: String, presenting: Presentation) async throws -> AuthToken
     func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any]) -> Bool
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool
     func applicationDidBecomeActive(_ application: UIApplication)

--- a/Sources/Core/Classes/models/requests/WebSessionLogoutRequest.swift
+++ b/Sources/Core/Classes/models/requests/WebSessionLogoutRequest.swift
@@ -9,4 +9,14 @@ public class WebSessionLogoutRequest {
         self.presentationContextProvider = presentationContextProvider
         self.origin = origin
     }
+
+    /// Same as ``init(presentationContextProvider:origin:)``, but derives the presentation
+    /// context from a ``Presentation``, so the view controller does not need to conform
+    /// to `ASWebAuthenticationPresentationContextProviding`.
+    ///
+    /// - Throws: `ReachFiveError.TechnicalError` if the view controller has been deallocated.
+    @MainActor
+    public convenience init(presenting: Presentation, origin: String? = nil) throws {
+        self.init(presentationContextProvider: try presenting.webAuthContextProvider(), origin: origin)
+    }
 }

--- a/Sources/Core/Classes/models/requests/WebviewLoginRequest.swift
+++ b/Sources/Core/Classes/models/requests/WebviewLoginRequest.swift
@@ -41,4 +41,34 @@ public class WebviewLoginRequest {
         self.webSessionMode = webSessionMode
         self.loginUrlFragment = loginUrlFragment
     }
+
+    /// Same as ``init(state:nonce:scope:presentationContextProvider:origin:provider:prefersEphemeralWebBrowserSession:webSessionMode:)``,
+    /// but derives the presentation context from a ``Presentation``, so the view controller
+    /// does not need to conform to `ASWebAuthenticationPresentationContextProviding`.
+    ///
+    /// - Throws: `ReachFiveError.TechnicalError` if the view controller has been deallocated.
+    @MainActor
+    public convenience init(
+        state: String? = nil,
+        nonce: String? = nil,
+        scope: [String]? = nil,
+        presenting: Presentation,
+        origin: String? = nil,
+        provider: String? = nil,
+        prefersEphemeralWebBrowserSession: Bool = false,
+        webSessionMode: WebSessionMode = .sdkScheme,
+        loginUrlFragment: [String: String]? = nil
+    ) throws {
+        self.init(
+            state: state,
+            nonce: nonce,
+            scope: scope,
+            presentationContextProvider: try presenting.webAuthContextProvider(),
+            origin: origin,
+            provider: provider,
+            prefersEphemeralWebBrowserSession: prefersEphemeralWebBrowserSession,
+            webSessionMode: webSessionMode,
+            loginUrlFragment: loginUrlFragment
+        )
+    }
 }

--- a/Tests/Reach5Tests/PresentationTests.swift
+++ b/Tests/Reach5Tests/PresentationTests.swift
@@ -114,4 +114,18 @@ final class PresentationTests: XCTestCase {
         XCTAssertNotIdentical(firstAnchor, secondAnchor,
                               "l'anchor de repli doit être reconstruite à chaque appel, pas mise en cache")
     }
+
+    // MARK: - Inits de commodité des requêtes
+
+    func testWebviewLoginRequestConvenienceInitDerivesTheContextProvider() throws {
+        let vc = ConformingViewController()
+        let request = try WebviewLoginRequest(presenting: Presentation(from: vc))
+        XCTAssertIdentical(request.presentationContextProvider, vc)
+    }
+
+    func testWebSessionLogoutRequestConvenienceInitDerivesTheContextProvider() throws {
+        let vc = ConformingViewController()
+        let request = try WebSessionLogoutRequest(presenting: Presentation(from: vc))
+        XCTAssertIdentical(request.presentationContextProvider, vc)
+    }
 }

--- a/Tests/Reach5Tests/PresentationTests.swift
+++ b/Tests/Reach5Tests/PresentationTests.swift
@@ -97,4 +97,21 @@ final class PresentationTests: XCTestCase {
         XCTAssertNil(weakVC, "l'adaptateur ne doit pas retenir le view controller")
         _ = provider
     }
+
+    func testWebAuthContextProviderAdapterFallsBackSilentlyWhenViewControllerIsDeallocated() throws {
+        // Documente le comportement actuel : si le view controller est désalloué entre la
+        // création de l'adaptateur et l'appel du callback par ASWebAuthenticationSession,
+        // aucune erreur n'est levée (le callback n'est pas throwing) — l'adaptateur retombe
+        // silencieusement sur une anchor de repli fraîchement créée plutôt que de signaler l'échec.
+        var vc: UIViewController? = UIViewController()
+        let provider = try Presentation(from: vc!).webAuthContextProvider()
+        weak var weakVC = vc
+        vc = nil
+        XCTAssertNil(weakVC, "précondition : le view controller doit être réellement désalloué")
+
+        let firstAnchor = provider.presentationAnchor(for: makeSession())
+        let secondAnchor = provider.presentationAnchor(for: makeSession())
+        XCTAssertNotIdentical(firstAnchor, secondAnchor,
+                              "l'anchor de repli doit être reconstruite à chaque appel, pas mise en cache")
+    }
 }

--- a/Tests/Reach5Tests/PresentationTests.swift
+++ b/Tests/Reach5Tests/PresentationTests.swift
@@ -1,0 +1,100 @@
+import XCTest
+import UIKit
+import AuthenticationServices
+@testable import Reach5
+
+/// VC conformant au protocole : `webAuthContextProvider()` doit le retourner tel quel
+/// pour préserver un anchor choisi par l'app.
+private final class ConformingViewController: UIViewController, ASWebAuthenticationPresentationContextProviding {
+    func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
+        view.window!
+    }
+}
+
+@MainActor
+final class PresentationTests: XCTestCase {
+
+    private func makeSession() -> ASWebAuthenticationSession {
+        ASWebAuthenticationSession(url: URL(string: "https://example.com")!, callbackURLScheme: "test") { _, _ in }
+    }
+
+    private func assertThrowsTechnicalError<T>(_ expression: @autoclosure () throws -> T, reasonContains fragment: String, _ message: String) {
+        XCTAssertThrowsError(try expression()) { error in
+            guard case ReachFiveError.TechnicalError(let reason, _) = error else {
+                return XCTFail("\(message) : attendu TechnicalError, obtenu \(error)")
+            }
+            XCTAssertTrue(reason.contains(fragment), "\(message) : raison inattendue « \(reason) »")
+        }
+    }
+
+    // MARK: - presentingViewController
+
+    func testPresentingViewControllerReturnsTheViewController() throws {
+        let vc = UIViewController()
+        let presentation = Presentation(from: vc)
+        XCTAssertIdentical(try presentation.presentingViewController(), vc)
+    }
+
+    func testResolversThrowWhenViewControllerIsDeallocated() {
+        var vc: UIViewController? = UIViewController()
+        let presentation = Presentation(from: vc!)
+        vc = nil
+
+        assertThrowsTechnicalError(try presentation.presentingViewController(), reasonContains: "no longer exists",
+                                   "presentingViewController après désallocation")
+        assertThrowsTechnicalError(try presentation.anchor(), reasonContains: "no longer exists",
+                                   "anchor après désallocation")
+        assertThrowsTechnicalError(try presentation.webAuthContextProvider(), reasonContains: "no longer exists",
+                                   "webAuthContextProvider après désallocation")
+    }
+
+    // MARK: - anchor
+
+    func testAnchorThrowsWhenViewControllerIsNotAttachedToAWindow() {
+        // Référence forte locale : Presentation ne retient pas le VC (weak).
+        let vc = UIViewController()
+        let presentation = Presentation(from: vc)
+        assertThrowsTechnicalError(try presentation.anchor(), reasonContains: "not attached to a window",
+                                   "anchor sans fenêtre")
+    }
+
+    func testAnchorReturnsTheWindowWhenAttached() throws {
+        let vc = UIViewController()
+        let window = UIWindow()
+        window.rootViewController = vc
+        window.makeKeyAndVisible()
+
+        XCTAssertIdentical(try Presentation(from: vc).anchor(), window)
+    }
+
+    // MARK: - webAuthContextProvider
+
+    func testWebAuthContextProviderReturnsAConformingViewControllerAsIs() throws {
+        let vc = ConformingViewController()
+        let provider = try Presentation(from: vc).webAuthContextProvider()
+        XCTAssertIdentical(provider, vc)
+    }
+
+    func testWebAuthContextProviderAdapterResolvesTheWindowLazily() throws {
+        let vc = UIViewController()
+        let provider = try Presentation(from: vc).webAuthContextProvider()
+        XCTAssertNotIdentical(provider, vc)
+
+        // La fenêtre est attachée APRÈS la création de l'adaptateur : elle doit
+        // quand même être résolue, preuve que la résolution est paresseuse.
+        let window = UIWindow()
+        window.rootViewController = vc
+        window.makeKeyAndVisible()
+
+        XCTAssertIdentical(provider.presentationAnchor(for: makeSession()), window)
+    }
+
+    func testWebAuthContextProviderAdapterDoesNotRetainTheViewController() throws {
+        var vc: UIViewController? = UIViewController()
+        let provider = try Presentation(from: vc!).webAuthContextProvider()
+        weak var weakVC = vc
+        vc = nil
+        XCTAssertNil(weakVC, "l'adaptateur ne doit pas retenir le view controller")
+        _ = provider
+    }
+}

--- a/docs/modules/ROOT/examples/customProviderProtocols.swift
+++ b/docs/modules/ROOT/examples/customProviderProtocols.swift
@@ -7,7 +7,7 @@ public protocol ProviderCreator {
 
 public protocol Provider {
     var name: String { get }
-    func login(scope: [String]?, origin: String, viewController: UIViewController?) async throws -> AuthToken
+    func login(scope: [String]?, origin: String, presenting: Presentation) async throws -> AuthToken
     func logout() async throws
 
     // Default (no-op) implementations provided — override only what your provider needs:

--- a/docs/modules/ROOT/examples/customProviderWrappingNativeSDK.swift
+++ b/docs/modules/ROOT/examples/customProviderWrappingNativeSDK.swift
@@ -20,11 +20,9 @@ class ConfiguredMyProvider: NSObject, Provider {
         self.reachFive = reachFive
     }
 
-    func login(scope: [String]?, origin: String, viewController: UIViewController?) async throws -> AuthToken {
-        guard let viewController else { throw ReachFiveError.TechnicalError(reason: "No presenting view controller") }
-
+    func login(scope: [String]?, origin: String, presenting: Presentation) async throws -> AuthToken {
         // 1. Drive your native SDK's own login UI/flow here, e.g.:
-        let code = try await MyNativeSDK.shared.login(presenting: viewController)
+        let code = try await MyNativeSDK.shared.login(presenting: presenting.presentingViewController())
 
         // 2. Exchange its authorization code for a ReachFive AuthToken.
         guard let reachFive else { throw ReachFiveError.TechnicalError(reason: "ReachFive instance was deallocated") }

--- a/docs/modules/ROOT/examples/getProviderAndLogin.swift
+++ b/docs/modules/ROOT/examples/getProviderAndLogin.swift
@@ -9,7 +9,7 @@ do {
         let authToken = try await provider.login(
             scope: scope,
             origin: "home",
-            viewController: self
+            presenting: Presentation(from: self)
         )
         // Get the profile's authentication token
     }

--- a/docs/modules/ROOT/examples/logout.swift
+++ b/docs/modules/ROOT/examples/logout.swift
@@ -18,12 +18,8 @@ do {
 
 // Web-based logout with redirect
 do {
-    let WebSessionLogoutRequest = WebSessionLogoutRequest(
-        presentationContextProvider: // Provide a context provider, e.g., a view controller
-        ,
-        origin: "app_logout"
-    )
-    try await AppDelegate.reachfive().logout(webSessionLogout: WebSessionLogoutRequest)
+    let request = try WebSessionLogoutRequest(presenting: Presentation(from: self), origin: "app_logout")
+    try await AppDelegate.reachfive().logout(webSessionLogout: request)
     // Browser cookies are cleared, user is redirected
 } catch {
     // Handle ReachFiveError

--- a/docs/modules/ROOT/examples/webviewLogin.swift
+++ b/docs/modules/ROOT/examples/webviewLogin.swift
@@ -3,7 +3,7 @@ do {
         state: "zf3ifjfmdkj",
         nonce: "n-0S6_PzA3Ze",
         scope: ["openid", "profile", "email"],
-        presentationContextProvider: self
+        presenting: Presentation(from: self)
     ))
     // Get the profile's authentication token
 } catch {

--- a/docs/modules/ROOT/pages/getProvider.adoc
+++ b/docs/modules/ROOT/pages/getProvider.adoc
@@ -19,22 +19,20 @@ Refer at the iOS SDK Installation to initialize the providers at the client's in
 
 == Usage
 
-When calling `.login`, pass a link:https://developer.apple.com/documentation/uikit/uiviewcontroller[UIViewController^] as the <<Examples,`viewController`>> argument.
-Whether it must implement link:https://developer.apple.com/documentation/authenticationservices/aswebauthenticationpresentationcontextproviding[`ASWebAuthenticationPresentationContextProviding`^] depends on how the provider authenticates:
-
-* *Required* for web-based providers: xref:providerCreator.adoc[`WebProvider`], and any provider with no matching native creator (falls back to `DefaultProvider`).
-These open an `ASWebAuthenticationSession` and need a presentation anchor.
-* *Not required* for native SDK providers (`GoogleProvider`, `FacebookProvider`, `WeChat`).
-`AppleProvider` needs the view controller in the app's view hierarchy instead.
-
-Add the following to your `UIViewController` when the protocol is required:
+For `.login`, pass the initiating link:https://developer.apple.com/documentation/uikit/uiviewcontroller[UIViewController^] wrapped in a `Presentation`:
 
 [source,swift]
 ----
-func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
-    view.window!
-}
+try await provider.login(scope: scope, origin: origin, presenting: Presentation(from: self))
 ----
+
+Each provider derives what it needs from it, depending on how it authenticates:
+
+* Web-based providers (xref:providerCreator.adoc[`WebProvider`], and any provider with no matching native creator, falling back to `DefaultProvider`) open an `ASWebAuthenticationSession` and need a presentation context. The SDK derives one from the view controller; if it already implements link:https://developer.apple.com/documentation/authenticationservices/aswebauthenticationpresentationcontextproviding[`ASWebAuthenticationPresentationContextProviding`^], its own `presentationAnchor(for:)` keeps precedence.
+* `AppleProvider` needs the view controller to be attached to a window at call time.
+* Native SDK providers (`GoogleProvider`, `FacebookProvider`, `WeChat`) need only the view controller itself, or nothing at all.
+
+In every case, call `.login` from `viewDidAppear` or a user interaction, not from `viewDidLoad`, so the view controller is attached to a window.
 
 == Examples
 

--- a/docs/modules/ROOT/pages/providerCreator.adoc
+++ b/docs/modules/ROOT/pages/providerCreator.adoc
@@ -50,7 +50,7 @@ Login may hand off to an external app (e.g. a banking app) that reopens yours vi
 * [ ] Initialize the SDK so provider configurations are fetched and `getProvider` can resolve your provider (see xref:application/applicationDidFinishLaunchingWithOptions.adoc[`applicationDidFinishLaunchingWithOptions(_:)`]).
 * [ ] Add `applinks:$\{host\}` to Associated Domains and the matching `applinks` section in `apple-app-site-association` (see xref:index.adoc#associated-domains-universal-link-providers[`apple-app-site-association`]).
 * [ ] Forward `application(_:continue:restorationHandler:)` to {company} and honour the returned `Bool` (see xref:application/applicationContinueUserActivity.adoc[`application(_:continue:restorationHandler:)`]).
-* [ ] Call xref:getProvider.adoc[`getProvider(name:).login(...)`] from a `UIViewController` that implements `ASWebAuthenticationPresentationContextProviding`.
+* [ ] Call xref:getProvider.adoc[`getProvider(name:).login(...)`] with a `Presentation` built from a `UIViewController` attached to a window; see xref:getProvider.adoc[] for details.
 
 Do *not* use xref:loadLoginWebview.adoc[`loadLoginWebview`]: the callback is delivered through xref:application/applicationContinueUserActivity.adoc[`application(_:continue:)`], not an embedded webview.
 
@@ -67,7 +67,7 @@ This is the same flow as the default custom-scheme login, but the OAuth `redirec
 * [ ] Register a <<WebProvider,`WebProvider`>> with `mode: .universalLink` in `ReachFive(providersCreators:)` (iOS 17.4+).
 * [ ] Initialize the SDK so provider configurations are fetched and `getProvider` can resolve your provider (see xref:application/applicationDidFinishLaunchingWithOptions.adoc[`applicationDidFinishLaunchingWithOptions(_:)`]).
 * [ ] Add `webcredentials:$\{host\}` to Associated Domains and the matching `webcredentials` section in `apple-app-site-association` (see xref:index.adoc#associated-domains-universal-link-providers[`apple-app-site-association`]).
-* [ ] Call xref:getProvider.adoc[`getProvider(name:).login(...)`] from a `UIViewController` that implements `ASWebAuthenticationPresentationContextProviding`.
+* [ ] Call xref:getProvider.adoc[`getProvider(name:).login(...)`] with a `Presentation` built from a `UIViewController` attached to a window; see xref:getProvider.adoc[] for details.
 
 No `application(_:continue:)` wiring is required for login completion; the `ASWebAuthenticationSession` completes inside the sheet.
 

--- a/docs/modules/ROOT/pages/webviewLogin.adoc
+++ b/docs/modules/ROOT/pages/webviewLogin.adoc
@@ -41,9 +41,9 @@ image::sdk-ios:ROOT:secure-login-dialog.png[width=500px,role=zoom]
 
 == Usage
 
-Because of the <<presentationContextProvider,`presentationContextProvider`>> property, you must ensure that your link:https://developer.apple.com/documentation/uikit/uiviewcontroller[UIViewController^] implements the `ASWebAuthenticationPresentationContextProviding` protocol.
+Build the request with `presenting: Presentation(from: self)` from the initiating link:https://developer.apple.com/documentation/uikit/uiviewcontroller[UIViewController^]: the SDK derives the presentation context itself, as it does for xref:getProvider.adoc[`provider.login`].
 
-To do this, add the following to your UIViewController:
+Alternatively, pass your own <<presentationContextProvider,`presentationContextProvider`>> — any object implementing `ASWebAuthenticationPresentationContextProviding`, for instance the view controller itself:
 
 [source,swift]
 ----

--- a/docs/modules/ROOT/partials/models.adoc
+++ b/docs/modules/ROOT/partials/models.adoc
@@ -156,7 +156,7 @@ The provider which name matches the name passed in argument.
 
 - `scope` `[String]`: the list of the profile’s scopes. Make sure they are allowed by the client. Default scopes are the allowed scopes set up in the client’s configuration.
 - `origin` `String`: the origin of the call
-- `viewController` `UIViewController`: the class that manages the views of your iOS app.
+- `presenting` `Presentation`: where the provider presents its UI. Build it from the initiating view controller: `Presentation(from: self)`. The view controller must be attached to a window at call time.
 
 It authenticates the profile with the provider otherwise it returns a `ReachFiveError`.
 | logout `function` | No argument is expected. Kill the SSO session of the profile otherwise returns a `ReachFiveError`.


### PR DESCRIPTION
The viewController parameter had a hidden requirement: sometimes it needed to conform to ASWebAuthenticationPresentationContextProviding, and the error incorrectly complained that the controller was not viewController.
AppleProvider only needed an ASPresentationAnchor, the error message is clearer now.