### PR TITLE
Ouvrir DictionaryEncodable pour que les classes de modèle soient vraiment publiques

### DIFF
--- a/Sources/Core/Classes/utils/DictionaryEncodable.swift
+++ b/Sources/Core/Classes/utils/DictionaryEncodable.swift
@@ -1,15 +1,15 @@
 import Foundation
 
-protocol DictionaryEncodable: Encodable {}
+public protocol DictionaryEncodable: Encodable {}
 
 extension DictionaryEncodable {
-    func dictionary() -> [String: Any]? {
+    public func dictionary() -> [String: Any]? {
         let encoder = JSONEncoder()
         encoder.keyEncodingStrategy = .convertToSnakeCase
         encoder.dateEncodingStrategy = .millisecondsSince1970
         guard let json = try? encoder.encode(self),
-              let dict = try? JSONSerialization.jsonObject(with: json, options: []) as? [String: Any]
-        else {
+              let dict = try? JSONSerialization.jsonObject(with: json, options: []) as? [String: Any] else
+        {
             return nil
         }
         return dict


### PR DESCRIPTION
Pouvoir utiliser la méthode `dictionary` pour encoder les classes de modèles, ce qui permet de profiter pleinement de celles-ci