### PR TITLE
[CA-6191] Retour externe de b.connect : une seule session à la fois

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
   - Renamed `baseScheme` field to `customScheme`
   - The initializer now stops the program with a `preconditionFailure` when the scheme is not a valid URL scheme (either because of the `customScheme` parameter, or indirectly because the default scheme is derived from an ill-formatted `clientId`, e.g. one containing `_`). In that case, pass an explicit valid `customScheme` and declare it in your Info.plist and your ReachFive console.
 
-- `application(_:continue:restorationHandler:)` and `application(_:open:options:)` now returns `false` when no the SDK flow or any registered provider consumed the activity or URL.
+- `application(_:continue:restorationHandler:)` and `application(_:open:options:)` now returns `false` when neither an SDK flow nor any registered provider consumed the activity or URL, instead of always returning `true`. If your app also routes universal links or custom-scheme URLs itself, only do so when the call returns `false`.
 
 - ProviderCreator : the factory receives the ``ReachFive`` instance instead of sub-components, so that the creator can reuse high-level helpers such as `buildAuthorizeURL`,`authWithCode` or `webviewLogin`.
 
@@ -27,9 +27,6 @@
 - New `WebProvider` to register a web provider with a `variant` and a completion `mode`. See the [ProviderCreator](https://developer.reachfive.com/sdk-ios/providerCreator.html) and [custom provider guide](https://developer.reachfive.com/sdk-ios/guides/custom-provider.html) documentation.
 - `webviewLogin` accepts a `webSessionMode` parameter picking the shape of the `ASWebAuthenticationSession` callback: `.customScheme` (default) or `.universalLink(_:)` (iOS 17.4+). `WebProvider` takes the same choices.
 - `webviewLogin` accepts a new `loginUrlFragment` parameter to pass key/value pairs in the fragment of the `/oauth/authorize` URL, so a client's Login URL can customize itself (logo, colors) per calling channel in an orchestrated flow.
-
-### Other changes
-- **One web login at a time.** `webviewLogin`, a `login` on a web provider, and `logout(webSessionLogout:)` all share a single web session. A call started while another one is still in progress ends with `ReachFiveError.AuthCanceled` and leaves the login under way untouched. Nothing is expected of you: a double tap on a login control is absorbed by the SDK, and `AuthCanceled` is the outcome you already ignore. To end a web login early — a screen being torn down, a timeout — cancel the `Task` that started it.
 
 ## v10.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
   - Renamed `baseScheme` field to `customScheme`
   - The initializer now stops the program with a `preconditionFailure` when the scheme is not a valid URL scheme (either because of the `customScheme` parameter, or indirectly because the default scheme is derived from an ill-formatted `clientId`, e.g. one containing `_`). In that case, pass an explicit valid `customScheme` and declare it in your Info.plist and your ReachFive console.
 
-- `application(_:continue:restorationHandler:)` now returns `false` when neither ReachFive's web-auth session nor any registered provider consumed the activity, instead of always returning `true`. If your app also routes universal links itself, only do so when this call returns `false`.
+- `application(_:continue:restorationHandler:)` and `application(_:open:options:)` now returns `false` when no the SDK flow or any registered provider consumed the activity or URL.
 
 - ProviderCreator : the factory receives the ``ReachFive`` instance instead of sub-components, so that the creator can reuse high-level helpers such as `buildAuthorizeURL`,`authWithCode` or `webviewLogin`.
 
@@ -24,7 +24,7 @@
   ```
 
 ### New features
-- New `WebProvider` to register a web provider (e.g. B.connect) with a `variant` and a completion `mode`. See the [ProviderCreator](https://developer.reachfive.com/sdk-ios/providerCreator.html) and [custom provider guide](https://developer.reachfive.com/sdk-ios/guides/custom-provider.html) documentation.
+- New `WebProvider` to register a web provider with a `variant` and a completion `mode`. See the [ProviderCreator](https://developer.reachfive.com/sdk-ios/providerCreator.html) and [custom provider guide](https://developer.reachfive.com/sdk-ios/guides/custom-provider.html) documentation.
 - `webviewLogin` accepts a `webSessionMode` parameter picking the shape of the `ASWebAuthenticationSession` callback: `.customScheme` (default) or `.universalLink(_:)` (iOS 17.4+). `WebProvider` takes the same choices.
 - `webviewLogin` accepts a new `loginUrlFragment` parameter to pass key/value pairs in the fragment of the `/oauth/authorize` URL, so a client's Login URL can customize itself (logo, colors) per calling channel in an orchestrated flow.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@
 - `webviewLogin` accepts a `webSessionMode` parameter picking the shape of the `ASWebAuthenticationSession` callback: `.customScheme` (default) or `.universalLink(_:)` (iOS 17.4+). `WebProvider` takes the same choices.
 - `webviewLogin` accepts a new `loginUrlFragment` parameter to pass key/value pairs in the fragment of the `/oauth/authorize` URL, so a client's Login URL can customize itself (logo, colors) per calling channel in an orchestrated flow.
 
+### Other changes
+- **One web login at a time.** `webviewLogin`, a `login` on a web provider, and `logout(webSessionLogout:)` all share a single web session. A call started while another one is still in progress ends with `ReachFiveError.AuthCanceled` and leaves the login under way untouched. Nothing is expected of you: a double tap on a login control is absorbed by the SDK, and `AuthCanceled` is the outcome you already ignore. To end a web login early — a screen being torn down, a timeout — cancel the `Task` that started it.
+
 ## v10.0.1
 
 - Fix compilation issue in XCode 26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,9 @@
 
 ### New features
 - New `WebProvider` to register a web provider (e.g. B.connect) with a `variant` and a completion `mode`. See the [ProviderCreator](https://developer.reachfive.com/sdk-ios/providerCreator.html) and [custom provider guide](https://developer.reachfive.com/sdk-ios/guides/custom-provider.html) documentation.
-- `webviewLogin` accepts a `webSessionMode` parameter picking how the `ASWebAuthenticationSession` returns: `.sdkScheme`, `.externalAppScheme`, `.externalAppUniversalLink(_:)` or `.inSheetUniversalLink(_:)` (iOS 17.4+). `WebProvider` takes the same choices.
+- `webviewLogin` accepts a `webSessionMode` parameter picking the shape of the `ASWebAuthenticationSession` callback: `.customScheme` (default) or `.universalLink(_:)` (iOS 17.4+). `WebProvider` takes the same choices.
+
+  There is deliberately **no** "in-band vs out-of-band" axis. A provider can decide *mid-flight*, with the sheet already open, whether the login ends inside the sheet or leaves the app — B.connect picks `passive` or `active` only after the `/authorize` call. `.customScheme` therefore arms both return channels at once: the sheet intercepts `reachfive-<clientId>://callback` if the flow never leaves it, and `application(_:open:)` + `tryComplete` resolve it if the default browser delivers it instead. Nothing to choose, and nothing to get wrong.
 - `webviewLogin` accepts a new `loginUrlFragment` parameter to pass key/value pairs in the fragment of the `/oauth/authorize` URL, so a client's Login URL can customize itself (logo, colors) per calling channel in an orchestrated flow.
 
 ## v10.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,9 @@
 
 - `application(_:continue:restorationHandler:)` now returns `false` when neither ReachFive's web-auth session nor any registered provider consumed the activity, instead of always returning `true`. If your app also routes universal links itself, only do so when this call returns `false`.
 
-- ProviderCreator : the factory receives the ``ReachFive`` instance instead of sub-components, so that the creator can
-  reuse high-level helpers such as `buildAuthorizeURL`,`authWithCode` or `webviewLogin`.
+- ProviderCreator : the factory receives the ``ReachFive`` instance instead of sub-components, so that the creator can reuse high-level helpers such as `buildAuthorizeURL`,`authWithCode` or `webviewLogin`.
 
-- `Provider.login` takes a `Presentation` instead of a `UIViewController?`:
+- `Provider.login` takes a `Presentation` instead of a `UIViewController?` to handle the different type of conformance itself (either conforming to `ASWebAuthenticationPresentationContextProviding` or needing a `ASPresentationAnchor` ) 
 
   ```swift
   // Before
@@ -24,13 +23,9 @@
   try await provider.login(scope: scope, origin: origin, presenting: Presentation(from: self))
   ```
 
-  The view controller no longer needs to conform to `ASWebAuthenticationPresentationContextProviding` for web providers: the SDK derives the presentation context itself (a conforming view controller keeps precedence if you have one). It must simply be attached to a window at call time — call `login` from `viewDidAppear` or a user interaction, not from `viewDidLoad`. When calling `webviewLogin` or `logout(webSessionLogout:)` directly, the existing request initializers are unchanged; `WebviewLoginRequest` and `WebSessionLogoutRequest` also gain a convenience initializer taking `presenting: Presentation`, which lifts the conformance requirement there too.
-
 ### New features
 - New `WebProvider` to register a web provider (e.g. B.connect) with a `variant` and a completion `mode`. See the [ProviderCreator](https://developer.reachfive.com/sdk-ios/providerCreator.html) and [custom provider guide](https://developer.reachfive.com/sdk-ios/guides/custom-provider.html) documentation.
 - `webviewLogin` accepts a `webSessionMode` parameter picking the shape of the `ASWebAuthenticationSession` callback: `.customScheme` (default) or `.universalLink(_:)` (iOS 17.4+). `WebProvider` takes the same choices.
-
-  There is deliberately **no** "in-band vs out-of-band" axis. A provider can decide *mid-flight*, with the sheet already open, whether the login ends inside the sheet or leaves the app — B.connect picks `passive` or `active` only after the `/authorize` call. `.customScheme` therefore arms both return channels at once: the sheet intercepts `reachfive-<clientId>://callback` if the flow never leaves it, and `application(_:open:)` + `tryComplete` resolve it if the default browser delivers it instead. Nothing to choose, and nothing to get wrong.
 - `webviewLogin` accepts a new `loginUrlFragment` parameter to pass key/value pairs in the fragment of the `/oauth/authorize` URL, so a client's Login URL can customize itself (logo, colors) per calling channel in an orchestrated flow.
 
 ## v10.0.1

--- a/Sandbox/Sandbox/Application/AppDelegate.swift
+++ b/Sandbox/Sandbox/Application/AppDelegate.swift
@@ -55,7 +55,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         GoogleProvider(variant: "one_tap"),
         FacebookProvider(),
         AppleProvider(variant: "natif"),
-        WebProvider(name: .bconnect, variant: "natif", mode: .externalAppUniversalLink)
+        WebProvider(name: .bconnect, variant: "natif", mode: .customScheme)
     ]
     #if targetEnvironment(macCatalyst)
     static let macLocal: ReachFive = ReachFive(sdkConfig: sdkLocal, providersCreators: providers, storage: storage, sdkInternalConfig: SdkInternalConfig(loggingEnabled: true))

--- a/Sandbox/Sandbox/Application/Base.lproj/Main.storyboard
+++ b/Sandbox/Sandbox/Application/Base.lproj/Main.storyboard
@@ -1265,41 +1265,7 @@
                                             <rect key="frame" x="0.0" y="0.0" width="402" height="43.666667938232422"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Login using secure webview (HTTPS)" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Ht1-ps-l01">
-                                                    <rect key="frame" x="8" y="0.0" width="386" height="43.666667938232422"/>
-                                                    <autoresizingMask key="autoresizingMask"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                            </subviews>
-                                        </tableViewCellContentView>
-                                    </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="webviewLoginExternalApp" textLabel="Ea1-pp-l02" style="IBUITableViewCellStyleDefault" id="Ea1-pp-c02">
-                                        <rect key="frame" x="0.0" y="808.00001525878906" width="402" height="43.666667938232422"/>
-                                        <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Ea1-pp-c02" id="Ea1-pp-cv2">
-                                            <rect key="frame" x="0.0" y="0.0" width="402" height="43.666667938232422"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                            <subviews>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Login using secure webview (external app)" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Ea1-pp-l02">
-                                                    <rect key="frame" x="8" y="0.0" width="386" height="43.666667938232422"/>
-                                                    <autoresizingMask key="autoresizingMask"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                            </subviews>
-                                        </tableViewCellContentView>
-                                    </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="webviewLoginExternalAppScheme" textLabel="Es1-ch-l03" style="IBUITableViewCellStyleDefault" id="Es1-ch-c03">
-                                        <rect key="frame" x="0.0" y="851.66668319702148" width="402" height="43.666667938232422"/>
-                                        <autoresizingMask key="autoresizingMask"/>
-                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Es1-ch-c03" id="Es1-ch-cv3">
-                                            <rect key="frame" x="0.0" y="0.0" width="402" height="43.666667938232422"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                            <subviews>
-                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Login using secure webview (external app, scheme)" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Es1-ch-l03">
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Login using secure webview (universal link)" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Ht1-ps-l01">
                                                     <rect key="frame" x="8" y="0.0" width="386" height="43.666667938232422"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>

--- a/Sandbox/Sandbox/Application/Sandbox.entitlements
+++ b/Sandbox/Sandbox/Application/Sandbox.entitlements
@@ -6,14 +6,6 @@
 	<array>
 		<string>Default</string>
 	</array>
-	<!--
-	  Ces entrées n'ont pas de granularité de chemin : c'est l'apple-app-site-association servi par
-	  le host qui la porte, via `components`. Contrainte à y respecter, pour le harnais B.connect :
-	  NI cette app NI OneCheckBank ne doivent réclamer /_dev/bconnect/ — sinon l'UIApplication.open
-	  de OneCheckBank vers /_dev/bconnect/bank/return rouvrirait une app au lieu d'atteindre Safari,
-	  et le détour par le navigateur par défaut, qui est tout l'objet du test, n'aurait jamais lieu.
-	  OneCheckBank ne doit réclamer que /_dev/bank/.
-	-->
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>webcredentials:local-sandbox.og4.me?mode=developer</string>

--- a/Sandbox/Sandbox/Application/Sandbox.entitlements
+++ b/Sandbox/Sandbox/Application/Sandbox.entitlements
@@ -6,6 +6,14 @@
 	<array>
 		<string>Default</string>
 	</array>
+	<!--
+	  Ces entrées n'ont pas de granularité de chemin : c'est l'apple-app-site-association servi par
+	  le host qui la porte, via `components`. Contrainte à y respecter, pour le harnais B.connect :
+	  NI cette app NI OneCheckBank ne doivent réclamer /_dev/bconnect/ — sinon l'UIApplication.open
+	  de OneCheckBank vers /_dev/bconnect/bank/return rouvrirait une app au lieu d'atteindre Safari,
+	  et le détour par le navigateur par défaut, qui est tout l'objet du test, n'aurait jamais lieu.
+	  OneCheckBank ne doit réclamer que /_dev/bank/.
+	-->
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>webcredentials:local-sandbox.og4.me?mode=developer</string>

--- a/Sandbox/Sandbox/Tabs/ActionController.swift
+++ b/Sandbox/Sandbox/Tabs/ActionController.swift
@@ -64,27 +64,12 @@ class ActionController: UITableViewController {
                     }
                 }
 
-                // secure webview completing in-band via an https universal link (intercepted in the sheet, iOS 17.4+)
+                // secure webview completing via an https universal link, intercepted in the sheet (iOS 17.4+)
                 if indexPath.row == 1 {
                     guard #available(iOS 17.4, *) else { return }
-                    let inSheetCallback = URL(string: "https://local-sandbox.og4.me/universal_link_internal")!
+                    let universalLinkCallback = URL(string: "https://local-sandbox.og4.me/universal_link_internal")!
                     await handleAuthToken {
-                        try await AppDelegate.reachfive().webviewLogin(WebviewLoginRequest(presenting: Presentation(from: self), origin: "ActionController.webviewLogin.https", webSessionMode: .inSheetUniversalLink(inSheetCallback)))
-                    }
-                }
-
-                // secure webview handing off to an external app and returning out-of-band via an https universal link
-                if indexPath.row == 2 {
-                    let externalAppCallback = URL(string: "https://local-sandbox.og4.me/_dev/mobile/callback")!
-                    await handleAuthToken {
-                        try await AppDelegate.reachfive().webviewLogin(WebviewLoginRequest(presenting: Presentation(from: self), origin: "ActionController.webviewLogin.externalApp", webSessionMode: .externalAppUniversalLink(externalAppCallback)))
-                    }
-                }
-
-                // secure webview handing off to an external app and returning OUT-OF-BAND via the custom scheme
-                if indexPath.row == 3 {
-                    await handleAuthToken {
-                        try await AppDelegate.reachfive().webviewLogin(WebviewLoginRequest(presenting: Presentation(from: self), origin: "ActionController.webviewLogin.externalAppScheme", webSessionMode: .externalAppScheme))
+                        try await AppDelegate.reachfive().webviewLogin(WebviewLoginRequest(presenting: Presentation(from: self), origin: "ActionController.webviewLogin.universalLink", webSessionMode: .universalLink(universalLinkCallback)))
                     }
                 }
             }

