### PR TITLE
Une seule initialisation du SDK même si plusieurs appelants la demandent en même temps

### DIFF
--- a/Sources/Core/Classes/ReachFive.swift
+++ b/Sources/Core/Classes/ReachFive.swift
@@ -24,6 +24,10 @@ public class ReachFive: NSObject {
     var accountRecoveryCallback: AccountRecoveryCallback? = nil
     var emailVerificationCallback: EmailVerificationCallback? = nil
     var state: State = .NotInitialized
+    /// The initialization currently in flight, if any, so concurrent `initialize()` calls share it
+    /// instead of each fetching the configuration and creating its own set of providers.
+    /// Only ever read and written on the main actor, from `initialize()`.
+    var initialization: Task<[Provider], Error>? = nil
     public let sdkConfig: SdkConfig
     let providersCreators: Array<ProviderCreator>
     public let reachFiveApi: ReachFiveApi

--- a/Sources/Core/Classes/ReachFiveApplication.swift
+++ b/Sources/Core/Classes/ReachFiveApplication.swift
@@ -20,7 +20,9 @@ public extension ReachFive {
     }
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        Task {
+        // On the main actor: the hook we forward is a UIKit app-lifecycle callback, and the native
+        // SDKs behind the providers expect it on the main thread — as UIKit called us here.
+        Task { @MainActor in
             do {
                 for provider in try await initialize() {
                     let _ = provider.application(application, didFinishLaunchingWithOptions: launchOptions)

--- a/Sources/Core/Classes/ReachFiveProviders.swift
+++ b/Sources/Core/Classes/ReachFiveProviders.swift
@@ -9,6 +9,13 @@ public extension ReachFive {
         providers
     }
 
+    /// Fetches the client configuration and creates the providers again, unconditionally.
+    ///
+    /// Isolated to the main actor: it writes the SDK's shared state (`clientConfig`, `scope`,
+    /// `providers`, `state`) that the app-lifecycle hooks and `getProviders()` read from the main
+    /// thread, and native providers expect to be created there. Both network calls suspend, so the
+    /// main thread is never blocked.
+    @MainActor
     func reinitialize() async throws -> [Provider] {
         let clientConfig = try await reachFiveApi.clientConfig()
 
@@ -31,10 +38,28 @@ public extension ReachFive {
         return providers
     }
 
+    /// Initializes the SDK once, whoever asks first.
+    ///
+    /// Callers legitimately overlap: the host app awaits `initialize()` for the client configuration
+    /// while `application(_:didFinishLaunchingWithOptions:)` initializes the SDK on its own. Since
+    /// `reinitialize()` only reaches `.Initialized` after two round trips, a plain state check would
+    /// let every caller start its own initialization — doubling the requests and, worse, building
+    /// several sets of providers of which only the last one written is kept and reachable through
+    /// `getProviders()`. Concurrent callers therefore await the initialization already in flight.
+    ///
+    /// A failed initialization is not remembered, so a later call retries.
+    @MainActor
     func initialize() async throws -> [Provider] {
         switch state {
         case .NotInitialized:
-            return try await reinitialize()
+            if let initialization {
+                return try await initialization.value
+            }
+
+            let initialization = Task { try await reinitialize() }
+            self.initialization = initialization
+            defer { self.initialization = nil }
+            return try await initialization.value
 
         case .Initialized:
             return providers


### PR DESCRIPTION
Constaté en lançant le Sandbox : le `create` d'un `ProviderCreator` était appelé deux fois par démarrage.

`AppDelegate.didFinishLaunchingWithOptions` attend `initialize()` pour récupérer la configuration du client, et retourne ensuite `reachfive.application(_:didFinishLaunchingWithOptions:)`, qui lance sa propre initialisation. `initialize()` teste `state`, mais `reinitialize()` n'atteint `.Initialized` qu'après deux allers-retours réseau : les deux tâches voyaient `.NotInitialized`, faisaient chacune les deux requêtes et construisaient chacune un jeu complet de providers, dont seul le dernier écrit survivait dans `self.providers`.

## Comment

`ReachFive` mémorise la `Task` d'initialisation en cours ; les appels concurrents attendent sa valeur au lieu d'en démarrer une nouvelle. Un échec n'est pas mémorisé, un appel ultérieur réessaie.

`initialize()` et `reinitialize()` passent sur le main actor. C'est ce qui rend atomique le test-puis-pose de la tâche mémorisée — sans isolation, deux threads coopératifs pourraient encore la franchir tous les deux. Au passage, les écritures de `clientConfig`, `scope`, `providers` et `state` ne courent plus contre les lectures faites depuis le thread principal (`getProviders()`, crochets de cycle de vie), et les providers natifs sont désormais créés là où leurs SDK l'attendent. Les deux appels réseau suspendent : le thread principal n'est jamais bloqué.

Le `Task` de `application(_:didFinishLaunchingWithOptions:)` devient `@MainActor` : il reforwarde un crochet de cycle de vie UIKit aux providers, que les SDK natifs attendent sur le thread principal — là où UIKit nous avait appelés.

## À regarder de plus près

- `Sources/Core/Classes/ReachFiveProviders.swift` : la mémoïsation et le choix du main actor
- `Sources/Core/Classes/ReachFiveApplication.swift` : le `Task { @MainActor in }`

## Vérification

Compteur temporaire dans `reinitialize()`, Sandbox lancé en simulateur : **2** initialisations à 36 µs d'écart avant, **1** après. Les 59 tests de `Reach5Tests` passent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)