### PR TITLE
Configurer l'origine WebAuthn une seule fois dans SdkConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,8 +30,10 @@
 - `ReachFive.login(withProvider:idToken:nonce:scope:origin:givenName:familyName:)`, the provider
   counterpart of `loginCallback`: it exchanges the ID token issued by a native provider SDK for a ReachFive
   `AuthToken`. Used internally by Sign In With Apple, and intended for integrators writing their own
-  `Provider`.
-
+  `Provider` — it replaces assembling `reachFiveApi.authorize(params:)` and `authWithCode` by hand.
+- `SdkConfig.originWebAuthn`: the WebAuthn origin can now be configured once, instead of being repeated on
+  every passkey request. It defaults to `https://<domain>`, and a request that carries its own
+  `originWebAuthn` still takes precedence.
 
 ## v10.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@
 - `ReachFive.login(withProvider:idToken:nonce:scope:origin:givenName:familyName:)`, the provider
   counterpart of `loginCallback`: it exchanges the ID token issued by a native provider SDK for a ReachFive
   `AuthToken`. Used internally by Sign In With Apple, and intended for integrators writing their own
-  `Provider` — it replaces assembling `reachFiveApi.authorize(params:)` and `authWithCode` by hand.
+  `Provider`.
 - `SdkConfig.originWebAuthn`: the WebAuthn origin can now be configured once, instead of being repeated on
   every passkey request. It defaults to `https://<domain>`, and a request that carries its own
   `originWebAuthn` still takes precedence.

