### PR TITLE
Corrige les 20 bugs de doc listés au baseline du harnais d'exemples

### DIFF
--- a/docs/modules/ROOT/examples/addPasswordlessCallback.swift
+++ b/docs/modules/ROOT/examples/addPasswordlessCallback.swift
@@ -8,9 +8,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     ) -> Bool {
       AppDelegate.reachfive().addPasswordlessCallback { result in
         switch (result) {
-          case .success(authToken):
+          case .success(let authToken):
             // Handle authToken
-          case .failure(error):
+          case .failure(let error):
             // Handle error
           }
       }

--- a/docs/modules/ROOT/examples/listWebAuthnDevices.swift
+++ b/docs/modules/ROOT/examples/listWebAuthnDevices.swift
@@ -3,7 +3,7 @@ import Reach5
 let profileAuthToken: AuthToken = // Here paste the authorization token of the profile retrieved after login
 
 do {
-    let listDevices = try await AppDelegate.reachfive().listWebAuthnDevices(authToken: profileAuthToken)
+    let listDevices = try await AppDelegate.reachfive().listWebAuthnCredentials(authToken: profileAuthToken)
     // Get the list of devices
 } catch {
     // Return a ReachFive error

--- a/docs/modules/ROOT/examples/logout.swift
+++ b/docs/modules/ROOT/examples/logout.swift
@@ -19,8 +19,9 @@ do {
 // Web-based logout with redirect
 do {
     let WebSessionLogoutRequest = WebSessionLogoutRequest(
-        origin: "app_logout",
         presentationContextProvider: // Provide a context provider, e.g., a view controller
+        ,
+        origin: "app_logout"
     )
     try await AppDelegate.reachfive().logout(webSessionLogout: WebSessionLogoutRequest)
     // Browser cookies are cleared, user is redirected

--- a/docs/modules/ROOT/examples/mfaDeleteCredentialPhoneNumber.swift
+++ b/docs/modules/ROOT/examples/mfaDeleteCredentialPhoneNumber.swift
@@ -2,7 +2,7 @@ import Reach5
 
 do {
     try await AppDelegate.reachfive().mfaDeleteCredential(
-        phoneNumber: "+33682234940",
+        "+33682234940",
         authToken: profileAuthToken
     )
     // Do something

--- a/docs/modules/ROOT/examples/mfaStartWithEmail.swift
+++ b/docs/modules/ROOT/examples/mfaStartWithEmail.swift
@@ -2,7 +2,7 @@ import Reach5
 
 do {
     let response = try await AppDelegate.reachfive().mfaStart(
-        registering: .Email(redirectUri: "reachfive-${clientId}://callback"),
+        registering: .Email(redirectUrl: URL(string: "reachfive-${clientId}://callback")!),
         authToken: profileAuthToken
     )
     // Do something

--- a/docs/modules/ROOT/examples/mfaStartWithPhoneNumber.swift
+++ b/docs/modules/ROOT/examples/mfaStartWithPhoneNumber.swift
@@ -2,7 +2,7 @@ import Reach5
 
 do {
     let response = try await AppDelegate.reachfive().mfaStart(
-        registering: .PhoneNumber(phoneNumber: "+3531235555"),
+        registering: .PhoneNumber("+3531235555"),
         authToken: profileAuthToken
     )
     // Do something

--- a/docs/modules/ROOT/examples/mfaStartWithStepUp.swift
+++ b/docs/modules/ROOT/examples/mfaStartWithStepUp.swift
@@ -5,7 +5,7 @@ let scope = ["openid", "email", "profile", "phone", "full_write", "offline_acces
 do {
     let response = try await AppDelegate.reachfive().mfaStart(
         stepUp: .AuthTokenFlow(
-            authType: "email",
+            authType: .email,
             authToken: profileAuthToken,
             scope: scope
         )

--- a/docs/modules/ROOT/examples/mfaStartWithStepUpLoginFlow.swift
+++ b/docs/modules/ROOT/examples/mfaStartWithStepUpLoginFlow.swift
@@ -5,9 +5,9 @@ let scope = ["openid", "email", "profile", "phone", "full_write", "offline_acces
 do {
     let response = try await AppDelegate.reachfive().mfaStart(
         stepUp: .LoginFlow(
-            authType: "email",
+            authType: .email,
             stepUpToken: "stepUpToken123",
-            redirectUri: "https://example.com/callback",
+            redirectUri: URL(string: "https://example.com/callback")!,
             origin: "ios-app"
         )
     )

--- a/docs/modules/ROOT/examples/refreshAccessToken.swift
+++ b/docs/modules/ROOT/examples/refreshAccessToken.swift
@@ -3,7 +3,7 @@ import Reach5
 let authToken: AuthToken = // The authentication token obtained from login or signup.
 
 do {
-    let refreshedAuthToken = try await AppDelegate.reachfive().refreshAccessToken(authToken)
+    let refreshedAuthToken = try await AppDelegate.reachfive().refreshAccessToken(authToken: authToken)
     // Do something
 } catch {
     // Return a ReachFive error

--- a/docs/modules/ROOT/examples/requestAccountRecoveryWithEmail.swift
+++ b/docs/modules/ROOT/examples/requestAccountRecoveryWithEmail.swift
@@ -1,7 +1,7 @@
 do {
     try await AppDelegate.reachfive().requestAccountRecovery(
         email: "john.doe@gmail.com",
-        redirectUrl: "reachfive-clientId://account-recovery"
+        redirectUrl: URL(string: "reachfive-clientId://account-recovery")!
     )
     // Do something
 } catch {

--- a/docs/modules/ROOT/examples/requestAccountRecoveryWithPhoneNumber.swift
+++ b/docs/modules/ROOT/examples/requestAccountRecoveryWithPhoneNumber.swift
@@ -1,7 +1,7 @@
 do {
     try await AppDelegate.reachfive().requestAccountRecovery(
         phoneNumber: "+33682234940",
-        redirectUrl: "https://example-password-reset.com"
+        redirectUrl: URL(string: "https://example-password-reset.com")!
     )
     // Do something
 } catch {

--- a/docs/modules/ROOT/examples/requestPasswordResetWithEmail.swift
+++ b/docs/modules/ROOT/examples/requestPasswordResetWithEmail.swift
@@ -1,7 +1,7 @@
 do {
     try await AppDelegate.reachfive().requestPasswordReset(
         email: "john.doe@gmail.com",
-        redirectUrl: "reachfive-clientId://password-reset"
+        redirectUrl: URL(string: "reachfive-clientId://password-reset")!
     )
     // Do something
 } catch {

--- a/docs/modules/ROOT/examples/sendEmailVerification.swift
+++ b/docs/modules/ROOT/examples/sendEmailVerification.swift
@@ -5,7 +5,7 @@ let profileAuthToken: AuthToken = // Here paste the authorization token of the p
 do {
     let emailVerificationResponse = try await AppDelegate.reachfive().sendEmailVerification(
         authToken: profileAuthToken,
-        redirectUrl: "https://example-email-verification.com" // optional
+        redirectUrl: URL(string: "https://example-email-verification.com")! // optional
     )
     switch emailVerificationResponse {
     case .Success:

--- a/docs/modules/ROOT/examples/signupWithEmail.swift
+++ b/docs/modules/ROOT/examples/signupWithEmail.swift
@@ -3,19 +3,19 @@ import Reach5
 do {
     let signupFlow = try await AppDelegate.reachfive().signup(
         profile: ProfileSignupRequest(
-            givenName: "John",
-            familyName: "Doe",
-            gender: "male",
+            password: "hjk90wxc",
             email: "john.doe@gmail.com",
             customIdentifier: "coolCat55",
-            password: "hjk90wxc"
+            givenName: "John",
+            familyName: "Doe",
+            gender: "male"
         ),
-        redirectUrl: "https://www.example.com/redirect",
+        redirectUrl: URL(string: "https://www.example.com/redirect")!,
         scope: ["openid", "profile", "email"]
     )
 
     switch signupFlow {
-    case .AchievedLogin(authToken: AuthToken):
+    case .AchievedLogin(authToken: let authToken):
         // Signup completed and user is logged in
         // Use authToken as needed
     case .AwaitingIdentifierVerification:

--- a/docs/modules/ROOT/examples/signupWithPhoneNumber.swift
+++ b/docs/modules/ROOT/examples/signupWithPhoneNumber.swift
@@ -3,18 +3,18 @@ import Reach5
 do {
     let signupFlow = try await AppDelegate.reachfive().signup(
         profile: ProfileSignupRequest(
-            givenName: "John",
-            familyName: "Doe",
-            gender: "male",
+            password: "hjk90wxc",
             phoneNumber: "+353875551234",
             customIdentifier: "coolCat55",
-            password: "hjk90wxc"
+            givenName: "John",
+            familyName: "Doe",
+            gender: "male"
         ),
         scope: ["openid", "profile", "phone"]
     )
 
     switch signupFlow {
-    case .AchievedLogin(authToken: AuthToken):
+    case .AchievedLogin(authToken: let authToken):
         // Signup completed and user is logged in
         // Use authToken as needed
     case .AwaitingIdentifierVerification:

--- a/docs/modules/ROOT/examples/startPasswordlessWithEmail.swift
+++ b/docs/modules/ROOT/examples/startPasswordlessWithEmail.swift
@@ -1,7 +1,10 @@
 import Reach5
 
 do {
-    try await AppDelegate.reachfive().startPasswordless(.Email(email: "john.doe@gmail.com"))
+    try await AppDelegate.reachfive().startPasswordless(.Email(
+        email: "john.doe@gmail.com",
+        redirectUri: URL(string: "reachfive-${clientId}://callback")!
+    ))
     // Do something
 } catch {
     // Return a ReachFive error

--- a/docs/modules/ROOT/examples/startPasswordlessWithPhoneNumber.swift
+++ b/docs/modules/ROOT/examples/startPasswordlessWithPhoneNumber.swift
@@ -1,7 +1,10 @@
 import Reach5
 
 do {
-    try await AppDelegate.reachfive().startPasswordless(.PhoneNumber(phoneNumber: "+33792244940"))
+    try await AppDelegate.reachfive().startPasswordless(.PhoneNumber(
+        phoneNumber: "+33792244940",
+        redirectUri: URL(string: "reachfive-${clientId}://callback")!
+    ))
     // Do something
 } catch {
     // Return a ReachFive error

--- a/docs/modules/ROOT/examples/updateEmail.swift
+++ b/docs/modules/ROOT/examples/updateEmail.swift
@@ -6,7 +6,7 @@ do {
     let updatedProfile = try await AppDelegate.reachfive().updateEmail(
         authToken: profileAuthToken,
         email: "johnatthan.doe@gmail.com",
-        redirectUrl: "https://example-email-update.com"
+        redirectUrl: URL(string: "https://example-email-update.com")!
     )
     // Get the updated profile
 } catch {

--- a/docs/modules/ROOT/examples/updatePasswordWithAccessToken.swift
+++ b/docs/modules/ROOT/examples/updatePasswordWithAccessToken.swift
@@ -6,8 +6,8 @@ do {
     try await AppDelegate.reachfive().updatePassword(
         .AccessTokenParams(
             authToken: profileAuthToken,
-            oldPassword: "gVc7piBn",
-            password: "ZPf7LFtc"
+            password: "ZPf7LFtc",
+            oldPassword: "gVc7piBn"
         )
     )
     // Do something

--- a/docs/modules/ROOT/examples/verifyEmail.swift
+++ b/docs/modules/ROOT/examples/verifyEmail.swift
@@ -5,8 +5,8 @@ let profileAuthToken: AuthToken = // Here paste the authorization token of the p
 do {
     try await AppDelegate.reachfive().verifyEmail(
         authToken: profileAuthToken,
-        email: "johnatthan.doe@gmail.com",
-        code: "123456"
+        code: "123456",
+        email: "johnatthan.doe@gmail.com"
     )
     // Successfully verified email
 } catch {

--- a/docs/verification/baseline.txt
+++ b/docs/verification/baseline.txt
@@ -1,23 +1,3 @@
 # Documentation examples that currently fail the API check because of
 # genuine bugs in the doc snippets (wrong argument label/order/type,
 # renamed API…). To be fixed in a dedicated task. One example stem per line.
-addPasswordlessCallback
-listWebAuthnDevices
-logout
-mfaDeleteCredentialPhoneNumber
-mfaStartWithEmail
-mfaStartWithPhoneNumber
-mfaStartWithStepUp
-mfaStartWithStepUpLoginFlow
-refreshAccessToken
-requestAccountRecoveryWithEmail
-requestAccountRecoveryWithPhoneNumber
-requestPasswordResetWithEmail
-sendEmailVerification
-signupWithEmail
-signupWithPhoneNumber
-startPasswordlessWithEmail
-startPasswordlessWithPhoneNumber
-updateEmail
-updatePasswordWithAccessToken
-verifyEmail


### PR DESCRIPTION
## Contexte

Corrige les tests en échec.

## Ce qui a été corrigé

Chaque appel a été confronté à la vraie signature dans `Sources/Core/` :

- **Ordre/labels d'arguments incorrects** : `mfaDeleteCredential`, `mfaStart` (Email/PhoneNumber/StepUp), `refreshAccessToken`, `signupWithEmail`/`signupWithPhoneNumber` (password doit précéder les autres champs), `updatePasswordWithAccessToken`, `verifyEmail`, `logout` (ordre de `WebSessionLogoutRequest`).
- **`String` passé où `URL` est attendu** : `requestAccountRecoveryWith{Email,PhoneNumber}`, `requestPasswordResetWithEmail`, `sendEmailVerification`, `signupWithEmail`, `updateEmail`.
- **Méthode renommée** : `listWebAuthnDevices` → `listWebAuthnCredentials`.
- **Argument requis manquant** : `redirectUri` sur `startPasswordless(.Email/.PhoneNumber)`.
- **Pattern de switch incorrect** : `case .success(authToken):` / `case .failure(error):` sans `let` (addPasswordlessCallback) ; `case .AchievedLogin(authToken: AuthToken):` qui essayait de matcher contre le *type* `AuthToken` au lieu de binder la valeur (signupWithEmail/PhoneNumber) — ce second bug n'est apparu qu'une fois le bug d'ordre d'arguments du même appel corrigé.

## Vérification

`docs/verification/check.sh` lancé en local (build réel Mac Catalyst) :
- Avant : 38/58 compilent, 20 échecs connus (baselinés)
- Après : **58/58 compilent**, 0 échec, `baseline.txt` vidé

## Test plan
- [x] `docs/verification/check.sh` passe en local, 0 échec
- [ ] CI `check-doc-examples` vert

🤖 Generated with [Claude Code](https://claude.com/claude-code)