### PR TITLE
Fix configuration example and clean up docs navigation

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -1,7 +1,6 @@
 * Introduction icon:book[]
 ** xref:index.adoc[]
 ** xref:guides/use-cases.adoc[]
-// ** xref:guides/auth-ios.adoc[]
 ** xref:reference/errors.adoc[]
 
 .Guides icon:book[]

--- a/docs/modules/ROOT/partials/r_configure.adoc
+++ b/docs/modules/ROOT/partials/r_configure.adoc
@@ -30,6 +30,9 @@ Available from version `6.3.0`.
 
 Available from version `7.0.0`.
 
+|reachfive-$\{clientId\}://email-verification
+|This callback URL is used to return to the app after email verification.
+
 |===
 
 == Configuration
@@ -60,15 +63,17 @@ let ReachFive = ReachFive(
     sdkConfig: SdkConfig(
         domain: DOMAIN,
         clientId: CLIENT_ID,
-        scheme: "reachfive-${clientId}://myOwnScheme", <1>
-        mfaUri: "reachfive-${clientId}://myOwnMfaScheme", <2>
-        accountRecoveryUri: "reachfive-${clientId}://myOwnRecoveryScheme" <3>
+        customScheme: "myOwnScheme", <1>
+        mfaUri: URL(string: "myOwnScheme://myOwnMfaPath")!, <2>
+        accountRecoveryUri: URL(string: "myOwnScheme://myOwnRecoveryPath")!, <3>
+        emailVerificationUri: URL(string: "myOwnScheme://myOwnEmailVerificationPath")! <4>
     )
 )
 ----
-<1> Where the callback `scheme` ends with `myOwnScheme`.
-<2> Where the callback mfaUri `scheme` ends with `myOwnMfaScheme`.
-<3> Where the callback accountRecoveryUri `scheme` ends with `myOwnRecoveryScheme`.
+<1> The custom URL scheme. Pass the scheme only (no `://`); it replaces the default `reachfive-${clientId}`. Every callback URI that you don't override explicitly is then derived from it (`myOwnScheme://callback`, `myOwnScheme://mfa`, and so on).
+<2> Overrides the full MFA callback URI.
+<3> Overrides the full account recovery callback URI.
+<4> Overrides the full email verification callback URI.
 
 === Customise storage
 
@@ -85,7 +90,7 @@ let ReachFive = ReachFive(
         domain: DOMAIN,
         clientId: CLIENT_ID
     ),
-    storage: UserDefaultsStorage()
+    storage: UserDefaultsStorage() <1>
 )
 ----
 <1> This value can be any object that implements our `Storage` protocol.


### PR DESCRIPTION
## Context

Audit of the SDK's public surface (everything an integrator can call) compared against `docs/`. This PR fixes a configuration documentation error found during that audit. Documentation only — no code changes.

## Configuration fixes (`r_configure`)

- Non-existent parameter `scheme:` → `customScheme:`, with the example values made consistent (bare scheme vs `URL` for the per-URI overrides) and `emailVerificationUri` added.
- Added the `reachfive-${clientId}://email-verification` scheme to the "Allowed Callback URLs" table.

## Navigation

- Removed the dead link to the "Legacy SDK" guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)