--- a/Sandbox/Sandbox/Tabs/ActionController.swift
+++ b/Sandbox/Sandbox/Tabs/ActionController.swift
@@ -67,7 +67,8 @@ class ActionController: UITableViewController {
                 // secure webview completing via an https universal link, intercepted in the sheet (iOS 17.4+)
                 if indexPath.row == 1 {
                     guard #available(iOS 17.4, *) else { return }
-                    let universalLinkCallback = URL(string: "https://local-sandbox.og4.me/universal_link_internal")!
+                    let domain = AppDelegate.reachfive().sdkConfig.domain
+                    let universalLinkCallback = URL(string: "https://\(domain)/universal_link_internal")!
                     await handleAuthToken {
                         try await AppDelegate.reachfive().webviewLogin(WebviewLoginRequest(presenting: Presentation(from: self), origin: "ActionController.webviewLogin.universalLink", webSessionMode: .universalLink(universalLinkCallback)))
                     }

--- a/Sources/Core/Classes/DefaultProvider.swift
+++ b/Sources/Core/Classes/DefaultProvider.swift
@@ -49,8 +49,8 @@ public final class WebProvider: ProviderCreator {
 class DefaultProvider: NSObject, Provider {
     let name: String
 
-    // `weak` : ReachFive retient ses providers, une référence forte ici créerait un cycle
-    // ReachFive ↔ DefaultProvider et le graphe SDK ne serait jamais désalloué (même pattern que
+    // `weak`: ReachFive retains its providers, so a strong reference here would create a
+    // ReachFive ↔ DefaultProvider cycle and the SDK graph would never be deallocated (same pattern as
     // LoginWKWebview).
     private weak var reachfive: ReachFive?
     let providerConfig: ProviderConfig
@@ -67,14 +67,13 @@ class DefaultProvider: NSObject, Provider {
 
         switch mode {
         case .customScheme:
-            // Le custom scheme n'a pas besoin de l'`universalLink` du backend : la redirect_uri est celle
-            // du SdkConfig.
+            // A custom scheme needs no `universalLink` from the backend: the redirect_uri is the SdkConfig's.
             webSessionMode = .customScheme
 
         case .universalLink:
-            // Deux causes d'échec différé : la configuration backend ne porte pas d'`universalLink`, ou
-            // l'OS est trop ancien. Le cas `.universalLink` est inconstructible sous iOS 17.4 côté
-            // appelant, mais il est ici résolu depuis la configuration backend — contrôle runtime.
+            // Two causes of deferred failure: the backend configuration carries no `universalLink`, or the OS
+            // is too old. `.universalLink` cannot be constructed below iOS 17.4 on the caller's side, but here
+            // it is resolved from the backend configuration, hence the runtime check.
             guard let link = providerConfig.universalLink else {
                 Logger.shared.log("No universal link configured for provider '\(providerConfig.provider)' in universal-link mode; login() will fail with a TechnicalError.")
                 webSessionMode = nil

--- a/Sources/Core/Classes/DefaultProvider.swift
+++ b/Sources/Core/Classes/DefaultProvider.swift
@@ -4,7 +4,7 @@ import AuthenticationServices
 /// Registers a **web** provider (one without a native SDK component, served by `DefaultProvider`) so the app
 /// can pick its **variant** and its **completion mode**
 ///
-/// Example: `WebProvider(name: .bconnect, variant: "natif", mode: .externalAppUniversalLink)`.
+/// Example: `WebProvider(name: .bconnect, variant: "natif", mode: .customScheme)`.
 public final class WebProvider: ProviderCreator {
     /// The SLO providers supported by the backend. `rawValue` is the backend name.
     public enum Name: String {
@@ -19,29 +19,15 @@ public final class WebProvider: ProviderCreator {
     }
 
     /// How this provider's login session completes. Same choices as ``WebSessionMode``, resolved into it by
-    /// `DefaultProvider.init` (a universal-link mode uses the provider's `universalLink` from its backend config).
-    public struct WebProviderMode {
-        enum Callback { case customScheme, universalLink }
-        let callback: Callback
-        let channel: WebSessionMode.Channel
-
-        private init(callback: Callback, channel: WebSessionMode.Channel) {
-            self.callback = callback
-            self.channel = channel
-        }
-
-        /// Custom scheme intercepted in the sheet — the default, on every iOS version.
-        public static let sdkScheme = WebProviderMode(callback: .customScheme, channel: .inBand)
-
-        /// An external app reopens the host app via the custom scheme.
-        public static let externalAppScheme = WebProviderMode(callback: .customScheme, channel: .outOfBand)
-
-        /// An external app reopens the host app via a universal link.
-        public static let externalAppUniversalLink = WebProviderMode(callback: .universalLink, channel: .outOfBand)
+    /// `DefaultProvider.init` (`universalLink` uses the provider's `universalLink` from its backend config).
+    public enum WebProviderMode {
+        /// Custom scheme — the default, on every iOS version. Covers both a redirection intercepted in
+        /// the sheet and one delivered by the default browser to `application(_:open:)`.
+        case customScheme
 
         /// Universal link intercepted in the sheet (via `callback: .https`).
         @available(iOS 17.4, *)
-        public static let inSheetUniversalLink = WebProviderMode(callback: .universalLink, channel: .inBand)
+        case universalLink
     }
 
     private let providerName: Name
@@ -49,7 +35,7 @@ public final class WebProvider: ProviderCreator {
     public let variant: String?
     public let mode: WebProviderMode
 
-    public init(name: Name, variant: String? = nil, mode: WebProviderMode = .sdkScheme) {
+    public init(name: Name, variant: String? = nil, mode: WebProviderMode = .customScheme) {
         self.providerName = name
         self.variant = variant
         self.mode = mode
@@ -73,34 +59,33 @@ class DefaultProvider: NSObject, Provider {
     public init(
         reachfive: ReachFive,
         providerConfig: ProviderConfig,
-        mode: WebProvider.WebProviderMode = .sdkScheme
+        mode: WebProvider.WebProviderMode = .customScheme
     ) {
         self.reachfive = reachfive
         self.providerConfig = providerConfig
         self.name = providerConfig.provider
 
-        switch mode.callback {
+        switch mode {
         case .customScheme:
             // Le custom scheme n'a pas besoin de l'`universalLink` du backend : la redirect_uri est celle
-            // du SdkConfig, in-band comme hors-bande.
-            webSessionMode = mode.channel == .inBand ? .sdkScheme : .externalAppScheme
+            // du SdkConfig.
+            webSessionMode = .customScheme
 
         case .universalLink:
+            // Deux causes d'échec différé : la configuration backend ne porte pas d'`universalLink`, ou
+            // l'OS est trop ancien. Le cas `.universalLink` est inconstructible sous iOS 17.4 côté
+            // appelant, mais il est ici résolu depuis la configuration backend — contrôle runtime.
             guard let link = providerConfig.universalLink else {
                 Logger.shared.log("No universal link configured for provider '\(providerConfig.provider)' in universal-link mode; login() will fail with a TechnicalError.")
                 webSessionMode = nil
                 return
             }
-            if mode.channel == .inBand {
-                guard #available(iOS 17.4, *) else {
-                    Logger.shared.log("In-sheet universal link requires iOS 17.4+; login() for provider '\(providerConfig.provider)' will fail with a TechnicalError.")
-                    webSessionMode = nil
-                    return
-                }
-                webSessionMode = .inSheetUniversalLink(link)
-            } else {
-                webSessionMode = .externalAppUniversalLink(link)
+            guard #available(iOS 17.4, *) else {
+                Logger.shared.log("Universal link callback requires iOS 17.4+; login() for provider '\(providerConfig.provider)' will fail with a TechnicalError.")
+                webSessionMode = nil
+                return
             }
+            webSessionMode = .universalLink(link)
         }
     }
 

--- a/Sources/Core/Classes/LoginWKWebview.swift
+++ b/Sources/Core/Classes/LoginWKWebview.swift
@@ -12,14 +12,7 @@ public class LoginWKWebview: UIView {
     }
 
     /// Loads the ReachFive **first-party** login form into this embedded webview and awaits the
-    /// `AuthToken`. The flow completes in-band on the SDK's custom scheme, intercepted by the webview.
-    ///
-    /// **`WebProvider` logins** are not supported by this path: their callback completes the
-    /// `ASWebAuthenticationSession` held by `ReachFive` — whether it lands in the sheet, in
-    /// `application(_:open:)` after a detour through a third-party app, or in
-    /// `application(_:continue:)` as a universal link — never in this webview. Third-party OAuth
-    /// providers also generally reject embedded webviews. Use ``ReachFive/webviewLogin(_:)`` (or a
-    /// `WebProvider`) for them.
+    /// `AuthToken`. The flow completes on the SDK's custom scheme, intercepted by the webview.
     public func loadLoginWebview(reachfive: ReachFive, state: String? = nil, nonce: String? = nil, scope: [String]? = nil, origin: String? = nil) async throws -> AuthToken {
         let pkce = Pkce.generate()
         self.reachfive = reachfive

--- a/Sources/Core/Classes/LoginWKWebview.swift
+++ b/Sources/Core/Classes/LoginWKWebview.swift
@@ -13,6 +13,8 @@ public class LoginWKWebview: UIView {
 
     /// Loads the ReachFive **first-party** login form into this embedded webview and awaits the
     /// `AuthToken`. The flow completes on the SDK's custom scheme, intercepted by the webview.
+    ///
+    /// **Only flows that never leave the app are supported by this path.**
     public func loadLoginWebview(reachfive: ReachFive, state: String? = nil, nonce: String? = nil, scope: [String]? = nil, origin: String? = nil) async throws -> AuthToken {
         let pkce = Pkce.generate()
         self.reachfive = reachfive

--- a/Sources/Core/Classes/LoginWKWebview.swift
+++ b/Sources/Core/Classes/LoginWKWebview.swift
@@ -14,10 +14,12 @@ public class LoginWKWebview: UIView {
     /// Loads the ReachFive **first-party** login form into this embedded webview and awaits the
     /// `AuthToken`. The flow completes in-band on the SDK's custom scheme, intercepted by the webview.
     ///
-    /// **Universal-link** providers are not supported by this path: their out-of-band callback comes
-    /// in through `application(_:continue:)` and completes the session held by `ReachFive`, not this
-    /// webview — and third-party OAuth providers generally reject embedded webviews. Use
-    /// ``ReachFive/webviewLogin(_:)`` (or a `WebProvider`) for them.
+    /// **`WebProvider` logins** are not supported by this path: their callback completes the
+    /// `ASWebAuthenticationSession` held by `ReachFive` — whether it lands in the sheet, in
+    /// `application(_:open:)` after a detour through a third-party app, or in
+    /// `application(_:continue:)` as a universal link — never in this webview. Third-party OAuth
+    /// providers also generally reject embedded webviews. Use ``ReachFive/webviewLogin(_:)`` (or a
+    /// `WebProvider`) for them.
     public func loadLoginWebview(reachfive: ReachFive, state: String? = nil, nonce: String? = nil, scope: [String]? = nil, origin: String? = nil) async throws -> AuthToken {
         let pkce = Pkce.generate()
         self.reachfive = reachfive

--- a/Sources/Core/Classes/Presentation.swift
+++ b/Sources/Core/Classes/Presentation.swift
@@ -59,9 +59,10 @@ public struct Presentation {
     }
 }
 
-// `ASWebAuthenticationSession.presentationContextProvider` est `weak` : l'adaptateur doit être
-// retenu ailleurs pendant la session. C'est le cas via `WebviewLoginRequest.presentationContextProvider`
-// (`let` fort), vivant pendant tout `webviewLogin` → `webAuthSession.start(...)`.
+// `ASWebAuthenticationSession.presentationContextProvider` is `weak`, so the adapter has to be retained
+// elsewhere for the duration of the session. It is, through
+// `WebviewLoginRequest.presentationContextProvider` (a strong `let`), which stays alive for the whole
+// `webviewLogin` → `webAuthSession.start(...)` call.
 private final class ViewControllerContextProvider: NSObject, ASWebAuthenticationPresentationContextProviding {
     private weak var viewController: UIViewController?
 
@@ -70,6 +71,36 @@ private final class ViewControllerContextProvider: NSObject, ASWebAuthentication
     }
 
     func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
-        viewController?.view.window ?? ASPresentationAnchor()
+        if let window = viewController?.view.window {
+            return window
+        }
+        // The presenting view controller is gone — deallocated, or dismissed since the request was built
+        // (`WebviewLoginRequest.init(presenting:)` resolves this provider at construction time, the session
+        // asks for the anchor later). The protocol offers no way to fail, and a bare `ASPresentationAnchor()`
+        // belongs to no scene, so the system would always answer `presentationContextInvalid`. Falling back
+        // to the app's own key window lets the login go through, anchored elsewhere.
+        if let window = Self.activeSceneKeyWindow() {
+            Logger.shared.log("The presenting view controller is no longer attached to a window; anchoring the web session on the app's key window instead. Call login() after the view appeared (e.g. from viewDidAppear), not from viewDidLoad.")
+            return window
+        }
+        Logger.shared.log("No window available to anchor the web session: it will fail with presentationContextInvalid. Call login() after the view appeared (e.g. from viewDidAppear), not from viewDidLoad.")
+        return ASPresentationAnchor()
+    }
+
+    /// The key window of a foreground scene, if there is one.
+    ///
+    /// There is no app-level shortcut for this on purpose: `UIApplication.keyWindow` is deprecated since
+    /// iOS 13 ("returns a key window across all connected scenes"), and the standard replacement,
+    /// `UIWindowScene.keyWindow`, is per-scene and iOS 15+. Picking the relevant scene is the app's call, so
+    /// it has to be spelled out here — and scanning `windows` for `isKeyWindow` gives the same result while
+    /// staying on the iOS 13 floor this package targets.
+    private static func activeSceneKeyWindow() -> UIWindow? {
+        let scenes = UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }
+        // Prefer a foreground-active scene, but accept a foreground-inactive one: a programmatic login or
+        // logout can run while the app is still being brought back to the foreground — which is exactly the
+        // situation a return from a third-party app creates.
+        let candidates = scenes.filter { $0.activationState == .foregroundActive }
+            + scenes.filter { $0.activationState == .foregroundInactive }
+        return candidates.flatMap(\.windows).first(where: \.isKeyWindow)
     }
 }

--- a/Sources/Core/Classes/ReachFive.swift
+++ b/Sources/Core/Classes/ReachFive.swift
@@ -32,7 +32,7 @@ public class ReachFive: NSObject {
     internal var clientConfig: ClientConfigResponse? = nil
     public let storage: Storage
     let credentialManager: CredentialManager
-    // Session de login web en cours (cf. ``WebAuthenticationSession``).
+    // The web login in progress (see ``WebAuthenticationSession``).
     let webAuthSession: WebAuthenticationSession
     public let pkceKey = "PASSWORDLESS_PKCE"
 
@@ -57,27 +57,34 @@ public class ReachFive: NSObject {
         """
     }
 
+    /// Routes an incoming URL to the matching SDK interception (passwordless, MFA, account recovery,
+    /// email verification). An URL that matches none of the ``SdkConfig`` URIs falls back to
+    /// `interceptPasswordless`, as it always has.
     public func interceptUrl(_ url: URL) -> () {
-        let receivedUrl = URLComponents(url: url, resolvingAgainstBaseURL: true)
-
-        let recovery = URLComponents(url: sdkConfig.accountRecoveryUri, resolvingAgainstBaseURL: true)
-        let mfa = URLComponents(url: sdkConfig.mfaUri, resolvingAgainstBaseURL: true)
-        let passwordless = URLComponents(url: sdkConfig.redirectUri, resolvingAgainstBaseURL: true)
-        let emailVerification = URLComponents(url: sdkConfig.emailVerificationUri, resolvingAgainstBaseURL: true)
-
-        switch (receivedUrl?.host, receivedUrl?.path) {
-
-        case (recovery?.host, recovery?.path): interceptAccountRecovery(url)
-        case (mfa?.host, mfa?.path): interceptVerifyMfaCredential(url)
-        case (passwordless?.host, passwordless?.path): interceptPasswordless(url)
-        case (emailVerification?.host, emailVerification?.path): interceptEmailVerification(url)
-
-            // fallback to old way of doing things if url components are not properly extracted
-        case ("account-recovery", _): interceptAccountRecovery(url)
-        case ("mfa", _): interceptVerifyMfaCredential(url)
-        case ("callback", _): interceptPasswordless(url)
-
-        default: interceptPasswordless(url)
+        if !routeUrl(url) {
+            interceptPasswordless(url)
         }
+    }
+
+    /// Same routing as ``interceptUrl(_:)``, but reports whether the URL actually matched one of the
+    /// ``SdkConfig`` URIs instead of falling back to passwordless.
+    /// Used by `application(_:open:)`, which must tell the host app when nothing of ours consumed the URL.
+    ///
+    /// The matching goes through ``matchesEndpoint(of:)``, the same matcher
+    /// `WebAuthenticationSession.isOurCallback` uses, so the two entry hooks can't disagree
+    @discardableResult
+    internal func routeUrl(_ url: URL) -> Bool {
+        if url.matchesEndpoint(of: sdkConfig.accountRecoveryUri) {
+            interceptAccountRecovery(url)
+        } else if url.matchesEndpoint(of: sdkConfig.mfaUri) {
+            interceptVerifyMfaCredential(url)
+        } else if url.matchesEndpoint(of: sdkConfig.redirectUri) {
+            interceptPasswordless(url)
+        } else if url.matchesEndpoint(of: sdkConfig.emailVerificationUri) {
+            interceptEmailVerification(url)
+        } else {
+           return false
+        }
+        return true
     }
 }

--- a/Sources/Core/Classes/ReachFiveApplication.swift
+++ b/Sources/Core/Classes/ReachFiveApplication.swift
@@ -6,8 +6,7 @@ public extension ReachFive {
     func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any]) -> Bool {
         // Out-of-band "custom scheme" channel: a third-party app reopens the host app through the SDK's
         // scheme. The web-auth session is tried first — its matching is exact (scheme + host + path +
-        // code/error of the expected redirect_uri, and it is only armed while a login is in flight) —
-        // otherwise `routeUrl` would swallow the link as a passwordless callback.
+        // code/error of the expected redirect_uri) — otherwise `routeUrl` would swallow the link as a passwordless callback.
         if webAuthSession.tryComplete(externalCallbackURL: url) {
             return true
         }

--- a/Sources/Core/Classes/ReachFiveApplication.swift
+++ b/Sources/Core/Classes/ReachFiveApplication.swift
@@ -4,19 +4,23 @@ import UIKit
 public extension ReachFive {
     @MainActor
     func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any]) -> Bool {
-        // Canal hors-bande « custom scheme » : une app externe rouvre l'app hôte par le scheme du SDK.
-        // On teste la session web-auth d'abord — son matching est exact (scheme + host + path + code/error
-        // de la redirect_uri attendue, et n'est armé que pendant un login hors-bande en cours) — sinon
-        // `interceptUrl` avalerait le lien comme un callback passwordless.
+        // Out-of-band "custom scheme" channel: a third-party app reopens the host app through the SDK's
+        // scheme. The web-auth session is tried first — its matching is exact (scheme + host + path +
+        // code/error of the expected redirect_uri, and it is only armed while a login is in flight) —
+        // otherwise `routeUrl` would swallow the link as a passwordless callback.
         if webAuthSession.tryComplete(externalCallbackURL: url) {
             return true
         }
 
-        interceptUrl(url)
+        // Returns true only if the URL was consumed (same contract as `application(_:continue:)`): a host
+        // app that forwards all of its links to us must be able to route the ones that aren't ours. That is
+        // why `routeUrl` does not fall back to `interceptPasswordless`, unlike `interceptUrl` called
+        // directly.
+        var handled = routeUrl(url)
         for provider in providers {
-            let _ = provider.application(app, open: url, options: options)
+            handled = provider.application(app, open: url, options: options) || handled
         }
-        return true
+        return handled
     }
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
@@ -42,20 +46,9 @@ public extension ReachFive {
         }
     }
 
-    @MainActor
     func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
-        // D'abord la session web-auth : son matching est exact (host + path + code/error du
-        // redirect_uri attendu), aucun risque d'avaler un lien qui ne lui est pas destiné — alors
-        // qu'un provider custom peut consommer l'activité plus largement et lui masquer son callback.
-        if userActivity.activityType == NSUserActivityTypeBrowsingWeb,
-           let url = userActivity.webpageURL,
-           webAuthSession.tryComplete(externalCallbackURL: url) {
-            return true
-        }
-
-        // …puis les providers. Ne renvoie true QUE si l'un d'eux a consommé l'activité (sinon false,
-        // pour que l'app hôte — qui nous forwarde tous ses liens — route elle-même les liens que
-        // ReachFive ne gère pas).
+        // Returns true only if a provider consumed the activity (false otherwise, so the host app — which
+        // forwards all of its links to us — routes the ones ReachFive does not handle).
         var handled = false
         for provider in providers {
             handled = provider.application(application, continue: userActivity, restorationHandler: restorationHandler) || handled

--- a/Sources/Core/Classes/ReachFiveError.swift
+++ b/Sources/Core/Classes/ReachFiveError.swift
@@ -64,13 +64,14 @@ public enum ReachFiveError: Error, CustomStringConvertible, LocalizedError {
     case RequestError(apiError: ApiError)
     case AuthFailure(reason: String, apiError: ApiError? = nil)
     /// Nothing happened, and nothing is expected of the caller. Returned when the system finds no credential
-    /// and the authentication ends silently, when the user cancels the request, and when a web login is
-    /// dropped because another one is already in progress (a double tap on a login control — see
-    /// ``WebAuthenticationSession``).
+    /// and the authentication ends silently, when the user cancels the request, and in two cases during a web login:
+    /// - when the login is dropped because another one is already in progress
+    /// - when the app is not associated with the host of an `.https` callback
     ///
     /// Ignoring it is a valid way to handle it. On the first two causes it is also a good time to show a
-    /// traditional login form, or ask the user to create an account; on the third there is nothing to show,
-    /// the login the user actually meant is still running.
+    /// traditional login form, or ask the user to create an account;
+    /// on the third there is nothing to show, the login the user actually meant is still running;
+    /// on the fourth it is a configuration error, so nothing the app can fix.
     case AuthCanceled
     case TechnicalError(reason: String, apiError: ApiError? = nil)
 }

--- a/Sources/Core/Classes/ReachFiveError.swift
+++ b/Sources/Core/Classes/ReachFiveError.swift
@@ -63,8 +63,14 @@ public enum ReachFiveError: Error, CustomStringConvertible, LocalizedError {
 
     case RequestError(apiError: ApiError)
     case AuthFailure(reason: String, apiError: ApiError? = nil)
-    /// Returned after signin requests. Either the system doesn't find any credentials and the authentification ends silently, or the user cancels the request.
-    /// This is a good time to show a traditional login form, or ask the user to create an account.
+    /// Nothing happened, and nothing is expected of the caller. Returned when the system finds no credential
+    /// and the authentication ends silently, when the user cancels the request, and when a web login is
+    /// dropped because another one is already in progress (a double tap on a login control — see
+    /// ``WebAuthenticationSession``).
+    ///
+    /// Ignoring it is a valid way to handle it. On the first two causes it is also a good time to show a
+    /// traditional login form, or ask the user to create an account; on the third there is nothing to show,
+    /// the login the user actually meant is still running.
     case AuthCanceled
     case TechnicalError(reason: String, apiError: ApiError? = nil)
 }

--- a/Sources/Core/Classes/ReachFiveLogin.swift
+++ b/Sources/Core/Classes/ReachFiveLogin.swift
@@ -17,7 +17,7 @@ public extension ReachFive {
 
             let _ = try? await webAuthSession.start(
                 url: reachFiveApi.buildLogoutURL(queryParams: options),
-                mode: .sdkScheme,
+                mode: .customScheme,
                 presentationContextProvider: request.presentationContextProvider,
                 prefersEphemeralWebBrowserSession: false)
         }

--- a/Sources/Core/Classes/ReachFiveLogin.swift
+++ b/Sources/Core/Classes/ReachFiveLogin.swift
@@ -19,7 +19,7 @@ public extension ReachFive {
                 url: reachFiveApi.buildLogoutURL(queryParams: options),
                 mode: .customScheme,
                 // A logout callback carries no `code` and is intercepted by the sheet, so the out-of-band
-                // channel must not be armed: a login code straying in would otherwise resolve this logout
+                // channel must not be prepared: a login code straying in would otherwise resolve this logout
                 // and be swallowed (the logout's continuation ignores the URL).
                 expectsAuthorizationCode: false,
                 presentationContextProvider: request.presentationContextProvider,

--- a/Sources/Core/Classes/ReachFiveLogin.swift
+++ b/Sources/Core/Classes/ReachFiveLogin.swift
@@ -18,6 +18,10 @@ public extension ReachFive {
             let _ = try? await webAuthSession.start(
                 url: reachFiveApi.buildLogoutURL(queryParams: options),
                 mode: .customScheme,
+                // A logout callback carries no `code` and is intercepted by the sheet, so the out-of-band
+                // channel must not be armed: a login code straying in would otherwise resolve this logout
+                // and be swallowed (the logout's continuation ignores the URL).
+                expectsAuthorizationCode: false,
                 presentationContextProvider: request.presentationContextProvider,
                 prefersEphemeralWebBrowserSession: false)
         }

--- a/Sources/Core/Classes/ReachFiveWebviewLogin.swift
+++ b/Sources/Core/Classes/ReachFiveWebviewLogin.swift
@@ -4,19 +4,24 @@ import AuthenticationServices
 public extension ReachFive {
 
     /// Orchestrates the whole web login: PKCE, authorize URL, web session (via the centralized carrier),
-    /// then code exchange. The session is carried by `ReachFive` so that a callback arriving *outside*
-    /// the sheet — `application(_:open:)` when a third-party app detour sends the user back through the
-    /// default browser, or `application(_:continue:)` for a universal link — can complete it, even for a
-    /// direct call to this public API.
+    /// then code exchange. The session is carried by `ReachFive` so that a callback arriving *outside* the
+    /// sheet — through `application(_:open:)`, when a third-party app detour sends the user back via the
+    /// default browser — can complete it, even for a direct call to this public API.
     func webviewLogin(_ request: WebviewLoginRequest) async throws -> AuthToken {
 
         let pkce = Pkce.generate()
+        // FIXME: this write lands in the *passwordless* PKCE slot, shared by every authorize-style flow.
+        // Two behaviours follows:
+        //   - a magic link tapped after the hosted login page switched to passwordless is completed by
+        //     `interceptPasswordless` using this PKCE;
+        //   - if iOS kills the app mid-detour, the callback received on relaunch is likewise completed by
+        //     `interceptPasswordless`, delivering this web login's token on the `passwordlessCallback`.
+        // The first is intentional, but the second is not.
+        // And it seems that starting a web login while a passwordless is pending overwrites the PKCE, so its magic link then fails.
         storage.save(key: pkceKey, value: pkce)
 
         let scope = (request.scope ?? scope)
         let mode = request.webSessionMode
-        // La `redirect_uri` du mode (nil pour un custom scheme, où le SdkConfig s'applique) est utilisée
-        // à l'identique pour `/authorize` et l'échange du code — exigence OAuth : les deux doivent coïncider.
         let authURL = buildAuthorizeURL(pkce: pkce, state: request.state, nonce: request.nonce, scope: scope, origin: request.origin, provider: request.provider, redirectUri: mode.redirectUri, loginUrlFragment: request.loginUrlFragment)
 
         let callbackURL = try await webAuthSession.start(

--- a/Sources/Core/Classes/ReachFiveWebviewLogin.swift
+++ b/Sources/Core/Classes/ReachFiveWebviewLogin.swift
@@ -15,7 +15,7 @@ public extension ReachFive {
         // Not airtight: reading the session suspends, so two calls in the same turn both get past this and
         // are only told apart by `start(...)`.
         guard !(await webAuthSession.isLoginInProgress) else {
-            Logger.shared.log("A web login is already in progress; this call is dropped before arming anything.")
+            Logger.shared.log("A web login is already in progress; this call is dropped before preparing anything.")
             throw ReachFiveError.AuthCanceled
         }
 

--- a/Sources/Core/Classes/ReachFiveWebviewLogin.swift
+++ b/Sources/Core/Classes/ReachFiveWebviewLogin.swift
@@ -4,9 +4,10 @@ import AuthenticationServices
 public extension ReachFive {
 
     /// Orchestrates the whole web login: PKCE, authorize URL, web session (via the centralized carrier),
-    /// then code exchange. The session is carried by `ReachFive` so that a return via universal link
-    /// (received through `application(_:continue:)`) can complete it out-of-band, even for a direct call
-    /// to this public API.
+    /// then code exchange. The session is carried by `ReachFive` so that a callback arriving *outside*
+    /// the sheet — `application(_:open:)` when a third-party app detour sends the user back through the
+    /// default browser, or `application(_:continue:)` for a universal link — can complete it, even for a
+    /// direct call to this public API.
     func webviewLogin(_ request: WebviewLoginRequest) async throws -> AuthToken {
 
         let pkce = Pkce.generate()

--- a/Sources/Core/Classes/ReachFiveWebviewLogin.swift
+++ b/Sources/Core/Classes/ReachFiveWebviewLogin.swift
@@ -28,8 +28,10 @@ public extension ReachFive {
         //     completed by `interceptPasswordless` using this PKCE;
         //   - not intentional: if iOS kills the app mid-detour, the callback received on relaunch is likewise
         //     completed by `interceptPasswordless`, delivering this web login's token on the
-        //     `passwordlessCallback` — a channel no caller asked for, but which does rescue the `code`;
-        //   - not intentional: starting a web login while a passwordless is pending overwrites its PKCE, so
+	    //     `passwordlessCallback` — a channel no caller asked for, but which does rescue the `code`.
+	    //     The same happens without a kill: cancel the login locally (sheet closed, `Task` cancelled) while the browser
+	    //     is still on its way, and the callback that lands afterwards takes that same detour;
+	    //   - not intentional: starting a web login while a passwordless is pending overwrites its PKCE, so
         //     its magic link then fails.
         // The guard above keeps a dropped call from adding a fourth. The fix is a slot per flow instead of one
         // shared key, which would also let the login in progress be persisted and resumed after an app kill:

--- a/Sources/Core/Classes/ReachFiveWebviewLogin.swift
+++ b/Sources/Core/Classes/ReachFiveWebviewLogin.swift
@@ -9,35 +9,31 @@ public extension ReachFive {
     /// default browser — can complete it, even for a direct call to this public API.
     func webviewLogin(_ request: WebviewLoginRequest) async throws -> AuthToken {
 
-        // Asked here and not only inside `webAuthSession.start(...)`, because the PKCE write below has to
-        // happen before the sheet opens and lands in a slot shared by every authorize-style flow: a call that
-        // is going to be dropped must not leave its PKCE where the login already under way expects its own.
-        // Measured on a device: the first web login of a session waits on iOS launching its browser process,
-        // and an impatient user taps a couple of dozen more times before the sheet appears — that many
-        // overwrites, one per dropped call.
-        //
-        // Not airtight: reading the session suspends, so two calls in the same turn can still both get past
-        // this and only be told apart by `start(...)`. Closing that window means arming the storage in the
-        // same main-actor turn as the slot, which the shared slot makes pointless — see the FIXME below.
+        // Dropped here rather than by `webAuthSession.start(...)`, because the PKCE write below has to happen
+        // before the sheet opens and lands in a slot shared by every authorize-style flow (see the FIXME): a
+        // call that is going to be dropped must not leave its PKCE where the login under way expects its own.
+        // Measured on a device: the first web login waits on iOS launching its browser process, and an
+        // impatient user taps a couple of dozen more times meanwhile — that many overwrites otherwise.
+        // Not airtight: reading the session suspends, so two calls in the same turn both get past this and
+        // are only told apart by `start(...)`.
         guard !(await webAuthSession.isLoginInProgress) else {
             Logger.shared.log("A web login is already in progress; this call is dropped before arming anything.")
             throw ReachFiveError.AuthCanceled
         }
 
         let pkce = Pkce.generate()
-        // FIXME: this write lands in the *passwordless* PKCE slot, shared by every authorize-style flow.
-        // Two behaviours follows:
-        //   - a magic link tapped after the hosted login page switched to passwordless is completed by
-        //     `interceptPasswordless` using this PKCE;
-        //   - if iOS kills the app mid-detour, the callback received on relaunch is likewise completed by
-        //     `interceptPasswordless`, delivering this web login's token on the `passwordlessCallback`.
-        // The first is intentional, but the second is not.
-        // And it seems that starting a web login while a passwordless is pending overwrites the PKCE, so its magic link then fails.
-        // Same cause, one more consequence: this write happens *before* `webAuthSession.start(...)` can drop
-        // the call, because the PKCE has to be in storage while the sheet is open. On a double tap the
-        // dropped call therefore leaves its own PKCE behind, and the login that survives no longer matches
-        // what the slot holds — so both rescues above would fail for it. Fixing the ordering needs a slot
-        // per login rather than one shared key, i.e. the storage-slot redesign.
+        // FIXME: this write lands in the *passwordless* PKCE slot, shared by every authorize-style flow, which
+        // makes three behaviours possible:
+        //   - intentional: a magic link tapped after the hosted login page switched to passwordless is
+        //     completed by `interceptPasswordless` using this PKCE;
+        //   - not intentional: if iOS kills the app mid-detour, the callback received on relaunch is likewise
+        //     completed by `interceptPasswordless`, delivering this web login's token on the
+        //     `passwordlessCallback` — a channel no caller asked for, but which does rescue the `code`;
+        //   - not intentional: starting a web login while a passwordless is pending overwrites its PKCE, so
+        //     its magic link then fails.
+        // The guard above keeps a dropped call from adding a fourth. The fix is a slot per flow instead of one
+        // shared key, which would also let the login in progress be persisted and resumed after an app kill:
+        // see the storage-slot redesign.
         storage.save(key: pkceKey, value: pkce)
 
         let scope = (request.scope ?? scope)

--- a/Sources/Core/Classes/ReachFiveWebviewLogin.swift
+++ b/Sources/Core/Classes/ReachFiveWebviewLogin.swift
@@ -26,12 +26,14 @@ public extension ReachFive {
         // makes three behaviours possible:
         //   - intentional: a magic link tapped after the hosted login page switched to passwordless is
         //     completed by `interceptPasswordless` using this PKCE;
-        //   - not intentional: if iOS kills the app mid-detour, the callback received on relaunch is likewise
-        //     completed by `interceptPasswordless`, delivering this web login's token on the
-	    //     `passwordlessCallback` — a channel no caller asked for, but which does rescue the `code`.
-	    //     The same happens without a kill: cancel the login locally (sheet closed, `Task` cancelled) while the browser
-	    //     is still on its way, and the callback that lands afterwards takes that same detour;
-	    //   - not intentional: starting a web login while a passwordless is pending overwrites its PKCE, so
+        //   - not intentional: the `code` gets rescued on a channel no caller asked for. The active b.connect
+        //     detour finishes on its own whatever we do to the sheet — the bank app, then the default browser,
+        //     carry the rest of the chain and deliver the callback to `application(_:open:)` regardless. If
+        //     the slot is empty by then (the login cancelled locally at any point of the detour, or the app
+        //     killed and relaunched by the link itself), `tryComplete` matches nothing and `routeUrl` hands our
+        //     own callback to `interceptPasswordless`, which delivers this web login's token on the
+        //     `passwordlessCallback`;
+        //   - not intentional: starting a web login while a passwordless is pending overwrites its PKCE, so
         //     its magic link then fails.
         // The guard above keeps a dropped call from adding a fourth. The fix is a slot per flow instead of one
         // shared key, which would also let the login in progress be persisted and resumed after an app kill:

--- a/Sources/Core/Classes/ReachFiveWebviewLogin.swift
+++ b/Sources/Core/Classes/ReachFiveWebviewLogin.swift
@@ -5,15 +5,13 @@ public extension ReachFive {
 
     /// Orchestrates the whole web login: PKCE, authorize URL, web session (via the centralized carrier),
     /// then code exchange. The session is carried by `ReachFive` so that a callback arriving *outside* the
-    /// sheet — through `application(_:open:)`, when a third-party app detour sends the user back via the
-    /// default browser — can complete it, even for a direct call to this public API.
+    /// sheet — through `application(_:open:)`, when a third-party app detour sends the user back —
+    /// can complete it, even for a direct call to this public API.
     func webviewLogin(_ request: WebviewLoginRequest) async throws -> AuthToken {
 
         // Dropped here rather than by `webAuthSession.start(...)`, because the PKCE write below has to happen
-        // before the sheet opens and lands in a slot shared by every authorize-style flow (see the FIXME): a
+        // before the sheet opens, and lands in a slot shared by every authorize-style flow (see the FIXME): a
         // call that is going to be dropped must not leave its PKCE where the login under way expects its own.
-        // Measured on a device: the first web login waits on iOS launching its browser process, and an
-        // impatient user taps a couple of dozen more times meanwhile — that many overwrites otherwise.
         // Not airtight: reading the session suspends, so two calls in the same turn both get past this and
         // are only told apart by `start(...)`.
         guard !(await webAuthSession.isLoginInProgress) else {

--- a/Sources/Core/Classes/ReachFiveWebviewLogin.swift
+++ b/Sources/Core/Classes/ReachFiveWebviewLogin.swift
@@ -9,6 +9,21 @@ public extension ReachFive {
     /// default browser — can complete it, even for a direct call to this public API.
     func webviewLogin(_ request: WebviewLoginRequest) async throws -> AuthToken {
 
+        // Asked here and not only inside `webAuthSession.start(...)`, because the PKCE write below has to
+        // happen before the sheet opens and lands in a slot shared by every authorize-style flow: a call that
+        // is going to be dropped must not leave its PKCE where the login already under way expects its own.
+        // Measured on a device: the first web login of a session waits on iOS launching its browser process,
+        // and an impatient user taps a couple of dozen more times before the sheet appears — that many
+        // overwrites, one per dropped call.
+        //
+        // Not airtight: reading the session suspends, so two calls in the same turn can still both get past
+        // this and only be told apart by `start(...)`. Closing that window means arming the storage in the
+        // same main-actor turn as the slot, which the shared slot makes pointless — see the FIXME below.
+        guard !(await webAuthSession.isLoginInProgress) else {
+            Logger.shared.log("A web login is already in progress; this call is dropped before arming anything.")
+            throw ReachFiveError.AuthCanceled
+        }
+
         let pkce = Pkce.generate()
         // FIXME: this write lands in the *passwordless* PKCE slot, shared by every authorize-style flow.
         // Two behaviours follows:

--- a/Sources/Core/Classes/ReachFiveWebviewLogin.swift
+++ b/Sources/Core/Classes/ReachFiveWebviewLogin.swift
@@ -18,6 +18,11 @@ public extension ReachFive {
         //     `interceptPasswordless`, delivering this web login's token on the `passwordlessCallback`.
         // The first is intentional, but the second is not.
         // And it seems that starting a web login while a passwordless is pending overwrites the PKCE, so its magic link then fails.
+        // Same cause, one more consequence: this write happens *before* `webAuthSession.start(...)` can drop
+        // the call, because the PKCE has to be in storage while the sheet is open. On a double tap the
+        // dropped call therefore leaves its own PKCE behind, and the login that survives no longer matches
+        // what the slot holds — so both rescues above would fail for it. Fixing the ordering needs a slot
+        // per login rather than one shared key, i.e. the storage-slot redesign.
         storage.save(key: pkceKey, value: pkce)
 
         let scope = (request.scope ?? scope)

--- a/Sources/Core/Classes/models/requests/WebviewLoginRequest.swift
+++ b/Sources/Core/Classes/models/requests/WebviewLoginRequest.swift
@@ -11,7 +11,7 @@ public class WebviewLoginRequest {
     public let prefersEphemeralWebBrowserSession: Bool
     /// The `redirect_uri` of this login and its return channel. The resolved `redirect_uri` must be one
     /// of the client's authorized callback URLs, and is reused identically for the code exchange.
-    /// Default: ``WebSessionMode/sdkScheme``.
+    /// Default: ``WebSessionMode/customScheme``.
     public let webSessionMode: WebSessionMode
     /// Key/value pairs propagated in the **fragment** of the `/oauth/authorize` URL (`#key=value&key2=value2`).
     /// Intended for the token-orchestration flow: `/oauth/authorize` 302-redirects to the client's Login URL,
@@ -28,7 +28,7 @@ public class WebviewLoginRequest {
         origin: String? = nil,
         provider: String? = nil,
         prefersEphemeralWebBrowserSession: Bool = false,
-        webSessionMode: WebSessionMode = .sdkScheme,
+        webSessionMode: WebSessionMode = .customScheme,
         loginUrlFragment: [String: String]? = nil
     ) {
         self.state = state ?? "state"
@@ -56,7 +56,7 @@ public class WebviewLoginRequest {
         origin: String? = nil,
         provider: String? = nil,
         prefersEphemeralWebBrowserSession: Bool = false,
-        webSessionMode: WebSessionMode = .sdkScheme,
+        webSessionMode: WebSessionMode = .customScheme,
         loginUrlFragment: [String: String]? = nil
     ) throws {
         self.init(

--- a/Sources/Core/Classes/web/URL+WebAuth.swift
+++ b/Sources/Core/Classes/web/URL+WebAuth.swift
@@ -9,6 +9,27 @@ extension URL {
             .value
     }
 
+    /// `true` when this URL designates the same endpoint as `expected`: same scheme and same host
+    /// (both case-insensitive, as RFC 3986 requires — `URL.scheme` is *not* normalized by Foundation),
+    /// and the same normalized path.
+    ///
+    /// `""` and `"/"` are treated as the same path: a browser routinely appends the trailing slash to an
+    /// authority-only URL, so a callback declared as `reachfive-<clientId>://callback` can be delivered
+    /// back as `reachfive-<clientId>://callback/`.
+    ///
+    /// This is the SDK's single matcher for its own callback URIs, shared by
+    /// ``ReachFive/interceptUrl(_:)`` and `WebAuthenticationSession.isOurCallback`, so that the two entry
+    /// hooks can never disagree on what is or isn't ours.
+    func matchesEndpoint(of expected: URL) -> Bool {
+        scheme?.lowercased() == expected.scheme?.lowercased()
+            && host?.lowercased() == expected.host?.lowercased()
+            && Self.normalizedPath(path) == Self.normalizedPath(expected.path)
+    }
+
+    private static func normalizedPath(_ path: String) -> String {
+        path == "/" ? "" : path
+    }
+
     /// The authorization `code` of this OAuth callback, or a `TechnicalError` carrying the `ApiError`
     /// described by the callback's parameters (`error`, `error_description`…).
     func authorizationCode() throws -> String {

--- a/Sources/Core/Classes/web/WebAuthentication.swift
+++ b/Sources/Core/Classes/web/WebAuthentication.swift
@@ -5,10 +5,7 @@ import AuthenticationServices
 /// universel) le compléter (``tryComplete(externalCallbackURL:)``).
 ///
 /// **Les deux canaux sont armés pour tout login.** Un provider peut décider *en vol*, feuille déjà
-/// ouverte, s'il termine dedans ou s'il sort de l'app : b.connect choisit `passive` (302 direct vers la
-/// `redirect_uri`, intercepté par la feuille) ou `active` (détour par l'app banque, qui rouvre le
-/// **navigateur par défaut** ; c'est Safari qui livre le custom scheme à `application(_:open:)`, la
-/// feuille restant ouverte derrière jusqu'à sa fermeture par ``complete(attempt:_:)``). L'appelant ne
+/// ouverte, s'il termine dedans ou s'il sort de l'app. L'appelant ne
 /// peut donc pas choisir le canal à l'avance, et n'a pas à le faire.
 ///
 /// **Un seul login à la fois.** Sur iPhone, la feuille modale d'une `ASWebAuthenticationSession` rend
@@ -100,23 +97,12 @@ final class WebAuthenticationSession {
                 let session: ASWebAuthenticationSession
                 switch mode.callback {
                 case .customScheme:
-                    // Les deux canaux sont armés : la feuille intercepte le custom scheme si le flow ne la
-                    // quitte jamais (cas `passive`), et `tryComplete` résout si le retour arrive par le
-                    // navigateur par défaut (cas `active` : app externe → Safari → `application(_:open:)`).
-                    // `complete()` étant idempotent (garde `attempt` + `continuation != nil`), le canal
-                    // perdant est sans effet.
                     session = ASWebAuthenticationSession(
                         url: url,
                         callbackURLScheme: self.baseScheme,
                         completionHandler: completionHandler)
 
                 case let .universalLink(callback):
-                    // iOS 17.4+ : lien universel intercepté dans la webview via `callback: .https`
-                    // (nécessite l'Associated Domain `webcredentials:<host>`). Le cas est inatteignable à
-                    // la compilation sous 17.4 grâce à l'`@available` porté par la fabrique
-                    // ``WebSessionMode/universalLink(_:)``, mais `DefaultProvider` le résout depuis la
-                    // configuration backend, où le contrôle ne peut être que runtime — d'où ce filet (et
-                    // l'extraction du host, faillible).
                     guard #available(iOS 17.4, *), let host = callback.host else {
                         self.complete(attempt: attempt, .failure(.TechnicalError(reason: "Universal link callback requires iOS 17.4+ and a host: \(callback)")))
                         return

--- a/Sources/Core/Classes/web/WebAuthentication.swift
+++ b/Sources/Core/Classes/web/WebAuthentication.swift
@@ -31,9 +31,7 @@ import AuthenticationServices
 @MainActor
 final class WebAuthenticationSession {
 
-    /// Whether a login is in progress, and everything its resolution needs — as **one** value rather than an
-    /// agreement to maintain by hand between a session, a continuation, an expected callback and a boolean.
-    /// Being `idle` and holding a continuation is not a state that can be written.
+    /// Whether a login is in progress, and everything its resolution needs between a session, a continuation, an expected callback and a boolean.
     private enum State {
         case idle
 
@@ -60,9 +58,8 @@ final class WebAuthenticationSession {
         var session: ASWebAuthenticationSession?
     }
 
-    /// Whether the slot is taken — for a caller with side effects to arm *before* presenting, which must not
-    /// arm them for a call `start(...)` is going to drop (see ``ReachFive/webviewLogin(_:)``). Internal on
-    /// purpose: an integrator has nothing to check, a dropped call already ends with `.AuthCanceled`.
+    /// Whether the slot is taken: a caller must not apply side effects *before* calling a `start(...)` that would  be knwon to be refused (see ``ReachFive/webviewLogin(_:)``).
+    /// Internal onpurpose: an integrator has nothing to check, a dropped call already ends with `.AuthCanceled`.
     var isLoginInProgress: Bool {
         if case .idle = state { false } else { true }
     }
@@ -81,12 +78,12 @@ final class WebAuthenticationSession {
     }
 
     /// Starts a web login and waits for its callback (success, error or cancellation). The
-    /// ``WebSessionMode`` drives how the session is built and which channels are armed, as described above.
+    /// ``WebSessionMode`` drives how the session is built and which channels are prepared, as described above.
     /// If the calling `Task` is cancelled (view torn down, timeout…), the sheet is closed and the call ends
     /// with `.AuthCanceled`.
     ///
     /// - Parameter expectsAuthorizationCode: `false` for a call whose callback carries no `code` (logout):
-    ///   the out-of-band channel is then not armed at all.
+    ///   the out-of-band channel is then not prepared at all.
     /// - Throws: `.AuthCanceled` when a web login is already in progress — the call is dropped, the login
     ///   under way is untouched, and the caller has nothing to single out.
     func start(url: URL,
@@ -99,10 +96,9 @@ final class WebAuthenticationSession {
         // already, to no effect, before the continuation was installed).
         try Task.checkCancellation()
 
-        // One login at a time, and the incumbent keeps its place. Silently: a second call is a double tap,
-        // and `.AuthCanceled` is what every integration already ignores.
+        // One login at a time, and the incumbent keeps its place.
         guard case .idle = state else {
-            Logger.shared.log("A web login is already in progress; this call is dropped. Nothing to handle: the login under way keeps the slot.")
+            Logger.shared.log("A web login is already in progress; this call is dropped, the login under way continues.")
             throw ReachFiveError.AuthCanceled
         }
 
@@ -161,7 +157,7 @@ final class WebAuthenticationSession {
         let expectedCallback: URL?
         switch mode.callback {
         case .customScheme:
-            // Arm the out-of-band channel: the provider may decide midway to leave for a third-party app,
+            // Prepare the out-of-band channel: the provider may decide midway to leave for a third-party app,
             // sheet already open, and come back through `application(_:open:)`.
             expectedCallback = expectsAuthorizationCode ? sdkRedirectUri : nil
             session = ASWebAuthenticationSession(
@@ -173,7 +169,7 @@ final class WebAuthenticationSession {
             guard #available(iOS 17.4, *), let host = callback.host else {
                 throw ReachFiveError.TechnicalError(reason: "Universal link callback requires iOS 17.4+ and a host: \(callback)")
             }
-            // No out-of-band channel to arm: `callback: .https(...)` makes the sheet itself intercept the
+            // No out-of-band channel to prepare: `callback: .https(...)` makes the sheet itself intercept the
             // redirection, and nothing else can deliver that link to us — `application(_:open:)` never
             // sees https URLs.
             expectedCallback = nil
@@ -213,7 +209,7 @@ final class WebAuthenticationSession {
         state = .running(login)
 
         if let error {
-            // Logged because `canceledLogin` covers more than the user tapping Cancel: the system also
+            // Logged because `.canceledLogin` covers more than the user tapping Cancel: the system also
             // reports it when the app is not associated with the host of an `.https` callback, and the
             // reason only shows up in `localizedDescription`. Only reached for an error this call is about
             // to deliver, so it never fires for a sheet we closed ourselves.
@@ -244,8 +240,7 @@ final class WebAuthenticationSession {
 
     /// `true` when the incoming URL designates the same endpoint as the `redirect_uri` we sent
     /// (``matchesEndpoint(of:)``, shared with ``ReachFive/interceptUrl(_:)``) and carries a `code` or an
-    /// `error` parameter — an OAuth refusal such as `access_denied` then ends the login cleanly with the
-    /// callback's `ApiError` instead of leaving it on the sheet. Comparing the scheme and the path we declared
+    /// `error` parameter. Comparing the scheme and the path we declared
     /// is enough to tell our callback apart from the app's other links.
     nonisolated static func isOurCallback(_ url: URL, expectedCallback expected: URL) -> Bool {
         url.matchesEndpoint(of: expected)

--- a/Sources/Core/Classes/web/WebAuthentication.swift
+++ b/Sources/Core/Classes/web/WebAuthentication.swift
@@ -104,6 +104,7 @@ final class WebAuthenticationSession {
 
         // One login at a time, and the incumbent keeps its place.
         guard !loginInProgress else {
+            print("🔍 [WebAuth] start REFUSED — slot still held by attempt \(self.attempt) (continuation=\(continuation != nil), session=\(session != nil))") // TEMP DEBUG
             throw ReachFiveError.TechnicalError(reason: "A web login is already in progress. Wait for it to finish, or cancel the Task that started it.")
         }
         loginInProgress = true
@@ -152,7 +153,9 @@ final class WebAuthenticationSession {
                 session.prefersEphemeralWebBrowserSession = prefersEphemeralWebBrowserSession
                 self.session = session
 
-                if !session.start() {
+                let started = session.start() // TEMP DEBUG: hoisted out of the `if` to log the value
+                print("🔍 [WebAuth] start() attempt=\(attempt) mode=\(mode.callback) → \(started)") // TEMP DEBUG
+                if !started {
                     // When start() returns false the completion handler may never be called, so the
                     // continuation is resumed with an error here.
                     self.complete(attempt: attempt, .failure(.TechnicalError(reason: "ASWebAuthenticationSession failed to start")))
@@ -180,6 +183,17 @@ final class WebAuthenticationSession {
     }
 
     private func handleSessionCompletion(attempt: Int, callbackURL: URL?, error: Error?) {
+        // TEMP DEBUG — the system called us back. Absence of this line means the completion handler never fired.
+        let ns = error as NSError?
+        let asCode = (error as? ASWebAuthenticationSessionError).map { "\($0.code) (\($0.code.rawValue))" } ?? "not an ASWebAuthenticationSessionError"
+        print("""
+              🔍 [WebAuth] handleSessionCompletion attempt=\(attempt) current=\(self.attempt) \
+              loginInProgress=\(loginInProgress) continuation=\(continuation != nil)
+                 callbackURL=\(callbackURL?.absoluteString ?? "nil")
+                 error=\(ns.map { "\($0.domain) code=\($0.code) — \($0.localizedDescription)" } ?? "nil")
+                 asWebAuthError=\(asCode)
+              """)
+
         if let error {
             complete(attempt: attempt, .failure(Self.reachFiveError(for: error)))
         } else if let callbackURL {
@@ -192,6 +206,9 @@ final class WebAuthenticationSession {
     /// The single resolution point: resumes the continuation with `result`, clears the state, and closes the
     /// sheet if it is still presented (out-of-band resolution, cancellation, replacement).
     private func complete(attempt: Int, _ result: Result<URL, ReachFiveError>) {
+        // TEMP DEBUG — did this resolution reach the continuation, or was it dropped (slot stays held)?
+        print("🔍 [WebAuth] complete attempt=\(attempt) current=\(self.attempt) continuation=\(continuation != nil) → \(attempt == self.attempt && continuation != nil ? "RESOLVES" : "DROPPED") result=\(result)")
+
         // Ignore a stale callback (a newer login came in) or a second resolution (`continuation` already nil).
         guard attempt == self.attempt, let continuation else { return }
         // Capture the session before nil-ing it, to close its sheet after the resume. The late cancellation

--- a/Sources/Core/Classes/web/WebAuthentication.swift
+++ b/Sources/Core/Classes/web/WebAuthentication.swift
@@ -1,56 +1,58 @@
 import AuthenticationServices
 
-/// Porte le login web en cours : démarre une `ASWebAuthenticationSession`, attend son callback, et
-/// laisse un lien reçu via `application(_:open:)` (custom scheme) ou `application(_:continue:)` (lien
-/// universel) le compléter (``tryComplete(externalCallbackURL:)``).
+/// Carries the web login in progress: starts an `ASWebAuthenticationSession`, waits for its callback, and
+/// lets a link received through `application(_:open:)` complete it (``tryComplete(externalCallbackURL:)``).
 ///
-/// **Les deux canaux sont armés pour tout login.** Un provider peut décider *en vol*, feuille déjà
-/// ouverte, s'il termine dedans ou s'il sort de l'app. L'appelant ne
-/// peut donc pas choisir le canal à l'avance, et n'a pas à le faire.
+/// **A custom-scheme login arms both channels.** A provider may decide *midway*, sheet already open,
+/// whether it finishes inside the sheet or leaves the app for a third-party one — b.connect picks
+/// `passive`/`active` only after `/authorize`. The caller therefore cannot pick the channel up front, and
+/// does not have to. A universal-link login is the exception: it is built with `callback: .https(...)`, so
+/// the sheet itself intercepts the redirection and no out-of-band channel is armed for it.
 ///
-/// **Un seul login à la fois.** Sur iPhone, la feuille modale d'une `ASWebAuthenticationSession` rend
-/// un second `start(...)` inatteignable par l'interaction utilisateur : tant qu'elle est présentée rien
-/// d'autre n'est déclenchable, et sa disparition passe par une résolution (callback, Annuler) qui reprend
-/// la continuation. Restent les appels **programmatiques** (logout/login déclenché par une logique d'app
-/// sans interaction, double invocation), le multi-fenêtres (iPad/macCatalyst), et un completion handler
-/// que le système ne rappellerait jamais : dans tous ces cas, le dernier arrivé gagne — le login
-/// précédent est repris avec `.AuthCanceled` et sa feuille est fermée, aucune continuation ne gèle.
+/// **One login at a time.** On iPhone, the modal sheet of an `ASWebAuthenticationSession` puts a second
+/// `start(...)` out of reach of user interaction: while it is presented nothing else can be triggered, and
+/// it only goes away through a resolution (callback, Cancel) that resumes the continuation. What remains is
+/// **programmatic** calls (a logout/login driven by app logic without interaction, a double invocation),
+/// multi-window setups (iPad/macCatalyst), and a completion handler the system would never call back. In
+/// all of those the last caller wins: the previous login is resumed with `.AuthCanceled` and its sheet is
+/// closed, so no continuation ever freezes.
 ///
-/// Les callbacks tardifs ou dupliqués sont neutralisés de deux façons : un **jeton par tentative**
-/// (`attempt`) — pour qu'un callback d'une `ASWebAuthenticationSession` périmée ne puisse jamais
-/// reprendre la continuation d'un login plus récent — et la remise à `nil` de `continuation` dans
-/// `complete(_:)` — pour que la résolution gagnante (in-band, hors-bande, ou annulation) reprenne la
-/// continuation exactement une fois.
+/// Late or duplicated callbacks are neutralised two ways: a **per-attempt token** (`attempt`), so the
+/// callback of a stale `ASWebAuthenticationSession` can never resume a newer login's continuation, and
+/// setting `continuation` back to `nil` in `complete(_:)`, so the winning resolution (in the sheet,
+/// out-of-band, or a cancellation) resumes the continuation exactly once.
 ///
-/// **Limitation (hors-bande)** : l'état d'un login en vol ne vit qu'en mémoire. Si iOS tue l'app
-/// pendant le détour hors de l'app, le callback reçu au relancement ne matche rien (`tryComplete`
-/// renvoie `false`, l'app hôte route le lien) et le `code` est perdu : l'utilisateur doit relancer le
-/// login. Le détour réel étant long — app externe **puis** navigateur par défaut — la fenêtre de risque
-/// n'est pas négligeable. Une reprise après relancement demanderait de persister le login en vol
-/// (redirect_uri + PKCE, déjà en storage) et un canal pour livrer le résultat à l'app — assumé hors
-/// périmètre tant que l'usage ne le justifie pas.
+/// **The out-of-band channel is only armed for a login**: `logout` also goes through `start(...)`, but with
+/// `expectsAuthorizationCode: false`. Its callback (`post_logout_redirect_uri`) carries no `code` and is
+/// intercepted by the sheet itself, so `expectedCallback` stays `nil`.
 ///
-/// **Deux imprécisions connues du matching**, assumées ici, que la comparaison du `state` refermerait :
-/// - `logout` passe aussi par `start(...)` et arme donc `expectedCallback`. Son callback
-///   (`post_logout_redirect_uri`) ne porte ni `code` ni `error`, donc ne s'auto-matche pas ; mais un
-///   code de login égaré pendant un logout résoudrait la continuation du logout (qui ignore l'URL) et
-///   fermerait sa feuille tôt. L'étanchéité demanderait un `expectsAuthorizationCode: Bool` interne.
-/// - Armer `expectedCallback` sur *tout* login web élargit la fenêtre où un lien magique passwordless
-///   tapé pendant qu'une feuille est ouverte serait consommé par `tryComplete` plutôt que routé vers
-///   `interceptPasswordless` (``ReachFive/interceptUrl(_:)``). C'était déjà le cas de l'ancien mode
-///   hors-bande à custom scheme.
+/// **Accepted imprecision in the matching**: arming `expectedCallback` for *every* web login widens the
+/// window in which a passwordless magic link, tapped while a sheet is open, would be consumed by
+/// `tryComplete` instead of being routed to `interceptPasswordless` (``ReachFive/interceptUrl(_:)``).
 ///
-/// `@MainActor` : tout le domaine `ASWebAuthenticationSession` est déjà main-thread.
+/// **Limitation (out-of-band)**: the state of a login in progress only lives in memory. If iOS kills the app
+/// during the detour outside it, the callback received on relaunch matches nothing (`tryComplete` returns
+/// `false`, the host app routes the link). It is then *accidentally* rescued: `webviewLogin` left its PKCE
+/// in the passwordless storage slot, so `interceptPasswordless` completes the login and delivers the token
+/// on the `passwordlessCallback` — a web login surfacing on the passwordless channel, which no caller asked
+/// for. That accident is the one thing standing between this limitation and a lost `code`, and the real
+/// detour can be long, so the window is not negligible. A proper
+/// resume after relaunch would mean persisting the login in progress (redirect_uri + PKCE, already in
+/// storage) and a channel to deliver the result to the app. Both the accident and the proper fix are out of
+/// scope here; see the PKCE storage-slot redesign.
+///
+/// `@MainActor`: the whole `ASWebAuthenticationSession` domain is already main-thread.
 @MainActor
 final class WebAuthenticationSession {
     private var session: ASWebAuthenticationSession?
     private var continuation: CheckedContinuation<URL, Error>?
-    /// La `redirect_uri` attendue pour cette tentative ; `nil` hors d'un login → `tryComplete` ne matche rien.
+    /// The `redirect_uri` expected for this attempt; `nil` outside a login, or for a universal-link login
+    /// (which has no out-of-band channel) → `tryComplete` then matches nothing.
     private var expectedCallback: URL?
-    /// Identifie la tentative en cours ; un callback capturant un `attempt` périmé est ignoré.
+    /// Identifies the attempt in progress; a callback capturing a stale `attempt` is ignored.
     private var attempt = 0
     private let baseScheme: String
-    /// La `redirect_uri` du `SdkConfig`, utilisée par défaut quand le mode n'en porte pas (custom scheme).
+    /// The `SdkConfig`'s `redirect_uri`, which is the one a custom-scheme login uses.
     private let sdkRedirectUri: URL
 
     nonisolated init(baseScheme: String, sdkRedirectUri: URL) {
@@ -58,23 +60,27 @@ final class WebAuthenticationSession {
         self.sdkRedirectUri = sdkRedirectUri
     }
 
-    /// Démarre un login web et attend son callback (succès, erreur ou annulation). Le ``WebSessionMode``
-    /// décrit la forme du callback (custom scheme ou lien universel) et pilote la construction de la
-    /// session. Les **deux canaux sont toujours armés** : la feuille intercepte si le flow ne la quitte
-    /// jamais, et ``tryComplete(externalCallbackURL:)`` résout si le retour arrive hors-bande — un
-    /// provider peut choisir entre les deux en vol, feuille déjà ouverte. Si le `Task` appelant est
-    /// annulé (vue démontée, timeout…), la feuille est fermée et l'appel se termine par `.AuthCanceled`.
+    /// Starts a web login and waits for its callback (success, error or cancellation). The
+    /// ``WebSessionMode`` describes the shape of the callback (custom scheme or universal link) and drives
+    /// how the session is built. For a custom scheme both channels are armed: the sheet intercepts if the
+    /// flow never leaves it, and ``tryComplete(externalCallbackURL:)`` resolves if the return comes back
+    /// out-of-band — a provider can pick either one midway, sheet already open. If the calling `Task` is
+    /// cancelled (view torn down, timeout…), the sheet is closed and the call ends with `.AuthCanceled`.
+    ///
+    /// - Parameter expectsAuthorizationCode: `false` for a call whose callback carries no `code` (logout):
+    ///   the out-of-band channel is then not armed at all.
     func start(url: URL,
                mode: WebSessionMode,
+               expectsAuthorizationCode: Bool = true,
                presentationContextProvider: ASWebAuthenticationPresentationContextProviding,
                prefersEphemeralWebBrowserSession: Bool = false) async throws -> URL {
 
-        // Un Task déjà annulé ne doit pas présenter de feuille (son `onCancel` ci-dessous aurait
-        // déjà tiré, à vide, avant que la continuation soit posée).
+        // An already-cancelled Task must not present a sheet (its `onCancel` below would have fired
+        // already, to no effect, before the continuation was installed).
         try Task.checkCancellation()
 
-        // Dernier arrivé gagne : reprend l'éventuel login encore en attente avec `.AuthCanceled` et
-        // ferme sa feuille, pour ne jamais laisser une continuation geler sans résolution.
+        // Last caller wins: resume any login still pending with `.AuthCanceled` and close its sheet, so a
+        // continuation is never left frozen without a resolution.
         complete(attempt: attempt, .failure(.AuthCanceled))
         attempt += 1
         let attempt = attempt
@@ -82,60 +88,64 @@ final class WebAuthenticationSession {
         return try await withTaskCancellationHandler {
             try await withCheckedThrowingContinuation { continuation in
                 self.continuation = continuation
-                // `tryComplete` est armé pour tout login : le provider peut décider en vol de sortir vers
-                // une app externe, feuille déjà ouverte. La `redirect_uri` attendue est celle du mode
-                // (lien universel) ou, à défaut, celle du SdkConfig (custom scheme).
-                self.expectedCallback = mode.redirectUri ?? sdkRedirectUri
 
                 let completionHandler: ASWebAuthenticationSession.CompletionHandler = { [weak self] callbackURL, error in
-                    // Tout passe sur le main thread pour éviter les situations de compétition.
+                    // Everything hops to the main thread to avoid races.
                     Task { @MainActor in
                         self?.handleSessionCompletion(attempt: attempt, callbackURL: callbackURL, error: error)
                     }
                 }
 
-                let session: ASWebAuthenticationSession
+                // A factory, not a session: a session the system refused to present is not documented as
+                // replayable, so a fresh one is built for each presentation attempt (see `present`).
+                let makeSession: () -> ASWebAuthenticationSession
                 switch mode.callback {
                 case .customScheme:
-                    session = ASWebAuthenticationSession(
-                        url: url,
-                        callbackURLScheme: self.baseScheme,
-                        completionHandler: completionHandler)
+                    // Arm the out-of-band channel: the provider may decide midway to leave for a
+                    // third-party app, sheet already open, and come back through `application(_:open:)`.
+                    self.expectedCallback = expectsAuthorizationCode ? sdkRedirectUri : nil
+                    makeSession = {
+                        ASWebAuthenticationSession(
+                            url: url,
+                            callbackURLScheme: self.baseScheme,
+                            completionHandler: completionHandler)
+                    }
 
                 case let .universalLink(callback):
                     guard #available(iOS 17.4, *), let host = callback.host else {
                         self.complete(attempt: attempt, .failure(.TechnicalError(reason: "Universal link callback requires iOS 17.4+ and a host: \(callback)")))
                         return
                     }
-                    session = ASWebAuthenticationSession(
-                        url: url,
-                        callback: .https(host: host, path: callback.path),
-                        completionHandler: completionHandler)
+                    // No out-of-band channel to arm: `callback: .https(...)` makes the sheet itself
+                    // intercept the redirection, and nothing else can deliver that link to us —
+                    // `application(_:open:)` never sees https URLs.
+                    self.expectedCallback = nil
+                    makeSession = {
+                        ASWebAuthenticationSession(
+                            url: url,
+                            callback: .https(host: host, path: callback.path),
+                            completionHandler: completionHandler)
+                    }
                 }
 
-                // Fenêtre qui sert d'ancre de présentation à la session.
-                session.presentationContextProvider = presentationContextProvider
-                session.prefersEphemeralWebBrowserSession = prefersEphemeralWebBrowserSession
-                self.session = session
-
-                if !session.start() {
-                    // Si start() renvoie false, le completion handler peut ne jamais être appelé : on
-                    // reprend la continuation avec une erreur.
-                    self.complete(attempt: attempt, .failure(.TechnicalError(reason: "ASWebAuthenticationSession failed to start")))
-                }
+                self.present(attempt: attempt,
+                             remainingAttempts: Self.presentationAttempts,
+                             makeSession: makeSession,
+                             presentationContextProvider: presentationContextProvider,
+                             prefersEphemeralWebBrowserSession: prefersEphemeralWebBrowserSession)
             }
         } onCancel: {
-            // L'annulation peut arriver sur n'importe quel thread → hop sur le main actor. Sans effet
-            // si la tentative est déjà résolue ou remplacée par un login plus récent (gardes de `complete`).
+            // Cancellation can arrive on any thread → hop onto the main actor. No effect if the attempt is
+            // already resolved or was replaced by a newer login (`complete`'s guards).
             Task { @MainActor in
                 self.complete(attempt: attempt, .failure(.AuthCanceled))
             }
         }
     }
 
-    /// Complète le login en cours si l'URL entrante est bien notre callback, et ferme la feuille
-    /// encore ouverte. Renvoie `true` seulement dans ce cas — sinon `false`, pour que l'app hôte puisse
-    /// router elle-même le lien.
+    /// Completes the login in progress if the incoming URL really is our callback, and closes the sheet if it
+    /// is still open. Returns `true` only in that case — otherwise `false`, so the host app can route the
+    /// link itself.
     func tryComplete(externalCallbackURL url: URL) -> Bool {
         guard let expectedCallback,
               Self.isOurCallback(url, expectedCallback: expectedCallback) else {
@@ -144,6 +154,55 @@ final class WebAuthenticationSession {
         complete(attempt: attempt, .success(url))
         return true
     }
+
+    /// Presents the sheet, retrying while the system refuses to present it.
+    ///
+    /// When `start(...)` has just replaced a login, the previous sheet is still being dismissed — an
+    /// asynchronous, animated dismissal — and `session.start()` answers `false`. That is the only reliable
+    /// "not ready yet" signal, so we wait and try again instead of betting on an animation duration. The
+    /// outgoing sheet's completion handler is not a safer barrier: it marks the end of the *session*, not
+    /// the end of the dismissal animation.
+    ///
+    /// How to reproduce the case: two very fast taps on the same web-login button (on an iOS device; not
+    /// reproducible on Mac Catalyst).
+    private func present(attempt: Int,
+                         remainingAttempts: Int,
+                         makeSession: @escaping () -> ASWebAuthenticationSession,
+                         presentationContextProvider: ASWebAuthenticationPresentationContextProviding,
+                         prefersEphemeralWebBrowserSession: Bool) {
+        let session = makeSession()
+        // The window that acts as the session's presentation anchor.
+        session.presentationContextProvider = presentationContextProvider
+        session.prefersEphemeralWebBrowserSession = prefersEphemeralWebBrowserSession
+        self.session = session
+
+        if session.start() {
+            return
+        }
+
+        guard remainingAttempts > 1 else {
+            // When start() returns false the completion handler may never be called, so the continuation is
+            // resumed with an error here.
+            complete(attempt: attempt, .failure(.TechnicalError(reason: "ASWebAuthenticationSession failed to start")))
+            return
+        }
+
+        Task { @MainActor in
+            try? await Task.sleep(nanoseconds: Self.presentationRetryDelay)
+            // No effect if the attempt has been resolved or replaced in the meantime.
+            guard attempt == self.attempt, self.continuation != nil else { return }
+            self.present(attempt: attempt,
+                         remainingAttempts: remainingAttempts - 1,
+                         makeSession: makeSession,
+                         presentationContextProvider: presentationContextProvider,
+                         prefersEphemeralWebBrowserSession: prefersEphemeralWebBrowserSession)
+        }
+    }
+
+    /// Presentation attempts, and the delay between two: enough to cover the dismissal of a sheet we just
+    /// cancelled, without ever looping for long when the refusal has another cause.
+    private static let presentationAttempts = 4
+    private static let presentationRetryDelay: UInt64 = 150_000_000
 
     private func handleSessionCompletion(attempt: Int, callbackURL: URL?, error: Error?) {
         if let error {
@@ -155,14 +214,14 @@ final class WebAuthenticationSession {
         }
     }
 
-    /// L'unique point de résolution : reprend la continuation avec `result`, nettoie l'état, et ferme
-    /// la feuille si elle est encore présentée (résolution hors-bande, annulation, remplacement).
+    /// The single resolution point: resumes the continuation with `result`, clears the state, and closes the
+    /// sheet if it is still presented (out-of-band resolution, cancellation, replacement).
     private func complete(attempt: Int, _ result: Result<URL, ReachFiveError>) {
-        // Ignore un callback périmé (login plus récent) ou une seconde résolution (`continuation` déjà nil).
+        // Ignore a stale callback (a newer login came in) or a second resolution (`continuation` already nil).
         guard attempt == self.attempt, let continuation else { return }
-        // Capture la session avant de la nil-er pour fermer sa feuille après la reprise. Le callback
-        // d'annulation tardif qui en résulte est ignoré (continuation désormais nil) ; sur une session
-        // déjà terminée ou jamais présentée, `cancel()` est sans effet.
+        // Capture the session before nil-ing it, to close its sheet after the resume. The late cancellation
+        // callback that results is ignored (`continuation` is nil by then); on a session that is already
+        // finished or was never presented, `cancel()` does nothing.
         let openSession = session
         self.continuation = nil
         self.session = nil
@@ -171,23 +230,19 @@ final class WebAuthenticationSession {
         openSession?.cancel()
     }
 
-    /// `true` si l'URL entrante a le même scheme et le même host (insensibles à la casse) et le même
-    /// path que le `redirect_uri` envoyé, et porte un paramètre `code` (succès) ou `error` (refus OAuth,
-    /// ex. `access_denied` — le login se termine alors proprement avec l'`ApiError` du callback au lieu
-    /// de rester bloqué sur la feuille). Comparer le scheme est ce qui permet aux deux hooks d'entrée
-    /// (`application(_:open:)` pour le custom scheme, `application(_:continue:)` pour le lien universel)
-    /// de partager ce même matcher sans faux positif : un login attendu en scheme ne matche que des URL
-    /// de ce scheme, un login attendu en https que des liens universels. Le path attendu étant celui qu'on
-    /// déclare (AASA pour l'https, redirect_uri pour le scheme), ce matching exact suffit à distinguer
-    /// notre callback des autres liens de l'app.
+    /// `true` when the incoming URL designates the same endpoint as the `redirect_uri` we sent
+    /// (``matchesEndpoint(of:)``, the matcher shared with ``ReachFive/interceptUrl(_:)``) and carries a
+    /// `code` (success) or an `error` parameter (OAuth refusal, e.g. `access_denied` — the login then ends
+    /// cleanly with the callback's `ApiError` instead of hanging on the sheet). Comparing the scheme keeps a
+    /// login expected on a custom scheme from matching an https URL, and the other way round. Since the
+    /// expected path is the one we declare (the redirect_uri), this matching is enough to tell our callback
+    /// apart from the app's other links.
     nonisolated static func isOurCallback(_ url: URL, expectedCallback expected: URL) -> Bool {
-        url.scheme?.lowercased() == expected.scheme?.lowercased()
-        && url.host?.lowercased() == expected.host?.lowercased()
-        && url.path == expected.path
+        url.matchesEndpoint(of: expected)
         && (url.queryValue("code") != nil || url.queryValue("error") != nil)
     }
 
-    /// Mappe une erreur d'`ASWebAuthenticationSession` vers une `ReachFiveError`.
+    /// Maps an `ASWebAuthenticationSession` error onto a `ReachFiveError`.
     nonisolated static func reachFiveError(for error: Error) -> ReachFiveError {
         guard let sessionError = error as? ASWebAuthenticationSessionError else {
             return .TechnicalError(reason: "Unknown Error \(error.localizedDescription)")

--- a/Sources/Core/Classes/web/WebAuthentication.swift
+++ b/Sources/Core/Classes/web/WebAuthentication.swift
@@ -89,6 +89,14 @@ final class WebAuthenticationSession {
         var session: ASWebAuthenticationSession?
     }
 
+    /// Whether the slot is taken, for a caller that has side effects to arm *before* presenting and must not
+    /// arm them for a call `start(...)` is going to drop (see `webviewLogin` and the shared PKCE slot).
+    /// Internal on purpose: an integrator has nothing to check, a dropped call already ends with
+    /// `.AuthCanceled`.
+    var isLoginInProgress: Bool {
+        if case .idle = state { false } else { true }
+    }
+
     private var state = State.idle
     /// Monotonic, never reset: a fresh identity for each accepted login, so the callback of a session
     /// belonging to a previous one can never resolve a newer login.

--- a/Sources/Core/Classes/web/WebAuthentication.swift
+++ b/Sources/Core/Classes/web/WebAuthentication.swift
@@ -9,13 +9,21 @@ import AuthenticationServices
 /// does not have to. A universal-link login is the exception: it is built with `callback: .https(...)`, so
 /// the sheet itself intercepts the redirection and no out-of-band channel is armed for it.
 ///
-/// **One login at a time.** On iPhone, the modal sheet of an `ASWebAuthenticationSession` puts a second
-/// `start(...)` out of reach of user interaction: while it is presented nothing else can be triggered, and
-/// it only goes away through a resolution (callback, Cancel) that resumes the continuation. What remains is
-/// **programmatic** calls (a logout/login driven by app logic without interaction, a double invocation),
-/// multi-window setups (iPad/macCatalyst), and a completion handler the system would never call back. In
-/// all of those the last caller wins: the previous login is resumed with `.AuthCanceled` and its sheet is
-/// closed, so no continuation ever freezes.
+/// **One login at a time, and the incumbent keeps its place.** A `start(...)` called while another login is
+/// in progress fails immediately with a `.TechnicalError`; the login already under way is left alone.
+///
+/// This is not a taste for strictness, it is the fix for a concrete bug. Replacing the incumbent means
+/// cancelling its sheet and presenting the replacement right behind it, and iOS then loads the view of the
+/// outgoing `SFAuthenticationViewController` while it is deallocating. `session.start()` still answers
+/// `true`, so there is nothing to retry on; the failure lands asynchronously in the completion handler as
+/// `presentationContextInvalid`, and *both* logins are lost. Reproduced with two very fast taps on the same
+/// web-login button (iOS device; not reproducible on Mac Catalyst). Refusing the newcomer removes the
+/// cancel-then-present sequence altogether, which is the only way found to remove the failure rather than
+/// race with it — and on a double tap the first tap is the one the user meant anyway.
+///
+/// The way out, if a login somehow never resolves (a completion handler the system never calls back): cancel
+/// the `Task` that started it. `onCancel` closes the sheet and resumes with `.AuthCanceled`, which frees the
+/// slot. A view being torn down does this on its own.
 ///
 /// Late or duplicated callbacks are neutralised two ways: a **per-attempt token** (`attempt`), so the
 /// callback of a stale `ASWebAuthenticationSession` can never resume a newer login's continuation, and
@@ -51,6 +59,21 @@ final class WebAuthenticationSession {
     private var expectedCallback: URL?
     /// Identifies the attempt in progress; a callback capturing a stale `attempt` is ignored.
     private var attempt = 0
+    /// A login is in progress. Invariant, outside the continuation closure: `loginInProgress` is true exactly
+    /// when `continuation` is non-nil — both are set by `start(...)` and both cleared by `complete(_:)`, the
+    /// single resolution point.
+    ///
+    /// It is not, however, redundant with `continuation != nil`, and it is not the old `hasResumed` either
+    /// (which was local to one call and guarded exactly-once resumption of a single continuation). What it
+    /// buys is that `start(...)` can refuse a second login **before** its first suspension point, and
+    /// therefore before `attempt += 1`:
+    /// - `continuation` and `session` are only assigned inside the continuation closure, past an `await`, so
+    ///   guarding on either would let two calls made in quick succession both through — which is exactly
+    ///   what a double tap on a login button produces;
+    /// - and bumping `attempt` before refusing would invalidate the token of the login *already in place*:
+    ///   its completion handler captured the old value, `complete(attempt:)` would no-op, and its
+    ///   continuation would freeze — the very failure the token exists to prevent.
+    private var loginInProgress = false
     private let baseScheme: String
     /// The `SdkConfig`'s `redirect_uri`, which is the one a custom-scheme login uses.
     private let sdkRedirectUri: URL
@@ -79,9 +102,11 @@ final class WebAuthenticationSession {
         // already, to no effect, before the continuation was installed).
         try Task.checkCancellation()
 
-        // Last caller wins: resume any login still pending with `.AuthCanceled` and close its sheet, so a
-        // continuation is never left frozen without a resolution.
-        complete(attempt: attempt, .failure(.AuthCanceled))
+        // One login at a time, and the incumbent keeps its place.
+        guard !loginInProgress else {
+            throw ReachFiveError.TechnicalError(reason: "A web login is already in progress. Wait for it to finish, or cancel the Task that started it.")
+        }
+        loginInProgress = true
         attempt += 1
         let attempt = attempt
 
@@ -96,20 +121,16 @@ final class WebAuthenticationSession {
                     }
                 }
 
-                // A factory, not a session: a session the system refused to present is not documented as
-                // replayable, so a fresh one is built for each presentation attempt (see `present`).
-                let makeSession: () -> ASWebAuthenticationSession
+                let session: ASWebAuthenticationSession
                 switch mode.callback {
                 case .customScheme:
                     // Arm the out-of-band channel: the provider may decide midway to leave for a
                     // third-party app, sheet already open, and come back through `application(_:open:)`.
                     self.expectedCallback = expectsAuthorizationCode ? sdkRedirectUri : nil
-                    makeSession = {
-                        ASWebAuthenticationSession(
-                            url: url,
-                            callbackURLScheme: self.baseScheme,
-                            completionHandler: completionHandler)
-                    }
+                    session = ASWebAuthenticationSession(
+                        url: url,
+                        callbackURLScheme: self.baseScheme,
+                        completionHandler: completionHandler)
 
                 case let .universalLink(callback):
                     guard #available(iOS 17.4, *), let host = callback.host else {
@@ -120,19 +141,22 @@ final class WebAuthenticationSession {
                     // intercept the redirection, and nothing else can deliver that link to us —
                     // `application(_:open:)` never sees https URLs.
                     self.expectedCallback = nil
-                    makeSession = {
-                        ASWebAuthenticationSession(
-                            url: url,
-                            callback: .https(host: host, path: callback.path),
-                            completionHandler: completionHandler)
-                    }
+                    session = ASWebAuthenticationSession(
+                        url: url,
+                        callback: .https(host: host, path: callback.path),
+                        completionHandler: completionHandler)
                 }
 
-                self.present(attempt: attempt,
-                             remainingAttempts: Self.presentationAttempts,
-                             makeSession: makeSession,
-                             presentationContextProvider: presentationContextProvider,
-                             prefersEphemeralWebBrowserSession: prefersEphemeralWebBrowserSession)
+                // The window that acts as the session's presentation anchor.
+                session.presentationContextProvider = presentationContextProvider
+                session.prefersEphemeralWebBrowserSession = prefersEphemeralWebBrowserSession
+                self.session = session
+
+                if !session.start() {
+                    // When start() returns false the completion handler may never be called, so the
+                    // continuation is resumed with an error here.
+                    self.complete(attempt: attempt, .failure(.TechnicalError(reason: "ASWebAuthenticationSession failed to start")))
+                }
             }
         } onCancel: {
             // Cancellation can arrive on any thread → hop onto the main actor. No effect if the attempt is
@@ -154,55 +178,6 @@ final class WebAuthenticationSession {
         complete(attempt: attempt, .success(url))
         return true
     }
-
-    /// Presents the sheet, retrying while the system refuses to present it.
-    ///
-    /// When `start(...)` has just replaced a login, the previous sheet is still being dismissed — an
-    /// asynchronous, animated dismissal — and `session.start()` answers `false`. That is the only reliable
-    /// "not ready yet" signal, so we wait and try again instead of betting on an animation duration. The
-    /// outgoing sheet's completion handler is not a safer barrier: it marks the end of the *session*, not
-    /// the end of the dismissal animation.
-    ///
-    /// How to reproduce the case: two very fast taps on the same web-login button (on an iOS device; not
-    /// reproducible on Mac Catalyst).
-    private func present(attempt: Int,
-                         remainingAttempts: Int,
-                         makeSession: @escaping () -> ASWebAuthenticationSession,
-                         presentationContextProvider: ASWebAuthenticationPresentationContextProviding,
-                         prefersEphemeralWebBrowserSession: Bool) {
-        let session = makeSession()
-        // The window that acts as the session's presentation anchor.
-        session.presentationContextProvider = presentationContextProvider
-        session.prefersEphemeralWebBrowserSession = prefersEphemeralWebBrowserSession
-        self.session = session
-
-        if session.start() {
-            return
-        }
-
-        guard remainingAttempts > 1 else {
-            // When start() returns false the completion handler may never be called, so the continuation is
-            // resumed with an error here.
-            complete(attempt: attempt, .failure(.TechnicalError(reason: "ASWebAuthenticationSession failed to start")))
-            return
-        }
-
-        Task { @MainActor in
-            try? await Task.sleep(nanoseconds: Self.presentationRetryDelay)
-            // No effect if the attempt has been resolved or replaced in the meantime.
-            guard attempt == self.attempt, self.continuation != nil else { return }
-            self.present(attempt: attempt,
-                         remainingAttempts: remainingAttempts - 1,
-                         makeSession: makeSession,
-                         presentationContextProvider: presentationContextProvider,
-                         prefersEphemeralWebBrowserSession: prefersEphemeralWebBrowserSession)
-        }
-    }
-
-    /// Presentation attempts, and the delay between two: enough to cover the dismissal of a sheet we just
-    /// cancelled, without ever looping for long when the refusal has another cause.
-    private static let presentationAttempts = 4
-    private static let presentationRetryDelay: UInt64 = 150_000_000
 
     private func handleSessionCompletion(attempt: Int, callbackURL: URL?, error: Error?) {
         if let error {
@@ -226,6 +201,7 @@ final class WebAuthenticationSession {
         self.continuation = nil
         self.session = nil
         self.expectedCallback = nil
+        self.loginInProgress = false
         continuation.resume(with: result)
         openSession?.cancel()
     }

--- a/Sources/Core/Classes/web/WebAuthentication.swift
+++ b/Sources/Core/Classes/web/WebAuthentication.swift
@@ -236,14 +236,21 @@ final class WebAuthenticationSession {
     }
 
     private func handleSessionCompletion(id: Int, callbackURL: URL?, error: Error?) {
+        // A session that is no longer the one in place reports late — typically the `canceledLogin` our own
+        // `cancel()` draws after an out-of-band resolution. Nothing to resolve, and nothing worth logging.
+        guard case var .running(login) = state, login.id == id else { return }
+
         // The session reported, so its sheet is already going away: forget it, so the resolution below does
         // not `cancel()` a session the system is done with (see `Login.session`).
-        if case var .running(login) = state, login.id == id {
-            login.session = nil
-            state = .running(login)
-        }
+        login.session = nil
+        state = .running(login)
 
         if let error {
+            // Logged because `canceledLogin` covers more than the user tapping Cancel: the system also
+            // reports it when the app is not associated with the host of an `.https` callback, and the
+            // reason only shows up in `localizedDescription`. Only reached for an error this call is about
+            // to deliver, so it never fires for a sheet we closed ourselves.
+            Logger.shared.log("The web session ended without a callback: \(error.localizedDescription)")
             complete(id: id, .failure(Self.reachFiveError(for: error)))
         } else if let callbackURL {
             complete(id: id, .success(callbackURL))
@@ -278,19 +285,18 @@ final class WebAuthenticationSession {
         && (url.queryValue("code") != nil || url.queryValue("error") != nil)
     }
 
-    /// Maps an `ASWebAuthenticationSession` error onto a `ReachFiveError`.
+    /// Maps an `ASWebAuthenticationSession` error onto a `ReachFiveError`. Pure: the raw error is logged by
+    /// `handleSessionCompletion(id:callbackURL:error:)`, which knows whether it is about to be delivered.
     ///
     /// `canceledLogin` is not only "the user tapped Cancel": the system also reports it when the app is not
-    /// associated with the host of an `.https` callback (measured on iOS and Mac Catalyst — the reason only
-    /// appears in `localizedDescription`). It is logged here so a misconfigured Associated Domain does not
-    /// vanish into the `.AuthCanceled` every integration ignores.
+    /// associated with the host of an `.https` callback, and when a sheet is closed by `cancel()` — measured
+    /// on iOS and Mac Catalyst. Only `localizedDescription` tells the three apart.
     nonisolated static func reachFiveError(for error: Error) -> ReachFiveError {
         guard let sessionError = error as? ASWebAuthenticationSessionError else {
             return .TechnicalError(reason: "Unknown Error \(error.localizedDescription)")
         }
         switch sessionError.code {
         case .canceledLogin:
-            Logger.shared.log("The web session ended without a callback: \(error.localizedDescription)")
             return .AuthCanceled
         case .presentationContextNotProvided:
             return .TechnicalError(reason: "Presentation context not provided: \(error.localizedDescription)")

--- a/Sources/Core/Classes/web/WebAuthentication.swift
+++ b/Sources/Core/Classes/web/WebAuthentication.swift
@@ -1,18 +1,16 @@
 import AuthenticationServices
 
-/// Carries the web login in progress: starts an `ASWebAuthenticationSession`, waits for its callback, and
-/// lets a link received through `application(_:open:)` complete it (``tryComplete(externalCallbackURL:)``).
+/// Carries the web login in progress: starts an `ASWebAuthenticationSession`, waits for its callback, and either complete it locally,
+/// or lets a link received through `application(_:open:)` complete it (``tryComplete(externalCallbackURL:)``).
 ///
-/// **A custom-scheme login arms both channels**, because a provider may decide *midway*, sheet already open,
-/// whether it finishes inside the sheet or leaves for a third-party app — b.connect picks `passive`/`active`
-/// only after `/authorize`, so neither the caller nor the SDK can choose up front. Two calls leave the
-/// out-of-band channel unarmed: a universal-link login, whose `callback: .https(...)` makes the sheet
+/// **A custom-scheme login prepares both channels**, because a provider may decide *midway*, sheet already open,
+/// whether it finishes inside the sheet or leaves for a third-party app. Two calls leave the
+/// out-of-band channel inactive: a universal-link login, whose `callback: .https(...)` makes the sheet
 /// intercept the redirection itself, and `logout`, whose callback carries no `code`
 /// (`expectsAuthorizationCode: false`).
 ///
-/// **One login at a time, and the newcomer is dropped silently** with `.AuthCanceled` — the error every
-/// integration already treats as "nothing happened" — leaving the login under way untouched. Nothing is
-/// expected of the caller: this is the SDK absorbing a double tap, not a failure to report.
+/// **One login at a time, and the newcomer is dropped silently** with `.AuthCanceled`, leaving the login under way untouched.
+/// Nothing is expected of the caller: this is the SDK absorbing a double tap, not a failure to report.
 ///
 /// Refusing rather than replacing is a measured choice. Replacing means cancelling the incumbent's sheet and
 /// presenting the newcomer behind it; `session.start()` then answers `false` while the outgoing sheet
@@ -25,13 +23,9 @@ import AuthenticationServices
 /// out of scope while one session is shared by the whole `ReachFive` instance.
 ///
 /// The way out if a login never resolves: cancel the `Task` that started it — `onCancel` closes the sheet and
-/// frees the slot, which a view being torn down does on its own. No extra API is needed for it.
+/// frees the slot, which a view being torn down does on its own.
 ///
-/// **Two accepted imprecisions**, both rooted in the shared PKCE slot and described by the FIXME in
-/// ``ReachFive/webviewLogin(_:)``: `expectedCallback` is armed for every custom-scheme login, which widens
-/// the window in which a passwordless magic link tapped while a sheet is open is consumed by `tryComplete`
-/// instead of ``ReachFive/interceptUrl(_:)``; and the login in progress lives only in memory, so an app kill
-/// mid-detour leaves its callback matching nothing on relaunch.
+/// **Two accepted imprecisions**, both rooted in the shared PKCE slot and described by the FIXME in ``ReachFive/webviewLogin(_:)``
 ///
 /// `@MainActor`: the whole `ASWebAuthenticationSession` domain is already main-thread.
 @MainActor

--- a/Sources/Core/Classes/web/WebAuthentication.swift
+++ b/Sources/Core/Classes/web/WebAuthentication.swift
@@ -9,26 +9,32 @@ import AuthenticationServices
 /// does not have to. A universal-link login is the exception: it is built with `callback: .https(...)`, so
 /// the sheet itself intercepts the redirection and no out-of-band channel is armed for it.
 ///
-/// **One login at a time, and the incumbent keeps its place.** A `start(...)` called while another login is
-/// in progress fails immediately with a `.TechnicalError`; the login already under way is left alone.
+/// **One login at a time, the incumbent keeps its place, and the newcomer is dropped silently.** A
+/// `start(...)` called while another login is in progress ends with `.AuthCanceled` — the error every
+/// integration already treats as "nothing happened" — and the login already under way is left alone. The
+/// caller has nothing to do about it: this is the SDK absorbing a double tap, not a failure to report.
 ///
-/// This is not a taste for strictness, it is the fix for a concrete bug. Replacing the incumbent means
-/// cancelling its sheet and presenting the replacement right behind it, and iOS then loads the view of the
-/// outgoing `SFAuthenticationViewController` while it is deallocating. `session.start()` still answers
-/// `true`, so there is nothing to retry on; the failure lands asynchronously in the completion handler as
-/// `presentationContextInvalid`, and *both* logins are lost. Reproduced with two very fast taps on the same
-/// web-login button (iOS device; not reproducible on Mac Catalyst). Refusing the newcomer removes the
-/// cancel-then-present sequence altogether, which is the only way found to remove the failure rather than
-/// race with it — and on a double tap the first tap is the one the user meant anyway.
+/// Refusing rather than replacing is the fix for a concrete bug. Replacing the incumbent means cancelling
+/// its sheet and presenting the replacement right behind it; `session.start()` then answers `false` while the
+/// outgoing sheet is still animating away, and retrying until it answers `true` only moves the failure —
+/// the presentation fails asynchronously in the completion handler with `presentationContextInvalid`, and
+/// *both* logins are lost. Measured on an iOS device with two very fast taps on the same web-login button
+/// (not reproducible on Mac Catalyst). Refusing the newcomer removes the cancel-then-present sequence
+/// altogether, which is the only way found to remove the failure rather than race with it — and on a double
+/// tap the first tap is the one the user meant anyway.
 ///
-/// The way out, if a login somehow never resolves (a completion handler the system never calls back): cancel
-/// the `Task` that started it. `onCancel` closes the sheet and resumes with `.AuthCanceled`, which frees the
-/// slot. A view being torn down does this on its own.
+/// Every other concurrent caller would be programmatic, and there is none: a logout is always a manual
+/// action, so it cannot be triggered while a login sheet is on screen. Multi-window setups (iPad,
+/// Mac Catalyst) are the one place where two concurrent logins would be legitimate; they are out of scope
+/// while a single session is shared by the whole `ReachFive` instance.
 ///
-/// Late or duplicated callbacks are neutralised two ways: a **per-attempt token** (`attempt`), so the
-/// callback of a stale `ASWebAuthenticationSession` can never resume a newer login's continuation, and
-/// setting `continuation` back to `nil` in `complete(_:)`, so the winning resolution (in the sheet,
-/// out-of-band, or a cancellation) resumes the continuation exactly once.
+/// The way out, if a login somehow never resolves: cancel the `Task` that started it. `onCancel` closes the
+/// sheet and resumes with `.AuthCanceled`, which frees the slot — a view being torn down does this on its
+/// own, and no extra API is needed for it.
+///
+/// Late or duplicated callbacks are neutralised by ``State``: a resolution has to name the login it belongs
+/// to (`Login.id`), and the winning one puts the state back to `idle`, so any later arrival finds nothing to
+/// resolve.
 ///
 /// **The out-of-band channel is only armed for a login**: `logout` also goes through `start(...)`, but with
 /// `expectsAuthorizationCode: false`. Its callback (`post_logout_redirect_uri`) carries no `code` and is
@@ -52,28 +58,41 @@ import AuthenticationServices
 /// `@MainActor`: the whole `ASWebAuthenticationSession` domain is already main-thread.
 @MainActor
 final class WebAuthenticationSession {
-    private var session: ASWebAuthenticationSession?
-    private var continuation: CheckedContinuation<URL, Error>?
-    /// The `redirect_uri` expected for this attempt; `nil` outside a login, or for a universal-link login
-    /// (which has no out-of-band channel) → `tryComplete` then matches nothing.
-    private var expectedCallback: URL?
-    /// Identifies the attempt in progress; a callback capturing a stale `attempt` is ignored.
-    private var attempt = 0
-    /// A login is in progress. Invariant, outside the continuation closure: `loginInProgress` is true exactly
-    /// when `continuation` is non-nil — both are set by `start(...)` and both cleared by `complete(_:)`, the
-    /// single resolution point.
-    ///
-    /// It is not, however, redundant with `continuation != nil`, and it is not the old `hasResumed` either
-    /// (which was local to one call and guarded exactly-once resumption of a single continuation). What it
-    /// buys is that `start(...)` can refuse a second login **before** its first suspension point, and
-    /// therefore before `attempt += 1`:
-    /// - `continuation` and `session` are only assigned inside the continuation closure, past an `await`, so
-    ///   guarding on either would let two calls made in quick succession both through — which is exactly
-    ///   what a double tap on a login button produces;
-    /// - and bumping `attempt` before refusing would invalidate the token of the login *already in place*:
-    ///   its completion handler captured the old value, `complete(attempt:)` would no-op, and its
-    ///   continuation would freeze — the very failure the token exists to prevent.
-    private var loginInProgress = false
+
+    /// Whether a login is in progress, and everything its resolution needs — as **one** value rather than an
+    /// agreement to maintain by hand between a session, a continuation, an expected callback and a boolean.
+    /// Being `idle` and holding a continuation is not a state that can be written.
+    private enum State {
+        case idle
+
+        /// `start(...)` was accepted and the slot is taken, but the continuation does not exist yet: it is
+        /// only handed to us inside `withCheckedThrowingContinuation`. Nothing else runs on the main actor
+        /// between the two, so no resolution can observe this state — it exists so the slot can be claimed
+        /// *before* the first suspension point, which is what a double tap needs.
+        case claimed(id: Int)
+
+        /// The continuation is installed; this is the only state a resolution can act on.
+        case running(Login)
+    }
+
+    private struct Login {
+        /// Identifies the login; a callback capturing a stale `id` is ignored.
+        let id: Int
+        let continuation: CheckedContinuation<URL, Error>
+        /// The `redirect_uri` expected out-of-band; `nil` for a universal-link login (the sheet intercepts
+        /// the redirection itself) → `tryComplete` then matches nothing.
+        let expectedCallback: URL?
+        /// The presented session, to be closed if a resolution comes from somewhere else. Set back to `nil`
+        /// as soon as the session reports its own completion: its sheet is then already on its way out, and
+        /// `cancel()`ing it at that point makes UIKit load the view of a deallocating
+        /// `SFAuthenticationViewController`.
+        var session: ASWebAuthenticationSession?
+    }
+
+    private var state = State.idle
+    /// Monotonic, never reset: a fresh identity for each accepted login, so the callback of a session
+    /// belonging to a previous one can never resolve a newer login.
+    private var lastLoginId = 0
     private let baseScheme: String
     /// The `SdkConfig`'s `redirect_uri`, which is the one a custom-scheme login uses.
     private let sdkRedirectUri: URL
@@ -92,6 +111,9 @@ final class WebAuthenticationSession {
     ///
     /// - Parameter expectsAuthorizationCode: `false` for a call whose callback carries no `code` (logout):
     ///   the out-of-band channel is then not armed at all.
+    /// - Throws: `.AuthCanceled` when a web login is already in progress — the call is dropped and the
+    ///   login under way is untouched. Callers do not have to single this case out: it is the same
+    ///   "nothing happened" outcome as a user tapping Cancel.
     func start(url: URL,
                mode: WebSessionMode,
                expectsAuthorizationCode: Bool = true,
@@ -102,125 +124,138 @@ final class WebAuthenticationSession {
         // already, to no effect, before the continuation was installed).
         try Task.checkCancellation()
 
-        // One login at a time, and the incumbent keeps its place.
-        guard !loginInProgress else {
-            print("🔍 [WebAuth] start REFUSED — slot still held by attempt \(self.attempt) (continuation=\(continuation != nil), session=\(session != nil))") // TEMP DEBUG
-            throw ReachFiveError.TechnicalError(reason: "A web login is already in progress. Wait for it to finish, or cancel the Task that started it.")
+        // One login at a time, and the incumbent keeps its place. Silently: a second call is a double tap,
+        // and `.AuthCanceled` is what every integration already ignores.
+        guard case .idle = state else {
+            Logger.shared.log("A web login is already in progress; this call is dropped. Nothing to handle: the login under way keeps the slot.")
+            throw ReachFiveError.AuthCanceled
         }
-        loginInProgress = true
-        attempt += 1
-        let attempt = attempt
+
+        // Built before the slot is claimed, so its only failure path — a universal-link callback this OS or
+        // this URL cannot support — throws without leaving a slot to release or a continuation to resume.
+        let id = lastLoginId + 1
+        let prepared = try prepareSession(id: id,
+                                         url: url,
+                                         mode: mode,
+                                         expectsAuthorizationCode: expectsAuthorizationCode,
+                                         presentationContextProvider: presentationContextProvider,
+                                         prefersEphemeralWebBrowserSession: prefersEphemeralWebBrowserSession)
+        lastLoginId = id
+        state = .claimed(id: id)
 
         return try await withTaskCancellationHandler {
             try await withCheckedThrowingContinuation { continuation in
-                self.continuation = continuation
+                self.state = .running(Login(id: id,
+                                            continuation: continuation,
+                                            expectedCallback: prepared.expectedCallback,
+                                            session: prepared.session))
 
-                let completionHandler: ASWebAuthenticationSession.CompletionHandler = { [weak self] callbackURL, error in
-                    // Everything hops to the main thread to avoid races.
-                    Task { @MainActor in
-                        self?.handleSessionCompletion(attempt: attempt, callbackURL: callbackURL, error: error)
-                    }
-                }
-
-                let session: ASWebAuthenticationSession
-                switch mode.callback {
-                case .customScheme:
-                    // Arm the out-of-band channel: the provider may decide midway to leave for a
-                    // third-party app, sheet already open, and come back through `application(_:open:)`.
-                    self.expectedCallback = expectsAuthorizationCode ? sdkRedirectUri : nil
-                    session = ASWebAuthenticationSession(
-                        url: url,
-                        callbackURLScheme: self.baseScheme,
-                        completionHandler: completionHandler)
-
-                case let .universalLink(callback):
-                    guard #available(iOS 17.4, *), let host = callback.host else {
-                        self.complete(attempt: attempt, .failure(.TechnicalError(reason: "Universal link callback requires iOS 17.4+ and a host: \(callback)")))
-                        return
-                    }
-                    // No out-of-band channel to arm: `callback: .https(...)` makes the sheet itself
-                    // intercept the redirection, and nothing else can deliver that link to us —
-                    // `application(_:open:)` never sees https URLs.
-                    self.expectedCallback = nil
-                    session = ASWebAuthenticationSession(
-                        url: url,
-                        callback: .https(host: host, path: callback.path),
-                        completionHandler: completionHandler)
-                }
-
-                // The window that acts as the session's presentation anchor.
-                session.presentationContextProvider = presentationContextProvider
-                session.prefersEphemeralWebBrowserSession = prefersEphemeralWebBrowserSession
-                self.session = session
-
-                let started = session.start() // TEMP DEBUG: hoisted out of the `if` to log the value
-                print("🔍 [WebAuth] start() attempt=\(attempt) mode=\(mode.callback) → \(started)") // TEMP DEBUG
-                if !started {
+                if !prepared.session.start() {
                     // When start() returns false the completion handler may never be called, so the
                     // continuation is resumed with an error here.
-                    self.complete(attempt: attempt, .failure(.TechnicalError(reason: "ASWebAuthenticationSession failed to start")))
+                    self.complete(id: id, .failure(.TechnicalError(reason: "ASWebAuthenticationSession failed to start")))
                 }
             }
         } onCancel: {
-            // Cancellation can arrive on any thread → hop onto the main actor. No effect if the attempt is
-            // already resolved or was replaced by a newer login (`complete`'s guards).
+            // Cancellation can arrive on any thread → hop onto the main actor. No effect if the login is
+            // already resolved (`complete`'s guard).
             Task { @MainActor in
-                self.complete(attempt: attempt, .failure(.AuthCanceled))
+                self.complete(id: id, .failure(.AuthCanceled))
             }
         }
+    }
+
+    /// Builds the session for `mode` and says which `redirect_uri`, if any, the out-of-band channel should
+    /// watch for. Deliberately free of any state mutation: `start(...)` calls it before claiming the slot.
+    private func prepareSession(id: Int,
+                                url: URL,
+                                mode: WebSessionMode,
+                                expectsAuthorizationCode: Bool,
+                                presentationContextProvider: ASWebAuthenticationPresentationContextProviding,
+                                prefersEphemeralWebBrowserSession: Bool)
+    throws -> (session: ASWebAuthenticationSession, expectedCallback: URL?) {
+
+        let completionHandler: ASWebAuthenticationSession.CompletionHandler = { [weak self] callbackURL, error in
+            // Everything hops to the main thread to avoid races.
+            Task { @MainActor in
+                self?.handleSessionCompletion(id: id, callbackURL: callbackURL, error: error)
+            }
+        }
+
+        let session: ASWebAuthenticationSession
+        let expectedCallback: URL?
+        switch mode.callback {
+        case .customScheme:
+            // Arm the out-of-band channel: the provider may decide midway to leave for a third-party app,
+            // sheet already open, and come back through `application(_:open:)`.
+            expectedCallback = expectsAuthorizationCode ? sdkRedirectUri : nil
+            session = ASWebAuthenticationSession(
+                url: url,
+                callbackURLScheme: baseScheme,
+                completionHandler: completionHandler)
+
+        case let .universalLink(callback):
+            guard #available(iOS 17.4, *), let host = callback.host else {
+                throw ReachFiveError.TechnicalError(reason: "Universal link callback requires iOS 17.4+ and a host: \(callback)")
+            }
+            // No out-of-band channel to arm: `callback: .https(...)` makes the sheet itself intercept the
+            // redirection, and nothing else can deliver that link to us — `application(_:open:)` never
+            // sees https URLs.
+            expectedCallback = nil
+            session = ASWebAuthenticationSession(
+                url: url,
+                callback: .https(host: host, path: callback.path),
+                completionHandler: completionHandler)
+        }
+
+        // The window that acts as the session's presentation anchor.
+        session.presentationContextProvider = presentationContextProvider
+        session.prefersEphemeralWebBrowserSession = prefersEphemeralWebBrowserSession
+        return (session, expectedCallback)
     }
 
     /// Completes the login in progress if the incoming URL really is our callback, and closes the sheet if it
     /// is still open. Returns `true` only in that case — otherwise `false`, so the host app can route the
     /// link itself.
     func tryComplete(externalCallbackURL url: URL) -> Bool {
-        guard let expectedCallback,
+        guard case let .running(login) = state,
+              let expectedCallback = login.expectedCallback,
               Self.isOurCallback(url, expectedCallback: expectedCallback) else {
             return false
         }
-        complete(attempt: attempt, .success(url))
+        complete(id: login.id, .success(url))
         return true
     }
 
-    private func handleSessionCompletion(attempt: Int, callbackURL: URL?, error: Error?) {
-        // TEMP DEBUG — the system called us back. Absence of this line means the completion handler never fired.
-        let ns = error as NSError?
-        let asCode = (error as? ASWebAuthenticationSessionError).map { "\($0.code) (\($0.code.rawValue))" } ?? "not an ASWebAuthenticationSessionError"
-        print("""
-              🔍 [WebAuth] handleSessionCompletion attempt=\(attempt) current=\(self.attempt) \
-              loginInProgress=\(loginInProgress) continuation=\(continuation != nil)
-                 callbackURL=\(callbackURL?.absoluteString ?? "nil")
-                 error=\(ns.map { "\($0.domain) code=\($0.code) — \($0.localizedDescription)" } ?? "nil")
-                 asWebAuthError=\(asCode)
-              """)
+    private func handleSessionCompletion(id: Int, callbackURL: URL?, error: Error?) {
+        // The session reported, so its sheet is already going away: forget it, so the resolution below does
+        // not `cancel()` a session the system is done with (see `Login.session`).
+        if case var .running(login) = state, login.id == id {
+            login.session = nil
+            state = .running(login)
+        }
 
         if let error {
-            complete(attempt: attempt, .failure(Self.reachFiveError(for: error)))
+            complete(id: id, .failure(Self.reachFiveError(for: error)))
         } else if let callbackURL {
-            complete(attempt: attempt, .success(callbackURL))
+            complete(id: id, .success(callbackURL))
         } else {
-            complete(attempt: attempt, .failure(.TechnicalError(reason: "No callback URL")))
+            complete(id: id, .failure(.TechnicalError(reason: "No callback URL")))
         }
     }
 
-    /// The single resolution point: resumes the continuation with `result`, clears the state, and closes the
-    /// sheet if it is still presented (out-of-band resolution, cancellation, replacement).
-    private func complete(attempt: Int, _ result: Result<URL, ReachFiveError>) {
-        // TEMP DEBUG — did this resolution reach the continuation, or was it dropped (slot stays held)?
-        print("🔍 [WebAuth] complete attempt=\(attempt) current=\(self.attempt) continuation=\(continuation != nil) → \(attempt == self.attempt && continuation != nil ? "RESOLVES" : "DROPPED") result=\(result)")
-
-        // Ignore a stale callback (a newer login came in) or a second resolution (`continuation` already nil).
-        guard attempt == self.attempt, let continuation else { return }
-        // Capture the session before nil-ing it, to close its sheet after the resume. The late cancellation
-        // callback that results is ignored (`continuation` is nil by then); on a session that is already
-        // finished or was never presented, `cancel()` does nothing.
-        let openSession = session
-        self.continuation = nil
-        self.session = nil
-        self.expectedCallback = nil
-        self.loginInProgress = false
-        continuation.resume(with: result)
-        openSession?.cancel()
+    /// The single resolution point: resumes the continuation with `result`, releases the slot, and closes the
+    /// sheet if it is still presented (out-of-band resolution, cancellation).
+    private func complete(id: Int, _ result: Result<URL, ReachFiveError>) {
+        // Ignore a stale callback (it names a login that is no longer the one in place) or a second
+        // resolution (the state is back to `idle`).
+        guard case let .running(login) = state, login.id == id else { return }
+        // Released before the resume so the slot is free for whatever the caller does next.
+        state = .idle
+        login.continuation.resume(with: result)
+        // Only reached when the resolution came from somewhere other than the session itself, which is why
+        // this cannot land on a session that has already reported.
+        login.session?.cancel()
     }
 
     /// `true` when the incoming URL designates the same endpoint as the `redirect_uri` we sent
@@ -236,12 +271,18 @@ final class WebAuthenticationSession {
     }
 
     /// Maps an `ASWebAuthenticationSession` error onto a `ReachFiveError`.
+    ///
+    /// `canceledLogin` is not only "the user tapped Cancel": the system also reports it when the app is not
+    /// associated with the host of an `.https` callback (measured on iOS and Mac Catalyst — the reason only
+    /// appears in `localizedDescription`). It is logged here so a misconfigured Associated Domain does not
+    /// vanish into the `.AuthCanceled` every integration ignores.
     nonisolated static func reachFiveError(for error: Error) -> ReachFiveError {
         guard let sessionError = error as? ASWebAuthenticationSessionError else {
             return .TechnicalError(reason: "Unknown Error \(error.localizedDescription)")
         }
         switch sessionError.code {
         case .canceledLogin:
+            Logger.shared.log("The web session ended without a callback: \(error.localizedDescription)")
             return .AuthCanceled
         case .presentationContextNotProvided:
             return .TechnicalError(reason: "Presentation context not provided: \(error.localizedDescription)")

--- a/Sources/Core/Classes/web/WebAuthentication.swift
+++ b/Sources/Core/Classes/web/WebAuthentication.swift
@@ -85,16 +85,17 @@ final class WebAuthenticationSession {
     /// - Parameter expectsAuthorizationCode: `false` for a call whose callback carries no `code` (logout):
     ///   the out-of-band channel is then not prepared at all.
     /// - Throws: `.AuthCanceled` when a web login is already in progress — the call is dropped, the login
-    ///   under way is untouched, and the caller has nothing to single out.
+    ///   under way is untouched, and the caller has nothing to single out — or when the calling `Task` was
+    ///   already cancelled, in which case nothing is presented at all.
     func start(url: URL,
                mode: WebSessionMode,
                expectsAuthorizationCode: Bool = true,
                presentationContextProvider: ASWebAuthenticationPresentationContextProviding,
                prefersEphemeralWebBrowserSession: Bool = false) async throws -> URL {
 
-        // An already-cancelled Task must not present a sheet (its `onCancel` below would have fired
-        // already, to no effect, before the continuation was installed).
-        try Task.checkCancellation()
+        // An already-cancelled Task must not present a sheet (its `onCancel` below would already have run,
+        // to no effect, before the continuation was installed).
+        guard !Task.isCancelled else { throw ReachFiveError.AuthCanceled }
 
         // One login at a time, and the incumbent keeps its place.
         guard case .idle = state else {
@@ -212,7 +213,7 @@ final class WebAuthenticationSession {
             // Logged because `.canceledLogin` covers more than the user tapping Cancel: the system also
             // reports it when the app is not associated with the host of an `.https` callback, and the
             // reason only shows up in `localizedDescription`. Only reached for an error this call is about
-            // to deliver, so it never fires for a sheet we closed ourselves.
+            // to deliver, so it never runs for a sheet we closed ourselves.
             Logger.shared.log("The web session ended without a callback: \(error.localizedDescription)")
             complete(id: id, .failure(Self.reachFiveError(for: error)))
         } else if let callbackURL {

--- a/Sources/Core/Classes/web/WebAuthentication.swift
+++ b/Sources/Core/Classes/web/WebAuthentication.swift
@@ -3,57 +3,35 @@ import AuthenticationServices
 /// Carries the web login in progress: starts an `ASWebAuthenticationSession`, waits for its callback, and
 /// lets a link received through `application(_:open:)` complete it (``tryComplete(externalCallbackURL:)``).
 ///
-/// **A custom-scheme login arms both channels.** A provider may decide *midway*, sheet already open,
-/// whether it finishes inside the sheet or leaves the app for a third-party one — b.connect picks
-/// `passive`/`active` only after `/authorize`. The caller therefore cannot pick the channel up front, and
-/// does not have to. A universal-link login is the exception: it is built with `callback: .https(...)`, so
-/// the sheet itself intercepts the redirection and no out-of-band channel is armed for it.
+/// **A custom-scheme login arms both channels**, because a provider may decide *midway*, sheet already open,
+/// whether it finishes inside the sheet or leaves for a third-party app — b.connect picks `passive`/`active`
+/// only after `/authorize`, so neither the caller nor the SDK can choose up front. Two calls leave the
+/// out-of-band channel unarmed: a universal-link login, whose `callback: .https(...)` makes the sheet
+/// intercept the redirection itself, and `logout`, whose callback carries no `code`
+/// (`expectsAuthorizationCode: false`).
 ///
-/// **One login at a time, the incumbent keeps its place, and the newcomer is dropped silently.** A
-/// `start(...)` called while another login is in progress ends with `.AuthCanceled` — the error every
-/// integration already treats as "nothing happened" — and the login already under way is left alone. The
-/// caller has nothing to do about it: this is the SDK absorbing a double tap, not a failure to report.
+/// **One login at a time, and the newcomer is dropped silently** with `.AuthCanceled` — the error every
+/// integration already treats as "nothing happened" — leaving the login under way untouched. Nothing is
+/// expected of the caller: this is the SDK absorbing a double tap, not a failure to report.
 ///
-/// Refusing rather than replacing is the fix for a concrete bug. Replacing the incumbent means cancelling
-/// its sheet and presenting the replacement right behind it; `session.start()` then answers `false` while the
-/// outgoing sheet is still animating away, and retrying until it answers `true` only moves the failure —
-/// the presentation fails asynchronously in the completion handler with `presentationContextInvalid`, and
-/// *both* logins are lost. Measured on an iOS device with two very fast taps on the same web-login button
-/// (not reproducible on Mac Catalyst). Refusing the newcomer removes the cancel-then-present sequence
-/// altogether, which is the only way found to remove the failure rather than race with it — and on a double
-/// tap the first tap is the one the user meant anyway.
+/// Refusing rather than replacing is a measured choice. Replacing means cancelling the incumbent's sheet and
+/// presenting the newcomer behind it; `session.start()` then answers `false` while the outgoing sheet
+/// animates away, and retrying until it answers `true` only moves the failure — the presentation then fails
+/// asynchronously with `presentationContextInvalid`, and *both* logins are lost. Reproduced on an iOS device
+/// with two fast taps on the same button (never on Mac Catalyst). Refusing removes the cancel-then-present
+/// sequence entirely, and on a double tap the first tap is the one the user meant. No legitimate caller wants
+/// the other behaviour: a logout is always a manual action, so it cannot start while a login sheet is on
+/// screen. Multi-window (iPad, Mac Catalyst) is the one place two concurrent logins would make sense, and is
+/// out of scope while one session is shared by the whole `ReachFive` instance.
 ///
-/// Every other concurrent caller would be programmatic, and there is none: a logout is always a manual
-/// action, so it cannot be triggered while a login sheet is on screen. Multi-window setups (iPad,
-/// Mac Catalyst) are the one place where two concurrent logins would be legitimate; they are out of scope
-/// while a single session is shared by the whole `ReachFive` instance.
+/// The way out if a login never resolves: cancel the `Task` that started it — `onCancel` closes the sheet and
+/// frees the slot, which a view being torn down does on its own. No extra API is needed for it.
 ///
-/// The way out, if a login somehow never resolves: cancel the `Task` that started it. `onCancel` closes the
-/// sheet and resumes with `.AuthCanceled`, which frees the slot — a view being torn down does this on its
-/// own, and no extra API is needed for it.
-///
-/// Late or duplicated callbacks are neutralised by ``State``: a resolution has to name the login it belongs
-/// to (`Login.id`), and the winning one puts the state back to `idle`, so any later arrival finds nothing to
-/// resolve.
-///
-/// **The out-of-band channel is only armed for a login**: `logout` also goes through `start(...)`, but with
-/// `expectsAuthorizationCode: false`. Its callback (`post_logout_redirect_uri`) carries no `code` and is
-/// intercepted by the sheet itself, so `expectedCallback` stays `nil`.
-///
-/// **Accepted imprecision in the matching**: arming `expectedCallback` for *every* web login widens the
-/// window in which a passwordless magic link, tapped while a sheet is open, would be consumed by
-/// `tryComplete` instead of being routed to `interceptPasswordless` (``ReachFive/interceptUrl(_:)``).
-///
-/// **Limitation (out-of-band)**: the state of a login in progress only lives in memory. If iOS kills the app
-/// during the detour outside it, the callback received on relaunch matches nothing (`tryComplete` returns
-/// `false`, the host app routes the link). It is then *accidentally* rescued: `webviewLogin` left its PKCE
-/// in the passwordless storage slot, so `interceptPasswordless` completes the login and delivers the token
-/// on the `passwordlessCallback` — a web login surfacing on the passwordless channel, which no caller asked
-/// for. That accident is the one thing standing between this limitation and a lost `code`, and the real
-/// detour can be long, so the window is not negligible. A proper
-/// resume after relaunch would mean persisting the login in progress (redirect_uri + PKCE, already in
-/// storage) and a channel to deliver the result to the app. Both the accident and the proper fix are out of
-/// scope here; see the PKCE storage-slot redesign.
+/// **Two accepted imprecisions**, both rooted in the shared PKCE slot and described by the FIXME in
+/// ``ReachFive/webviewLogin(_:)``: `expectedCallback` is armed for every custom-scheme login, which widens
+/// the window in which a passwordless magic link tapped while a sheet is open is consumed by `tryComplete`
+/// instead of ``ReachFive/interceptUrl(_:)``; and the login in progress lives only in memory, so an app kill
+/// mid-detour leaves its callback matching nothing on relaunch.
 ///
 /// `@MainActor`: the whole `ASWebAuthenticationSession` domain is already main-thread.
 @MainActor
@@ -82,17 +60,15 @@ final class WebAuthenticationSession {
         /// The `redirect_uri` expected out-of-band; `nil` for a universal-link login (the sheet intercepts
         /// the redirection itself) → `tryComplete` then matches nothing.
         let expectedCallback: URL?
-        /// The presented session, to be closed if a resolution comes from somewhere else. Set back to `nil`
-        /// as soon as the session reports its own completion: its sheet is then already on its way out, and
-        /// `cancel()`ing it at that point makes UIKit load the view of a deallocating
-        /// `SFAuthenticationViewController`.
+        /// The presented session, to close its sheet when the resolution comes from somewhere else
+        /// (out-of-band, or the calling `Task` cancelled). Set back to `nil` as soon as the session reports
+        /// its own completion: the system is then done with it and there is no sheet left to close.
         var session: ASWebAuthenticationSession?
     }
 
-    /// Whether the slot is taken, for a caller that has side effects to arm *before* presenting and must not
-    /// arm them for a call `start(...)` is going to drop (see `webviewLogin` and the shared PKCE slot).
-    /// Internal on purpose: an integrator has nothing to check, a dropped call already ends with
-    /// `.AuthCanceled`.
+    /// Whether the slot is taken — for a caller with side effects to arm *before* presenting, which must not
+    /// arm them for a call `start(...)` is going to drop (see ``ReachFive/webviewLogin(_:)``). Internal on
+    /// purpose: an integrator has nothing to check, a dropped call already ends with `.AuthCanceled`.
     var isLoginInProgress: Bool {
         if case .idle = state { false } else { true }
     }
@@ -111,17 +87,14 @@ final class WebAuthenticationSession {
     }
 
     /// Starts a web login and waits for its callback (success, error or cancellation). The
-    /// ``WebSessionMode`` describes the shape of the callback (custom scheme or universal link) and drives
-    /// how the session is built. For a custom scheme both channels are armed: the sheet intercepts if the
-    /// flow never leaves it, and ``tryComplete(externalCallbackURL:)`` resolves if the return comes back
-    /// out-of-band — a provider can pick either one midway, sheet already open. If the calling `Task` is
-    /// cancelled (view torn down, timeout…), the sheet is closed and the call ends with `.AuthCanceled`.
+    /// ``WebSessionMode`` drives how the session is built and which channels are armed, as described above.
+    /// If the calling `Task` is cancelled (view torn down, timeout…), the sheet is closed and the call ends
+    /// with `.AuthCanceled`.
     ///
     /// - Parameter expectsAuthorizationCode: `false` for a call whose callback carries no `code` (logout):
     ///   the out-of-band channel is then not armed at all.
-    /// - Throws: `.AuthCanceled` when a web login is already in progress — the call is dropped and the
-    ///   login under way is untouched. Callers do not have to single this case out: it is the same
-    ///   "nothing happened" outcome as a user tapping Cancel.
+    /// - Throws: `.AuthCanceled` when a web login is already in progress — the call is dropped, the login
+    ///   under way is untouched, and the caller has nothing to single out.
     func start(url: URL,
                mode: WebSessionMode,
                expectsAuthorizationCode: Bool = true,
@@ -269,17 +242,17 @@ final class WebAuthenticationSession {
         state = .idle
         login.continuation.resume(with: result)
         // Only reached when the resolution came from somewhere other than the session itself, which is why
-        // this cannot land on a session that has already reported.
+        // this cannot land on a session that has already reported. Unrelated to the "Attempting to load the
+        // view … while it is deallocating (SFAuthenticationViewController)" iOS logs when tearing a cancelled
+        // sheet down: that one shows up on a plain user cancel too, with no `cancel()` of ours involved.
         login.session?.cancel()
     }
 
     /// `true` when the incoming URL designates the same endpoint as the `redirect_uri` we sent
-    /// (``matchesEndpoint(of:)``, the matcher shared with ``ReachFive/interceptUrl(_:)``) and carries a
-    /// `code` (success) or an `error` parameter (OAuth refusal, e.g. `access_denied` — the login then ends
-    /// cleanly with the callback's `ApiError` instead of hanging on the sheet). Comparing the scheme keeps a
-    /// login expected on a custom scheme from matching an https URL, and the other way round. Since the
-    /// expected path is the one we declare (the redirect_uri), this matching is enough to tell our callback
-    /// apart from the app's other links.
+    /// (``matchesEndpoint(of:)``, shared with ``ReachFive/interceptUrl(_:)``) and carries a `code` or an
+    /// `error` parameter — an OAuth refusal such as `access_denied` then ends the login cleanly with the
+    /// callback's `ApiError` instead of leaving it on the sheet. Comparing the scheme and the path we declared
+    /// is enough to tell our callback apart from the app's other links.
     nonisolated static func isOurCallback(_ url: URL, expectedCallback expected: URL) -> Bool {
         url.matchesEndpoint(of: expected)
         && (url.queryValue("code") != nil || url.queryValue("error") != nil)

--- a/Sources/Core/Classes/web/WebAuthentication.swift
+++ b/Sources/Core/Classes/web/WebAuthentication.swift
@@ -1,8 +1,15 @@
 import AuthenticationServices
 
-/// Porte le login web en cours : démarre une `ASWebAuthenticationSession`, attend son callback,
-/// et — pour les logins hors-bande — laisse un lien reçu via `application(_:open:)` (custom scheme)
-/// ou `application(_:continue:)` (lien universel) le compléter (``tryComplete(externalCallbackURL:)``).
+/// Porte le login web en cours : démarre une `ASWebAuthenticationSession`, attend son callback, et
+/// laisse un lien reçu via `application(_:open:)` (custom scheme) ou `application(_:continue:)` (lien
+/// universel) le compléter (``tryComplete(externalCallbackURL:)``).
+///
+/// **Les deux canaux sont armés pour tout login.** Un provider peut décider *en vol*, feuille déjà
+/// ouverte, s'il termine dedans ou s'il sort de l'app : b.connect choisit `passive` (302 direct vers la
+/// `redirect_uri`, intercepté par la feuille) ou `active` (détour par l'app banque, qui rouvre le
+/// **navigateur par défaut** ; c'est Safari qui livre le custom scheme à `application(_:open:)`, la
+/// feuille restant ouverte derrière jusqu'à sa fermeture par ``complete(attempt:_:)``). L'appelant ne
+/// peut donc pas choisir le canal à l'avance, et n'a pas à le faire.
 ///
 /// **Un seul login à la fois.** Sur iPhone, la feuille modale d'une `ASWebAuthenticationSession` rend
 /// un second `start(...)` inatteignable par l'interaction utilisateur : tant qu'elle est présentée rien
@@ -19,11 +26,22 @@ import AuthenticationServices
 /// continuation exactement une fois.
 ///
 /// **Limitation (hors-bande)** : l'état d'un login en vol ne vit qu'en mémoire. Si iOS tue l'app
-/// pendant l'aller-retour vers l'app externe, le callback reçu au relancement ne matche rien
-/// (`tryComplete` renvoie `false`, l'app hôte route le lien) et le `code` est perdu : l'utilisateur
-/// doit relancer le login. Une reprise après relancement demanderait de persister le login en vol
+/// pendant le détour hors de l'app, le callback reçu au relancement ne matche rien (`tryComplete`
+/// renvoie `false`, l'app hôte route le lien) et le `code` est perdu : l'utilisateur doit relancer le
+/// login. Le détour réel étant long — app externe **puis** navigateur par défaut — la fenêtre de risque
+/// n'est pas négligeable. Une reprise après relancement demanderait de persister le login en vol
 /// (redirect_uri + PKCE, déjà en storage) et un canal pour livrer le résultat à l'app — assumé hors
 /// périmètre tant que l'usage ne le justifie pas.
+///
+/// **Deux imprécisions connues du matching**, assumées ici, que la comparaison du `state` refermerait :
+/// - `logout` passe aussi par `start(...)` et arme donc `expectedCallback`. Son callback
+///   (`post_logout_redirect_uri`) ne porte ni `code` ni `error`, donc ne s'auto-matche pas ; mais un
+///   code de login égaré pendant un logout résoudrait la continuation du logout (qui ignore l'URL) et
+///   fermerait sa feuille tôt. L'étanchéité demanderait un `expectsAuthorizationCode: Bool` interne.
+/// - Armer `expectedCallback` sur *tout* login web élargit la fenêtre où un lien magique passwordless
+///   tapé pendant qu'une feuille est ouverte serait consommé par `tryComplete` plutôt que routé vers
+///   `interceptPasswordless` (``ReachFive/interceptUrl(_:)``). C'était déjà le cas de l'ancien mode
+///   hors-bande à custom scheme.
 ///
 /// `@MainActor` : tout le domaine `ASWebAuthenticationSession` est déjà main-thread.
 @MainActor
@@ -44,10 +62,11 @@ final class WebAuthenticationSession {
     }
 
     /// Démarre un login web et attend son callback (succès, erreur ou annulation). Le ``WebSessionMode``
-    /// décrit comment la session se termine — croisement de deux axes (custom scheme vs lien universel,
-    /// in-band vs hors-bande) — et pilote donc à la fois la construction de la session et le canal du
-    /// callback. Si le `Task` appelant est annulé (vue démontée, timeout…), la feuille est fermée et
-    /// l'appel se termine par `.AuthCanceled`.
+    /// décrit la forme du callback (custom scheme ou lien universel) et pilote la construction de la
+    /// session. Les **deux canaux sont toujours armés** : la feuille intercepte si le flow ne la quitte
+    /// jamais, et ``tryComplete(externalCallbackURL:)`` résout si le retour arrive hors-bande — un
+    /// provider peut choisir entre les deux en vol, feuille déjà ouverte. Si le `Task` appelant est
+    /// annulé (vue démontée, timeout…), la feuille est fermée et l'appel se termine par `.AuthCanceled`.
     func start(url: URL,
                mode: WebSessionMode,
                presentationContextProvider: ASWebAuthenticationPresentationContextProviding,
@@ -66,9 +85,10 @@ final class WebAuthenticationSession {
         return try await withTaskCancellationHandler {
             try await withCheckedThrowingContinuation { continuation in
                 self.continuation = continuation
-                // Seul le mode hors-bande arme `tryComplete` ; en in-band, la session se complète elle-même.
-                // La `redirect_uri` attendue est celle du mode (lien universel) ou, à défaut, celle du SdkConfig.
-                self.expectedCallback = mode.channel == .outOfBand ? (mode.redirectUri ?? sdkRedirectUri) : nil
+                // `tryComplete` est armé pour tout login : le provider peut décider en vol de sortir vers
+                // une app externe, feuille déjà ouverte. La `redirect_uri` attendue est celle du mode
+                // (lien universel) ou, à défaut, celle du SdkConfig (custom scheme).
+                self.expectedCallback = mode.redirectUri ?? sdkRedirectUri
 
                 let completionHandler: ASWebAuthenticationSession.CompletionHandler = { [weak self] callbackURL, error in
                     // Tout passe sur le main thread pour éviter les situations de compétition.
@@ -78,35 +98,32 @@ final class WebAuthenticationSession {
                 }
 
                 let session: ASWebAuthenticationSession
-                switch (mode.channel, mode.callback) {
-                case (.inBand, .customScheme):
-                    // Scheme custom intercepté par la session (historique, tout iOS).
+                switch mode.callback {
+                case .customScheme:
+                    // Les deux canaux sont armés : la feuille intercepte le custom scheme si le flow ne la
+                    // quitte jamais (cas `passive`), et `tryComplete` résout si le retour arrive par le
+                    // navigateur par défaut (cas `active` : app externe → Safari → `application(_:open:)`).
+                    // `complete()` étant idempotent (garde `attempt` + `continuation != nil`), le canal
+                    // perdant est sans effet.
                     session = ASWebAuthenticationSession(
                         url: url,
                         callbackURLScheme: self.baseScheme,
                         completionHandler: completionHandler)
 
-                case let (.inBand, .universalLink(callback)):
-                    // iOS 17.4+ : lien universel intercepté in-band dans la webview via `callback: .https`
-                    // (nécessite l'Associated Domain `webcredentials:<host>`). La disponibilité est déjà
-                    // garantie en amont par la fabrique `@available` de ``WebSessionMode``, on garde ici
-                    // un filet runtime (et l'extraction du host, faillible).
+                case let .universalLink(callback):
+                    // iOS 17.4+ : lien universel intercepté dans la webview via `callback: .https`
+                    // (nécessite l'Associated Domain `webcredentials:<host>`). Le cas est inatteignable à
+                    // la compilation sous 17.4 grâce à l'`@available` porté par la fabrique
+                    // ``WebSessionMode/universalLink(_:)``, mais `DefaultProvider` le résout depuis la
+                    // configuration backend, où le contrôle ne peut être que runtime — d'où ce filet (et
+                    // l'extraction du host, faillible).
                     guard #available(iOS 17.4, *), let host = callback.host else {
-                        self.complete(attempt: attempt, .failure(.TechnicalError(reason: "In-sheet universal link callback requires iOS 17.4+ and a host: \(callback)")))
+                        self.complete(attempt: attempt, .failure(.TechnicalError(reason: "Universal link callback requires iOS 17.4+ and a host: \(callback)")))
                         return
                     }
                     session = ASWebAuthenticationSession(
                         url: url,
                         callback: .https(host: host, path: callback.path),
-                        completionHandler: completionHandler)
-
-                case (.outOfBand, _):
-                    // Le flow se termine dans une app externe : la session ne recevra jamais le callback
-                    // (traité hors-bande par `tryComplete`, quel que soit le type de lien), on ne lui donne
-                    // donc aucun scheme à intercepter.
-                    session = ASWebAuthenticationSession(
-                        url: url,
-                        callbackURLScheme: nil,
                         completionHandler: completionHandler)
                 }
 
@@ -171,10 +188,10 @@ final class WebAuthenticationSession {
     /// `true` si l'URL entrante a le même scheme et le même host (insensibles à la casse) et le même
     /// path que le `redirect_uri` envoyé, et porte un paramètre `code` (succès) ou `error` (refus OAuth,
     /// ex. `access_denied` — le login se termine alors proprement avec l'`ApiError` du callback au lieu
-    /// de rester bloqué sur la feuille). Comparer le scheme est ce qui permet aux deux canaux hors-bande
-    /// (custom scheme via `application(_:open:)`, lien universel via `application(_:continue:)`) de
-    /// partager ce même matcher sans faux positif : un login attendu en scheme ne matche que des URL de
-    /// ce scheme, un login attendu en https que des liens universels. Le path attendu étant celui qu'on
+    /// de rester bloqué sur la feuille). Comparer le scheme est ce qui permet aux deux hooks d'entrée
+    /// (`application(_:open:)` pour le custom scheme, `application(_:continue:)` pour le lien universel)
+    /// de partager ce même matcher sans faux positif : un login attendu en scheme ne matche que des URL
+    /// de ce scheme, un login attendu en https que des liens universels. Le path attendu étant celui qu'on
     /// déclare (AASA pour l'https, redirect_uri pour le scheme), ce matching exact suffit à distinguer
     /// notre callback des autres liens de l'app.
     nonisolated static func isOurCallback(_ url: URL, expectedCallback expected: URL) -> Bool {

--- a/Sources/Core/Classes/web/WebSessionMode.swift
+++ b/Sources/Core/Classes/web/WebSessionMode.swift
@@ -1,50 +1,50 @@
 import Foundation
 
-/// How an `ASWebAuthenticationSession` completes, on two orthogonal axes: the ``Callback`` shape (custom
-/// scheme, delivered via `application(_:open:)`, or universal link, via `application(_:continue:)`) and
-/// the ``Channel`` where it's intercepted (in the session's webview, or out-of-band via an external app).
-/// Use the factories below; only the in-sheet universal link needs iOS 17.4+.
+/// Comment une `ASWebAuthenticationSession` se termine : par le custom scheme du SDK, ou par un lien
+/// universel intercepté dans la feuille. Utiliser les fabriques ci-dessous.
+///
+/// Il n'y a **pas** d'axe « in-band vs hors-bande » : un provider peut décider en vol, feuille déjà
+/// ouverte, de rester dans la feuille ou de sortir vers une app externe (b.connect choisit
+/// `passive`/`active` après le `/authorize`). L'appelant ne peut donc pas trancher, et n'a pas à le
+/// faire : ``customScheme`` arme les deux canaux à la fois.
+///
+/// **Pourquoi un `struct` et pas un `enum`** : seul ``universalLink(_:)`` exige iOS 17.4+, et Swift
+/// refuse `@available` sur un cas d'énumération porteur d'une valeur associée (contrairement à un cas
+/// nu comme `ModalAuthorization.Passkey`). Une fabrique statique, elle, peut l'être — c'est ce qui
+/// garde la contrainte de version vérifiée **à la compilation** plutôt que reportée au runtime.
 public struct WebSessionMode {
     enum Callback {
         case customScheme
         case universalLink(URL)
     }
 
-    public enum Channel {
-        /// The redirection is intercepted _inside_ the session's webview.
-        case inBand
-        /// The flow ends in an external app that reopens the host app.
-        case outOfBand
-    }
-
     let callback: Callback
-    let channel: Channel
 
-    private init(callback: Callback, channel: Channel) {
+    private init(callback: Callback) {
         self.callback = callback
-        self.channel = channel
     }
 
-    /// Custom scheme intercepted in the sheet — the historical flow, on every iOS version.
-    public static let sdkScheme = WebSessionMode(callback: .customScheme, channel: .inBand)
+    /// Retour par le custom scheme du SDK (`reachfive-<clientId>://callback`), que la redirection
+    /// finale soit interceptée dans la feuille ou livrée par le navigateur par défaut à
+    /// `application(_:open:)`. Défaut, sur toutes les versions d'iOS supportées.
+    public static let customScheme = WebSessionMode(callback: .customScheme)
 
-    /// An external app reopens the host app via the custom scheme.
-    public static let externalAppScheme = WebSessionMode(callback: .customScheme, channel: .outOfBand)
-
-    /// An external app reopens the host app via a universal link. Requires the `applinks:<host>`
-    /// Associated Domain; `link` is the expected `redirect_uri`.
-    public static func externalAppUniversalLink(_ link: URL) -> WebSessionMode {
-        WebSessionMode(callback: .universalLink(link), channel: .outOfBand)
-    }
-
-    /// Universal link intercepted in the sheet (via `callback: .https`). Requires the
-    /// `webcredentials:<host>` Associated Domain; `link` is the expected `redirect_uri`.
+    /// Retour par un lien universel intercepté dans la feuille (via `callback: .https`).
+    /// Associated Domain `webcredentials:<host>` requis ; `link` est la `redirect_uri` attendue.
+    ///
+    /// **Pas de dégradation gracieuse sous iOS 17.4** : la redirection finale vers
+    /// `https://<host>/<path>?code=…` a lieu *dans la feuille*, et iOS ne suit pas un lien universel
+    /// sur une navigation qui n'est pas initiée par l'utilisateur. Sans `callback: .https`, la feuille
+    /// chargerait la page de callback, `application(_:continue:)` ne serait jamais appelé, et le login
+    /// resterait suspendu jusqu'à annulation. Le seul mécanisme capable de produire ce retour
+    /// hors-bande serait une app externe appelant `UIApplication.open` — ce que le flow réel ne fait
+    /// pas : l'app externe rouvre le *navigateur par défaut*, pas l'app hôte.
     @available(iOS 17.4, *)
-    public static func inSheetUniversalLink(_ link: URL) -> WebSessionMode {
-        WebSessionMode(callback: .universalLink(link), channel: .inBand)
+    public static func universalLink(_ link: URL) -> WebSessionMode {
+        WebSessionMode(callback: .universalLink(link))
     }
 
-    /// The OAuth `redirect_uri` carried by the mode; `nil` for a custom scheme, where the `SdkConfig`'s applies.
+    /// La `redirect_uri` portée par le mode ; `nil` pour le custom scheme, où celle du `SdkConfig` s'applique.
     var redirectUri: URL? {
         switch callback {
         case .customScheme: nil

--- a/Sources/Core/Classes/web/WebSessionMode.swift
+++ b/Sources/Core/Classes/web/WebSessionMode.swift
@@ -1,17 +1,12 @@
 import Foundation
 
-/// Comment une `ASWebAuthenticationSession` se termine : par le custom scheme du SDK, ou par un lien
-/// universel intercepté dans la feuille. Utiliser les fabriques ci-dessous.
+/// How an `ASWebAuthenticationSession` ends: through the SDK's custom scheme, or through a universal link
+/// intercepted in the sheet. Use the factories below.
 ///
-/// Il n'y a **pas** d'axe « in-band vs hors-bande » : un provider peut décider en vol, feuille déjà
-/// ouverte, de rester dans la feuille ou de sortir vers une app externe (b.connect choisit
-/// `passive`/`active` après le `/authorize`). L'appelant ne peut donc pas trancher, et n'a pas à le
-/// faire : ``customScheme`` arme les deux canaux à la fois.
-///
-/// **Pourquoi un `struct` et pas un `enum`** : seul ``universalLink(_:)`` exige iOS 17.4+, et Swift
-/// refuse `@available` sur un cas d'énumération porteur d'une valeur associée (contrairement à un cas
-/// nu comme `ModalAuthorization.Passkey`). Une fabrique statique, elle, peut l'être — c'est ce qui
-/// garde la contrainte de version vérifiée **à la compilation** plutôt que reportée au runtime.
+/// **Why a `struct` and not an `enum`**: only ``universalLink(_:)`` requires iOS 17.4+, and Swift refuses
+/// `@available` on an enum case carrying an associated value (unlike a bare case such as
+/// `ModalAuthorization.Passkey`). A static factory can carry it — which is what keeps the version
+/// constraint checked **at compile time** rather than deferred to runtime.
 public struct WebSessionMode {
     enum Callback {
         case customScheme
@@ -24,27 +19,19 @@ public struct WebSessionMode {
         self.callback = callback
     }
 
-    /// Retour par le custom scheme du SDK (`reachfive-<clientId>://callback`), que la redirection
-    /// finale soit interceptée dans la feuille ou livrée par le navigateur par défaut à
-    /// `application(_:open:)`. Défaut, sur toutes les versions d'iOS supportées.
+    /// Return through the SDK's custom scheme (`reachfive-<clientId>://callback`), whether the final
+    /// redirection is intercepted in the sheet or delivered by the default browser to
+    /// `application(_:open:)`. The default, on every supported iOS version.
     public static let customScheme = WebSessionMode(callback: .customScheme)
 
-    /// Retour par un lien universel intercepté dans la feuille (via `callback: .https`).
-    /// Associated Domain `webcredentials:<host>` requis ; `link` est la `redirect_uri` attendue.
-    ///
-    /// **Pas de dégradation gracieuse sous iOS 17.4** : la redirection finale vers
-    /// `https://<host>/<path>?code=…` a lieu *dans la feuille*, et iOS ne suit pas un lien universel
-    /// sur une navigation qui n'est pas initiée par l'utilisateur. Sans `callback: .https`, la feuille
-    /// chargerait la page de callback, `application(_:continue:)` ne serait jamais appelé, et le login
-    /// resterait suspendu jusqu'à annulation. Le seul mécanisme capable de produire ce retour
-    /// hors-bande serait une app externe appelant `UIApplication.open` — ce que le flow réel ne fait
-    /// pas : l'app externe rouvre le *navigateur par défaut*, pas l'app hôte.
+    /// Return through a universal link intercepted in the sheet (via `callback: .https`). Requires the
+    /// `webcredentials:<host>` Associated Domain; `link` is the expected `redirect_uri`.
     @available(iOS 17.4, *)
     public static func universalLink(_ link: URL) -> WebSessionMode {
         WebSessionMode(callback: .universalLink(link))
     }
 
-    /// La `redirect_uri` portée par le mode ; `nil` pour le custom scheme, où celle du `SdkConfig` s'applique.
+    /// The `redirect_uri` carried by the mode; `nil` for the custom scheme, where the `SdkConfig`'s applies.
     var redirectUri: URL? {
         switch callback {
         case .customScheme: nil

--- a/Sources/Reach5.xcodeproj/project.pbxproj
+++ b/Sources/Reach5.xcodeproj/project.pbxproj
@@ -7,6 +7,11 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		CA61910000000000000000E2 /* Presentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA61910000000000000000E1 /* Presentation.swift */; };
+		CA61910000000000000000F2 /* TokenType.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA61910000000000000000F1 /* TokenType.swift */; };
+		CA61910000000000000000B2 /* URL+WebAuth.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA61910000000000000000B1 /* URL+WebAuth.swift */; };
+		CA61910000000000000000C2 /* WebAuthentication.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA61910000000000000000C1 /* WebAuthentication.swift */; };
+		CA61910000000000000000D2 /* WebSessionMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA61910000000000000000D1 /* WebSessionMode.swift */; };
 		06FA9FFD97F751D36D924E4B /* SdkVersion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CEBCA83371E03539C69DBD8 /* SdkVersion.swift */; };
 		2A0305102C04DBE500A92524 /* ResetOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A03050F2C04DBE500A92524 /* ResetOptions.swift */; };
 		2A0305122C04F07900A92524 /* ResetPasskeyRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A0305112C04F07900A92524 /* ResetPasskeyRequest.swift */; };
@@ -108,6 +113,11 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		CA61910000000000000000E1 /* Presentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Presentation.swift; sourceTree = "<group>"; };
+		CA61910000000000000000F1 /* TokenType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenType.swift; sourceTree = "<group>"; };
+		CA61910000000000000000B1 /* URL+WebAuth.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+WebAuth.swift"; sourceTree = "<group>"; };
+		CA61910000000000000000C1 /* WebAuthentication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WebAuthentication.swift"; sourceTree = "<group>"; };
+		CA61910000000000000000D1 /* WebSessionMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WebSessionMode.swift"; sourceTree = "<group>"; };
 		2A03050F2C04DBE500A92524 /* ResetOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResetOptions.swift; sourceTree = "<group>"; };
 		2A0305112C04F07900A92524 /* ResetPasskeyRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResetPasskeyRequest.swift; sourceTree = "<group>"; };
 		2A0305132C063DEA00A92524 /* ResetPublicKeyCredential.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResetPublicKeyCredential.swift; sourceTree = "<group>"; };
@@ -235,6 +245,7 @@
 				2A624FD92B2BDBC400BF33A7 /* DefaultProvider.swift */,
 				2AE18CDA29FC1DAF00258D2B /* LoginWKWebview.swift */,
 				347FDB53229BE8F800660687 /* Provider.swift */,
+				CA61910000000000000000E1 /* Presentation.swift */,
 				347FDB66229C02FE00660687 /* ReachFive.swift */,
 				34F7D3E322A54AA2003A7BC0 /* ReachFiveApi.swift */,
 				2AB29A0A2C1225F500D0C5C8 /* ReachFiveApplication.swift */,
@@ -250,6 +261,7 @@
 				2AE53307299462DD00EF97E0 /* ReachFiveWebviewLogin.swift */,
 				34E18B8D22A6C13100952EBD /* models */,
 				34689A9A22CE3E34002970F9 /* utils */,
+				CA61910000000000000000A1 /* web */,
 			);
 			path = Classes;
 			sourceTree = "<group>";
@@ -271,10 +283,21 @@
 			path = utils;
 			sourceTree = "<group>";
 		};
+		CA61910000000000000000A1 /* web */ = {
+			isa = PBXGroup;
+			children = (
+				CA61910000000000000000B1 /* URL+WebAuth.swift */,
+				CA61910000000000000000C1 /* WebAuthentication.swift */,
+				CA61910000000000000000D1 /* WebSessionMode.swift */,
+			);
+			path = web;
+			sourceTree = "<group>";
+		};
 		34689A9F22CE5CF9002970F9 /* requests */ = {
 			isa = PBXGroup;
 			children = (
 				3404A40B22CBA6DD002FFEDB /* AuthCodeRequest.swift */,
+				CA61910000000000000000F1 /* TokenType.swift */,
 				2AE533142994632F00EF97E0 /* LoginCallback.swift */,
 				34689A9822CDFC24002970F9 /* LoginProviderRequest.swift */,
 				34E18B8E22A6C32500952EBD /* LoginRequest.swift */,
@@ -622,6 +645,11 @@
 				8496EB2B25DEAFCF005098DD /* WebAuthnLoginRequest.swift in Sources */,
 				2AE5331D2994638000EF97E0 /* NativeLoginRequest.swift in Sources */,
 				2A624FDA2B2BDBC400BF33A7 /* DefaultProvider.swift in Sources */,
+				CA61910000000000000000E2 /* Presentation.swift in Sources */,
+				CA61910000000000000000F2 /* TokenType.swift in Sources */,
+				CA61910000000000000000B2 /* URL+WebAuth.swift in Sources */,
+				CA61910000000000000000C2 /* WebAuthentication.swift in Sources */,
+				CA61910000000000000000D2 /* WebSessionMode.swift in Sources */,
 				8496EB3C25DEB141005098DD /* R5PublicKeyCredentialParameter.swift in Sources */,
 				2AE533222994638100EF97E0 /* PasskeySignupRequest.swift in Sources */,
 				2AE5331F2994638100EF97E0 /* SignupOptions.swift in Sources */,

--- a/Tests/Reach5Tests/Web/WebAuthenticationSessionTests.swift
+++ b/Tests/Reach5Tests/Web/WebAuthenticationSessionTests.swift
@@ -1,0 +1,25 @@
+import XCTest
+@testable import Reach5
+
+/// `WebAuthenticationSession`'s lifecycle, for the little of it that is reachable without presenting a sheet.
+@MainActor
+final class WebAuthenticationSessionTests: XCTestCase {
+
+    private func makeSession() -> WebAuthenticationSession {
+        WebAuthenticationSession(baseScheme: "reachfive-clientId",
+                                 sdkRedirectUri: URL(string: "reachfive-clientId://callback")!)
+    }
+
+    /// Outside a login the out-of-band channel is not armed, even for a URL perfectly shaped for this SDK:
+    /// what decides is `expectedCallback` (nil at rest), not the shape of the URL. The host app must get its
+    /// link back (`false`), not see it swallowed by the SDK.
+    func testTryCompleteMatchesNothingOutsideALogin() {
+        let session = makeSession()
+        for url in ["reachfive-clientId://callback?code=abc",
+                    "reachfive-clientId://callback?code=abc&state=x",
+                    "reachfive-clientId://callback/?code=abc",
+                    "reachfive-clientId://callback?error=access_denied"] {
+            XCTAssertFalse(session.tryComplete(externalCallbackURL: URL(string: url)!), url)
+        }
+    }
+}

--- a/Tests/Reach5Tests/Web/WebAuthenticationSessionTests.swift
+++ b/Tests/Reach5Tests/Web/WebAuthenticationSessionTests.swift
@@ -10,7 +10,7 @@ final class WebAuthenticationSessionTests: XCTestCase {
                                  sdkRedirectUri: URL(string: "reachfive-clientId://callback")!)
     }
 
-    /// Outside a login the out-of-band channel is not armed, even for a URL perfectly shaped for this SDK:
+    /// Outside a login the out-of-band channel is not prepared, even for a URL perfectly shaped for this SDK:
     /// what decides is `expectedCallback` (nil at rest), not the shape of the URL. The host app must get its
     /// link back (`false`), not see it swallowed by the SDK.
     func testTryCompleteMatchesNothingOutsideALogin() {
@@ -57,5 +57,36 @@ final class WebAuthenticationSessionTests: XCTestCase {
                 }
             }
         }
+    }
+
+    /// A caller whose task is already cancelled is refused before anything is presented, and with a
+    /// `ReachFiveError`: the public entry points document reporting nothing else, so a bare
+    /// `CancellationError` would escape every `catch let error as ReachFiveError` an integrator writes.
+    func testAnAlreadyCancelledCallerIsRefusedWithAuthCanceledAndHoldsNoSlot() async throws {
+        let session = makeSession()
+        let task = Task { @MainActor in
+            _ = try await session.start(url: URL(string: "https://example.reach5.net/oauth/authorize")!,
+                                        mode: .customScheme,
+                                        presentationContextProvider: DummyContextProvider())
+        }
+        // The task is isolated on the main actor, which runs this test: its body has not started yet.
+        task.cancel()
+
+        do {
+            _ = try await task.value
+            XCTFail("start should have thrown for an already-cancelled task")
+        } catch let error as ReachFiveError {
+            switch error {
+            case .AuthCanceled:
+                break
+            default:
+                XCTFail("the cancelled caller failed with an unexpected error: \(error)")
+            }
+        } catch {
+            XCTFail("the cancelled caller failed with \(type(of: error)), not a ReachFiveError: \(error)")
+        }
+
+        // Nothing was claimed, so nothing was presented: the next login is free to go through.
+        XCTAssertFalse(session.isLoginInProgress)
     }
 }

--- a/Tests/Reach5Tests/Web/WebAuthenticationSessionTests.swift
+++ b/Tests/Reach5Tests/Web/WebAuthenticationSessionTests.swift
@@ -22,4 +22,40 @@ final class WebAuthenticationSessionTests: XCTestCase {
             XCTAssertFalse(session.tryComplete(externalCallbackURL: URL(string: url)!), url)
         }
     }
+
+    /// A login refused for an unusable universal-link callback must not hold the slot. This is the one
+    /// failure path reachable without presenting a sheet, so it is the one that can guard the rule the slot
+    /// depends on: nothing claims it before the call is certain to go through.
+    ///
+    /// The tell is *which* error comes back the second time. `TechnicalError` means the call reached the
+    /// callback check again, so the slot was free; `AuthCanceled` would mean the first call kept it and the
+    /// SDK is now refusing every web login for the rest of the process.
+    func testAnUnusableUniversalLinkCallbackDoesNotHoldTheSlot() async throws {
+        guard #available(iOS 17.4, *) else {
+            throw XCTSkip("`.universalLink` requires iOS 17.4")
+        }
+        let session = makeSession()
+        // A callback with no host: the session cannot be built, and `start` gives up before presenting.
+        let mode = WebSessionMode.universalLink(URL(string: "https:///universal_link")!)
+        let authorizeURL = URL(string: "https://example.reach5.net/oauth/authorize")!
+        let contextProvider = DummyContextProvider()
+
+        for attempt in 1...2 {
+            do {
+                _ = try await session.start(url: authorizeURL,
+                                            mode: mode,
+                                            presentationContextProvider: contextProvider)
+                XCTFail("start should have thrown on attempt \(attempt)")
+            } catch let error as ReachFiveError {
+                switch error {
+                case .TechnicalError:
+                    break
+                case .AuthCanceled:
+                    XCTFail("attempt \(attempt) was dropped as if a login were already in progress: the slot leaked")
+                default:
+                    XCTFail("attempt \(attempt) failed with an unexpected error: \(error)")
+                }
+            }
+        }
+    }
 }

--- a/Tests/Reach5Tests/Web/WebviewLoginRequestTests.swift
+++ b/Tests/Reach5Tests/Web/WebviewLoginRequestTests.swift
@@ -23,35 +23,22 @@ final class WebviewLoginRequestTests: XCTestCase {
         XCTAssertEqual(WebviewLoginRequest(nonce: "my-nonce", presentationContextProvider: provider).nonce, "my-nonce")
     }
 
-    func testWebSessionModeDefaultsToSdkScheme() {
+    func testWebSessionModeDefaultsToCustomScheme() {
         let mode = WebviewLoginRequest(presentationContextProvider: provider).webSessionMode
-        guard case .customScheme = mode.callback, mode.channel == .inBand else {
-            return XCTFail("webSessionMode should default to .sdkScheme (customScheme + inBand)")
+        guard case .customScheme = mode.callback else {
+            return XCTFail("webSessionMode should default to .customScheme")
         }
+        XCTAssertNil(mode.redirectUri, "the custom scheme carries no redirect_uri of its own; the SdkConfig's applies")
     }
 
-    func testExternalAppSchemeModeIsPreserved() {
-        let mode = WebviewLoginRequest(presentationContextProvider: provider, webSessionMode: .externalAppScheme).webSessionMode
-        guard case .customScheme = mode.callback, mode.channel == .outOfBand else {
-            return XCTFail("webSessionMode should be external-app custom scheme")
-        }
-    }
-
-    func testExternalAppUniversalLinkModeIsPreserved() {
-        let mode = WebviewLoginRequest(presentationContextProvider: provider, webSessionMode: .externalAppUniversalLink(URL(string: "https://h/cb")!)).webSessionMode
-        guard case .universalLink(let link) = mode.callback, mode.channel == .outOfBand else {
-            return XCTFail("webSessionMode should be external-app universal link")
+    func testUniversalLinkModeIsPreserved() throws {
+        guard #available(iOS 17.4, *) else { throw XCTSkip("Universal link callback requires iOS 17.4+") }
+        let mode = WebviewLoginRequest(presentationContextProvider: provider, webSessionMode: .universalLink(URL(string: "https://h/cb")!)).webSessionMode
+        guard case .universalLink(let link) = mode.callback else {
+            return XCTFail("webSessionMode should be .universalLink")
         }
         XCTAssertEqual(link.absoluteString, "https://h/cb")
-    }
-
-    func testInSheetUniversalLinkModeIsPreserved() throws {
-        guard #available(iOS 17.4, *) else { throw XCTSkip("In-sheet universal link requires iOS 17.4+") }
-        let mode = WebviewLoginRequest(presentationContextProvider: provider, webSessionMode: .inSheetUniversalLink(URL(string: "https://h/cb")!)).webSessionMode
-        guard case .universalLink(let link) = mode.callback, mode.channel == .inBand else {
-            return XCTFail("webSessionMode should be in-sheet universal link")
-        }
-        XCTAssertEqual(link.absoluteString, "https://h/cb")
+        XCTAssertEqual(mode.redirectUri?.absoluteString, "https://h/cb")
     }
 
     func testDefaultLoginUrlFragmentIsNil() {


### PR DESCRIPTION
[Intégration de b.connect sur iOS](https://reach5.atlassian.net/browse/CA-6191)

Explication plus détaillée + quiz : [Artéfact Claude](https://claude.ai/code/artifact/6202f633-6e17-4f4c-b8b6-95e8bd81b29d)

Le porteur de session web (`WebAuthenticationSession`) passe de « dernier arrivé gagne » à « un seul login à la fois, le second est refusé ».
Un second appel à `webviewLogin`, à un `login` de provider web ou à `logout(webSessionLogout:)` termine donc en `AuthCanceled` sans toucher au login en cours ; la sortie de secours reste l'annulation du `Task` appelant.
Cf. le [fichier](https://github.com/ReachFive/reachfive-ios/pull/137/changes#diff-20845af48bcf218df15d5b4013f7b96da0c38f1587f2e17a4ab26034ba325125R15) pour une discussion de la raison de ce changement.

`WebSessionMode` perd son axe canal (in-band / hors-bande) : b.connect ne choisit son canal qu'après `/authorize`, feuille déjà ouverte, donc ni l'appelant ni le SDK ne peuvent choisir le canal de retour à l'avance. 
`.customScheme`  prépare désormais systématiquement les deux canaux et `.universalLink(_:)` reste réservé à l'interception dans la feuille.

`application(_:open:options:)` rejoint `application(_:continue:restorationHandler:)` : elle renvoie désormais `false` quand rien n'a consommé l'URL.
`interceptUrl` (publique, avec son repli passwordless historique) et le nouveau `routeUrl` (interne, sans ce repli) se partagent le même matcher normalisé (`URL.matchesEndpoint(of:)`), pour que les deux points d'entrée ne puissent jamais être en désaccord.

La vérification d'occupation de `webviewLogin` est remontée avant l'écriture du PKCE : un appel qui va être refusé ne doit pas écraser, dans le créneau partagé avec le passwordless, le PKCE que le login en cours attend encore.

## À regarder de plus près

- **`Sources/Core/Classes/web/WebAuthentication.swift`** — le porteur. `State`/`Login` remplacent quatre variables dispersées par une seule valeur ; `complete(id:)` est l'unique point de résolution.
- **`Sources/Core/Classes/ReachFiveWebviewLogin.swift`** — la vérification avant le PKCE, et le FIXME sur le créneau de storage partagé avec le passwordless.