--- a/Sources/Core/Classes/AppleProvider.swift
+++ b/Sources/Core/Classes/AppleProvider.swift
@@ -52,7 +52,7 @@ class ConfiguredAppleProvider: NSObject, Provider {
         let window = try await presenting.anchor()
 
         let scope: [String] = scope ?? clientConfigResponse.scope.components(separatedBy: " ")
-        let request = ResolvedNativeLoginRequest(anchor: window, originWebAuthn: "https://\(reachfive.sdkConfig.domain)", scopes: scope, origin: origin)
+        let request = ResolvedNativeLoginRequest(anchor: window, originWebAuthn: reachfive.sdkConfig.webAuthnOrigin, scopes: scope, origin: origin)
 
         let flow = try await reachfive.credentialManager.login(withRequest: request, usingModalAuthorizationFor: [.SignInWithApple], display: .Always, appleProvider: self, reachFive: reachfive)
 

--- a/Sources/Core/Classes/ReachFiveNative.swift
+++ b/Sources/Core/Classes/ReachFiveNative.swift
@@ -16,10 +16,9 @@ extension ReachFive {
     /// Signup with a passkey
     @available(iOS 16.0, *)
     public func signup(withRequest request: PasskeySignupRequest) async throws -> AuthToken {
-        let domain = sdkConfig.domain
         let scopes = request.scopes ?? scope
         let signupOptions = SignupOptions(
-            origin: request.originWebAuthn ?? "https://\(domain)",
+            origin: request.originWebAuthn ?? sdkConfig.webAuthnOrigin,
             friendlyName: request.friendlyName,
             profile: request.passkeyProfile,
             clientId: sdkConfig.clientId,
@@ -74,18 +73,18 @@ extension ReachFive {
     @available(iOS 16.0, *)
     public func registerNewPasskey(withRequest request: NewPasskeyRequest, authToken: AuthToken) async throws {
         // TODO: delete the former key from the server
-        try await credentialManager.registerNewPasskey(withRequest: request, originWebAuthn: request.originWebAuthn ?? "https://\(sdkConfig.domain)", authToken: authToken, reachFive: self)
+        try await credentialManager.registerNewPasskey(withRequest: request, originWebAuthn: request.originWebAuthn ?? sdkConfig.webAuthnOrigin, authToken: authToken, reachFive: self)
     }
 
     @available(iOS 16.0, *)
     public func resetPasskeys(withRequest request: ResetPasskeyRequest) async throws {
-        try await credentialManager.resetPasskeys(withRequest: request, originWebAuthn: request.originWebAuthn ?? "https://\(sdkConfig.domain)", reachFive: self)
+        try await credentialManager.resetPasskeys(withRequest: request, originWebAuthn: request.originWebAuthn ?? sdkConfig.webAuthnOrigin, reachFive: self)
     }
 
     private func resolve(_ request: NativeLoginRequest) -> ResolvedNativeLoginRequest {
         ResolvedNativeLoginRequest(
             anchor: request.anchor,
-            originWebAuthn: request.originWebAuthn ?? "https://\(sdkConfig.domain)",
+            originWebAuthn: request.originWebAuthn ?? sdkConfig.webAuthnOrigin,
             scopes: request.scopes ?? scope,
             origin: request.origin
         )

--- a/Sources/Core/Classes/models/SdkConfig.swift
+++ b/Sources/Core/Classes/models/SdkConfig.swift
@@ -70,10 +70,16 @@ public class SdkConfig {
 
     /// `internal`, like `makeUri` below: the single construction point on which the init's precondition
     /// relies, so tests can probe acceptable/unacceptable inputs without triggering it.
+    ///
+    /// Mirrors the WHATWG "serialization of an origin" (https://html.spec.whatwg.org/multipage/browsers.html#origin)
+    /// applied to `Foundation.URL`, which parses URLs but does not itself normalize them to the WHATWG URL
+    /// Standard: hence lower-casing the host here (WHATWG's domain/IPv6 parsers lower-case as they go) and
+    /// dropping the port when it is the scheme's default (the WHATWG URL parser nulls it at parse time,
+    /// `URL.port` does not).
     internal static func serializedOrigin(_ url: URL) -> String? {
         guard let scheme = url.scheme?.lowercased(), let rawHost = url.host else { return nil }
         // URL.host returns an IPv6 literal unbracketed ("::1"); an origin needs it back in brackets.
-        let host = rawHost.contains(":") ? "[\(rawHost)]" : rawHost
+        let host = (rawHost.contains(":") ? "[\(rawHost)]" : rawHost).lowercased()
         let defaultPort = ["http": 80, "https": 443][scheme]
         guard let port = url.port, port != defaultPort else { return "\(scheme)://\(host)" }
         return "\(scheme)://\(host):\(port)"

--- a/Sources/Core/Classes/models/SdkConfig.swift
+++ b/Sources/Core/Classes/models/SdkConfig.swift
@@ -68,9 +68,14 @@ public class SdkConfig {
         return origin
     }
 
-    private static func serializedOrigin(_ url: URL) -> String? {
-        guard let scheme = url.scheme?.lowercased(), let host = url.host else { return nil }
-        guard let port = url.port else { return "\(scheme)://\(host)" }
+    /// `internal`, like `makeUri` below: the single construction point on which the init's precondition
+    /// relies, so tests can probe acceptable/unacceptable inputs without triggering it.
+    internal static func serializedOrigin(_ url: URL) -> String? {
+        guard let scheme = url.scheme?.lowercased(), let rawHost = url.host else { return nil }
+        // URL.host returns an IPv6 literal unbracketed ("::1"); an origin needs it back in brackets.
+        let host = rawHost.contains(":") ? "[\(rawHost)]" : rawHost
+        let defaultPort = ["http": 80, "https": 443][scheme]
+        guard let port = url.port, port != defaultPort else { return "\(scheme)://\(host)" }
         return "\(scheme)://\(host):\(port)"
     }
 

--- a/Sources/Core/Classes/models/SdkConfig.swift
+++ b/Sources/Core/Classes/models/SdkConfig.swift
@@ -81,7 +81,9 @@ public class SdkConfig {
     /// a related but distinct text. RFC 6454 also requires the host lower-cased (§4.5) and the port
     /// omitted when it is the scheme's default (§6.2.5); `Foundation.URL` does neither on its own.
     internal static func serializedOrigin(_ url: URL) -> String? {
-        guard let scheme = url.scheme?.lowercased(), let rawHost = url.host else { return nil }
+        // `URL.host` is "", not nil, when the authority carries no host at all, as in "https://:8443":
+        // an origin needs a host, so reject it rather than serialize "https://:8443".
+        guard let scheme = url.scheme?.lowercased(), let rawHost = url.host, !rawHost.isEmpty else { return nil }
         // URL.host returns an IPv6 literal unbracketed ("::1"); an origin needs it back in brackets.
         let host = (rawHost.contains(":") ? "[\(rawHost)]" : rawHost).lowercased()
         let defaultPort = ["http": 80, "https": 443][scheme]

--- a/Sources/Core/Classes/models/SdkConfig.swift
+++ b/Sources/Core/Classes/models/SdkConfig.swift
@@ -63,7 +63,12 @@ public class SdkConfig {
     /// and are sent as given.
     var webAuthnOrigin: String {
         guard let originWebAuthn, let origin = Self.serializedOrigin(originWebAuthn) else {
-            return "https://\(domain)"
+            // `domain` is an unvalidated free-form String (unlike `originWebAuthn`, an `URL`): the same trust
+            // `ReachFiveApi.createUrl` already places in it to build every API request. A `domain` broken enough
+            // to matter here (a path, invalid characters) already crashes there first, so only lower-casing is
+            // worth doing on this fallback path — RFC 6454 requires it, and unlike other malformations, mixed
+            // case is a perfectly valid host that works fine everywhere else in the SDK.
+            return "https://\(domain.lowercased())"
         }
         return origin
     }

--- a/Sources/Core/Classes/models/SdkConfig.swift
+++ b/Sources/Core/Classes/models/SdkConfig.swift
@@ -71,11 +71,10 @@ public class SdkConfig {
     /// `internal`, like `makeUri` below: the single construction point on which the init's precondition
     /// relies, so tests can probe acceptable/unacceptable inputs without triggering it.
     ///
-    /// Mirrors the WHATWG "serialization of an origin" (https://html.spec.whatwg.org/multipage/browsers.html#origin)
-    /// applied to `Foundation.URL`, which parses URLs but does not itself normalize them to the WHATWG URL
-    /// Standard: hence lower-casing the host here (WHATWG's domain/IPv6 parsers lower-case as they go) and
-    /// dropping the port when it is the scheme's default (the WHATWG URL parser nulls it at parse time,
-    /// `URL.port` does not).
+    /// The WebAuthn spec requires `CollectedClientData.origin` to follow RFC 6454 ("The Web Origin
+    /// Concept"), §6.2 ASCII Serialization of an Origin — not the WHATWG HTML/URL origin concept, which is
+    /// a related but distinct text. RFC 6454 also requires the host lower-cased (§4.5) and the port
+    /// omitted when it is the scheme's default (§6.2.5); `Foundation.URL` does neither on its own.
     internal static func serializedOrigin(_ url: URL) -> String? {
         guard let scheme = url.scheme?.lowercased(), let rawHost = url.host else { return nil }
         // URL.host returns an IPv6 literal unbracketed ("::1"); an origin needs it back in brackets.

--- a/Sources/Core/Classes/models/SdkConfig.swift
+++ b/Sources/Core/Classes/models/SdkConfig.swift
@@ -15,6 +15,14 @@ public class SdkConfig {
     /// The redirect URI for email verification. Defaults to `reachfive-clientId://email-verification`
     public let emailVerificationUri: URL
 
+    /// The WebAuthn origin sent to the server for passkey requests, as a serialized origin
+    /// (`https://host`). Set it once here instead of repeating it on every passkey request.
+    ///
+    /// Defaults to `https://<domain>`, which is right unless your passkeys are scoped to a different
+    /// relying party — a custom domain, or one shared across several of your apps. A request that carries
+    /// its own `originWebAuthn` still wins over this value.
+    public let originWebAuthn: URL?
+
     public init(
         domain: String,
         clientId: String,
@@ -22,7 +30,8 @@ public class SdkConfig {
         redirectUri: URL? = nil,
         mfaUri: URL? = nil,
         accountRecoveryUri: URL? = nil,
-        emailVerificationUri: URL? = nil
+        emailVerificationUri: URL? = nil,
+        originWebAuthn: URL? = nil
     ) {
         self.domain = domain
         self.clientId = clientId
@@ -36,6 +45,33 @@ public class SdkConfig {
         self.mfaUri = mfaUri ?? Self.defaultUri(scheme: scheme, path: "mfa")
         self.emailVerificationUri = emailVerificationUri ?? Self.defaultUri(scheme: scheme, path: "email-verification")
         self.accountRecoveryUri = accountRecoveryUri ?? Self.defaultUri(scheme: scheme, path: "account-recovery")
+
+        if let originWebAuthn, Self.serializedOrigin(originWebAuthn) == nil {
+            preconditionFailure("""
+                '\(originWebAuthn)' is not a valid WebAuthn origin: it must be an absolute URL with a \
+                scheme and a host, e.g. https://auth.example.com.
+                """)
+        }
+        self.originWebAuthn = originWebAuthn
+    }
+
+    /// The WebAuthn origin to use when a request does not carry its own, serialized the way the server and
+    /// the system expect it: scheme, host and non-default port only. Neither a path nor a trailing slash
+    /// belongs in an origin, and `URL.absoluteString` would keep both.
+    ///
+    /// Only this configured value is normalized: the per-request `originWebAuthn` overrides are `String`s
+    /// and are sent as given.
+    var webAuthnOrigin: String {
+        guard let originWebAuthn, let origin = Self.serializedOrigin(originWebAuthn) else {
+            return "https://\(domain)"
+        }
+        return origin
+    }
+
+    private static func serializedOrigin(_ url: URL) -> String? {
+        guard let scheme = url.scheme?.lowercased(), let host = url.host else { return nil }
+        guard let port = url.port else { return "\(scheme)://\(host)" }
+        return "\(scheme)://\(host):\(port)"
     }
 
     /// Validation by construction: `URL(string:)` applies Foundation's RFC 3986 parsing,

--- a/Tests/Reach5Tests/Models/SdkConfigTests.swift
+++ b/Tests/Reach5Tests/Models/SdkConfigTests.swift
@@ -122,6 +122,15 @@ final class SdkConfigTests: XCTestCase {
         XCTAssertEqual(config.webAuthnOrigin, "https://example.reach5.net")
     }
 
+    /// `domain` is a free-form, unvalidated `String`, unlike `originWebAuthn`. Mixed case is the one
+    /// malformation that stays valid everywhere else in the SDK (DNS is case-insensitive) yet still needs
+    /// folding here, since RFC 6454 origins must be lower-case.
+    func testWebAuthnOriginDefaultLowercasesTheDomain() {
+        let config = SdkConfig(domain: "Example.Reach5.NET", clientId: "abc")
+
+        XCTAssertEqual(config.webAuthnOrigin, "https://example.reach5.net")
+    }
+
     func testConfiguredOriginWins() {
         let config = SdkConfig(
             domain: "example.reach5.net",

--- a/Tests/Reach5Tests/Models/SdkConfigTests.swift
+++ b/Tests/Reach5Tests/Models/SdkConfigTests.swift
@@ -197,6 +197,8 @@ final class SdkConfigTests: XCTestCase {
             "auth.example.com", // no scheme: parses as a relative reference
             "//auth.example.com", // scheme-relative: no scheme
             "https://", // scheme but no host
+            "https://:8443", // an authority with a port but no host: URL.host is "", not nil
+            "https://@:8443", // userinfo and port, still no host
             "https:///webauthn", // scheme and a path, still no host
             "mailto:test@example.com", // has a scheme, but no host
             "file:///path/to/file", // has a scheme, but no host

--- a/Tests/Reach5Tests/Models/SdkConfigTests.swift
+++ b/Tests/Reach5Tests/Models/SdkConfigTests.swift
@@ -155,4 +155,43 @@ final class SdkConfigTests: XCTestCase {
 
         XCTAssertEqual(config.webAuthnOrigin, "https://localhost:8443")
     }
+
+    /// Same style as `testAcceptableClientIds`/`testAcceptableCustomSchemes`: goes through
+    /// `SdkConfig.serializedOrigin` directly, the single construction point the init's precondition relies
+    /// on, so a malformed input can be checked without crashing the test process.
+    func testAcceptableWebAuthnOrigins() {
+        let acceptable: [(input: String, expected: String)] = [
+            ("https://auth.example.com", "https://auth.example.com"), // baseline
+            ("https://auth.example.com/", "https://auth.example.com"), // trailing slash stripped
+            ("https://auth.example.com/webauthn/register", "https://auth.example.com"), // path stripped
+            ("https://auth.example.com?client=abc", "https://auth.example.com"), // query stripped
+            ("https://auth.example.com#fragment", "https://auth.example.com"), // fragment stripped
+            ("https://user:pass@auth.example.com", "https://auth.example.com"), // userinfo dropped
+            ("HTTPS://auth.example.com", "https://auth.example.com"), // scheme is lowercased
+            ("https://localhost:8443", "https://localhost:8443"), // non-default port is kept
+            ("https://auth.example.com:443", "https://auth.example.com"), // default https port is stripped
+            ("http://auth.example.com:80", "http://auth.example.com"), // default http port is stripped
+            ("https://127.0.0.1:9000", "https://127.0.0.1:9000"), // IPv4 host, kept as-is
+            ("https://[::1]:8443", "https://[::1]:8443"), // IPv6 literal: URL.host drops the brackets, put them back
+        ]
+        for (input, expected) in acceptable {
+            let url = URL(string: input)!
+            XCTAssertEqual(SdkConfig.serializedOrigin(url), expected, "'\(input)' should serialize to '\(expected)'")
+        }
+    }
+
+    func testUnacceptableWebAuthnOrigins() {
+        let unacceptable = [
+            "auth.example.com", // no scheme: parses as a relative reference
+            "//auth.example.com", // scheme-relative: no scheme
+            "https://", // scheme but no host
+            "https:///webauthn", // scheme and a path, still no host
+            "mailto:test@example.com", // has a scheme, but no host
+            "file:///path/to/file", // has a scheme, but no host
+        ]
+        for input in unacceptable {
+            let url = URL(string: input)!
+            XCTAssertNil(SdkConfig.serializedOrigin(url), "'\(input)' should be rejected")
+        }
+    }
 }

--- a/Tests/Reach5Tests/Models/SdkConfigTests.swift
+++ b/Tests/Reach5Tests/Models/SdkConfigTests.swift
@@ -113,4 +113,46 @@ final class SdkConfigTests: XCTestCase {
         XCTAssertEqual(config.accountRecoveryUri.absoluteString, "reachfive-abc://account-recovery")
         XCTAssertEqual(config.emailVerificationUri.absoluteString, "reachfive-abc://email-verification")
     }
+
+    // MARK: - WebAuthn origin
+
+    func testWebAuthnOriginDefaultsToTheDomain() {
+        let config = SdkConfig(domain: "example.reach5.net", clientId: "abc")
+
+        XCTAssertEqual(config.webAuthnOrigin, "https://example.reach5.net")
+    }
+
+    func testConfiguredOriginWins() {
+        let config = SdkConfig(
+            domain: "example.reach5.net",
+            clientId: "abc",
+            originWebAuthn: URL(string: "https://auth.example.com")!)
+
+        XCTAssertEqual(config.webAuthnOrigin, "https://auth.example.com")
+    }
+
+    /// An origin is a scheme, a host and a non-default port — nothing else. `absoluteString` would keep the
+    /// path and the trailing slash, which the server and the system both reject; hence the normalization.
+    func testTrailingSlashAndPathAreStripped() {
+        let withTrailingSlash = SdkConfig(
+            domain: "example.reach5.net",
+            clientId: "abc",
+            originWebAuthn: URL(string: "https://auth.example.com/")!)
+        let withPath = SdkConfig(
+            domain: "example.reach5.net",
+            clientId: "abc",
+            originWebAuthn: URL(string: "https://auth.example.com/webauthn")!)
+
+        XCTAssertEqual(withTrailingSlash.webAuthnOrigin, "https://auth.example.com")
+        XCTAssertEqual(withPath.webAuthnOrigin, "https://auth.example.com")
+    }
+
+    func testNonDefaultPortIsKept() {
+        let config = SdkConfig(
+            domain: "example.reach5.net",
+            clientId: "abc",
+            originWebAuthn: URL(string: "https://localhost:8443")!)
+
+        XCTAssertEqual(config.webAuthnOrigin, "https://localhost:8443")
+    }
 }

--- a/Tests/Reach5Tests/Models/SdkConfigTests.swift
+++ b/Tests/Reach5Tests/Models/SdkConfigTests.swift
@@ -173,6 +173,9 @@ final class SdkConfigTests: XCTestCase {
             ("http://auth.example.com:80", "http://auth.example.com"), // default http port is stripped
             ("https://127.0.0.1:9000", "https://127.0.0.1:9000"), // IPv4 host, kept as-is
             ("https://[::1]:8443", "https://[::1]:8443"), // IPv6 literal: URL.host drops the brackets, put them back
+            ("https://AUTH.EXAMPLE.COM", "https://auth.example.com"), // host is lowercased, like the WHATWG domain parser does
+            ("https://[2001:DB8::1]", "https://[2001:db8::1]"), // IPv6 hex digits are lowercased too
+            ("https://café.example", "https://xn--caf-dma.example"), // IDNA: Foundation already punycode-encodes non-ASCII hosts
         ]
         for (input, expected) in acceptable {
             let url = URL(string: input)!


### PR DESCRIPTION
## Résumé
- `SdkConfig.originWebAuthn` (`URL?`) permet de configurer l'origine WebAuthn une seule fois, au lieu de la répéter sur chacune des cinq requêtes passkey.
- Repli inchangé sur `https://<domain>` ; une origine fournie explicitement sur une requête garde la priorité.
- La valeur est normalisée en origine sérialisée (schéma + hôte + port non-défaut), sans chemin ni slash final.