### PR TITLE
docs: fix unescaped URL

### DIFF
--- a/docs/modules/ROOT/partials/r_configure.adoc
+++ b/docs/modules/ROOT/partials/r_configure.adoc
@@ -101,7 +101,7 @@ If this entry (or the association file) is missing, the session fails to start.
 `$\{host\}` is the host of the `universalLink` returned by {company} for that provider.
 An `apple-app-site-association` file on that host is always required; include the `applinks` and/or `webcredentials` sections that correspond to the Associated Domains entries you declared above.
 
-IMPORTANT: Whitelist the full `universalLink` URL (e.g. `https://$\{host\}/path/to/callback`) in *Allowed Callback URLs* on your {cc} in addition to the custom-scheme entries above.
+IMPORTANT: Whitelist the full `universalLink` URL (e.g. `\https://$\{host\}/path/to/callback`) in *Allowed Callback URLs* on your {cc} in addition to the custom-scheme entries above.
 The SDK sends this URL as the OAuth `redirect_uri` for both `/authorize` and the code exchange when using xref:providerCreator.adoc[`WebProvider`] with `.externalApp` or `.universalLink`, or xref:webviewLogin.adoc[`webviewLogin`] with a matching `webSessionMode`.
 Use the exact URL returned in your provider configuration for the chosen variant—the same value that supplies `$\{host\}` and the callback path below.
 See xref:docs:ROOT:clients.adoc[] for how to configure Allowed Callback URLs.


### PR DESCRIPTION
# Jira

n/a - build failure 

# Description

Fixing unescaped URL that Asciidoc can't parse.