### PR TITLE
Les évènements de cycle de vie ne sont plus perdus quand ils arrivent avant les providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 - `application(_:continue:restorationHandler:)` now returns `false` when neither ReachFive's web-auth session nor any registered provider consumed the activity, instead of always returning `true`. If your app also routes universal links itself, only do so when this call returns `false`.
 
+- `applicationDidBecomeActive(_:)` and `application(_:didFinishLaunchingWithOptions:)` are `@MainActor`, like the two other app-lifecycle hooks. Calling them from your `UIApplicationDelegate`, which is main-actor isolated already, is unaffected.
+
 - ProviderCreator : the factory receives the ``ReachFive`` instance instead of sub-components, so that the creator can
   reuse high-level helpers such as `buildAuthorizeURL`,`authWithCode` or `webviewLogin`.
 
@@ -30,6 +32,9 @@
 - New `WebProvider` to register a web provider (e.g. B.connect) with a `variant` and a completion `mode`. See the [ProviderCreator](https://developer.reachfive.com/sdk-ios/providerCreator.html) and [custom provider guide](https://developer.reachfive.com/sdk-ios/guides/custom-provider.html) documentation.
 - `webviewLogin` accepts a `webSessionMode` parameter picking how the `ASWebAuthenticationSession` returns: `.sdkScheme`, `.externalAppScheme`, `.externalAppUniversalLink(_:)` or `.inSheetUniversalLink(_:)` (iOS 17.4+). `WebProvider` takes the same choices.
 - `webviewLogin` accepts a new `loginUrlFragment` parameter to pass key/value pairs in the fragment of the `/oauth/authorize` URL, so a client's Login URL can customize itself (logo, colors) per calling channel in an orchestrated flow.
+
+### Bug fixes
+- The app-lifecycle hooks no longer drop the events that reach the SDK before its initialization has created the providers. On a cold start that window covers the launch itself and everything in the first ~200 ms: a universal link or a custom scheme opening the app was silently lost for the providers, and Facebook never got its `AppEvents.shared.activateApp()`. Such an event is now forwarded as soon as the providers exist, in the order UIKit sent it. The hooks stay synchronous and never block the main thread.
 
 ## v10.0.1
 

--- a/Sources/Core/Classes/ReachFive.swift
+++ b/Sources/Core/Classes/ReachFive.swift
@@ -28,6 +28,10 @@ public class ReachFive: NSObject {
     /// instead of each fetching the configuration and creating its own set of providers.
     /// Only ever read and written on the main actor, from `initialize()`.
     var initialization: Task<[Provider], Error>? = nil
+    /// The last app-lifecycle event whose delivery to the providers was deferred, waiting for them to
+    /// exist. Each new deferred event chains onto it, so the providers see the events in the order
+    /// UIKit sent them. Only ever read and written on the main actor, from `withProviders(_:)`.
+    var lifecycleDelivery: Task<Void, Never>? = nil
     public let sdkConfig: SdkConfig
     let providersCreators: Array<ProviderCreator>
     public let reachFiveApi: ReachFiveApi

--- a/Sources/Core/Classes/ReachFiveApplication.swift
+++ b/Sources/Core/Classes/ReachFiveApplication.swift
@@ -4,64 +4,106 @@ import UIKit
 public extension ReachFive {
     @MainActor
     func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any]) -> Bool {
-        // Canal hors-bande « custom scheme » : une app externe rouvre l'app hôte par le scheme du SDK.
-        // On teste la session web-auth d'abord — son matching est exact (scheme + host + path + code/error
-        // de la redirect_uri attendue, et n'est armé que pendant un login hors-bande en cours) — sinon
-        // `interceptUrl` avalerait le lien comme un callback passwordless.
+        // Out-of-band "custom scheme" channel: an external app reopens the host app through the SDK's
+        // scheme. Try the web-auth session first — its matching is exact (scheme + host + path + code/error
+        // of the expected redirect_uri, and it is only armed while an out-of-band login is in flight) —
+        // otherwise `interceptUrl` would swallow the link as a passwordless callback.
         if webAuthSession.tryComplete(externalCallbackURL: url) {
             return true
         }
 
         interceptUrl(url)
-        for provider in providers {
-            let _ = provider.application(app, open: url, options: options)
+        withProviders { providers in
+            for provider in providers {
+                let _ = provider.application(app, open: url, options: options)
+            }
         }
         return true
     }
 
+    @MainActor
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        // On the main actor: the hook we forward is a UIKit app-lifecycle callback, and the native
-        // SDKs behind the providers expect it on the main thread — as UIKit called us here.
-        Task { @MainActor in
-            do {
-                for provider in try await initialize() {
-                    let _ = provider.application(application, didFinishLaunchingWithOptions: launchOptions)
-                }
-            } catch {
-                //TODO: faire une passe de cohérence sur l'utilisation de #if DEBUG et du Logger
-                #if DEBUG
-                print(Logger.shared.message(for: error))
-                #endif
+        withProviders { providers in
+            for provider in providers {
+                let _ = provider.application(application, didFinishLaunchingWithOptions: launchOptions)
             }
         }
 
         return true
     }
 
+    @MainActor
     func applicationDidBecomeActive(_ application: UIApplication) {
-        for provider in providers {
-            provider.applicationDidBecomeActive(application)
+        withProviders { providers in
+            for provider in providers {
+                provider.applicationDidBecomeActive(application)
+            }
         }
     }
 
     @MainActor
     func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
-        // D'abord la session web-auth : son matching est exact (host + path + code/error du
-        // redirect_uri attendu), aucun risque d'avaler un lien qui ne lui est pas destiné — alors
-        // qu'un provider custom peut consommer l'activité plus largement et lui masquer son callback.
+        // The web-auth session first: its matching is exact (host + path + code/error of the expected
+        // redirect_uri), so there is no risk of it swallowing a link meant for someone else — whereas a
+        // custom provider may consume the activity more broadly and hide its callback from the session.
         if userActivity.activityType == NSUserActivityTypeBrowsingWeb,
            let url = userActivity.webpageURL,
            webAuthSession.tryComplete(externalCallbackURL: url) {
             return true
         }
 
-        // …puis les providers. Ne renvoie true QUE si l'un d'eux a consommé l'activité (sinon false,
-        // pour que l'app hôte — qui nous forwarde tous ses liens — route elle-même les liens que
-        // ReachFive ne gère pas).
+        // …then the providers. Returns true ONLY if one of them consumed the activity (false otherwise,
+        // so that the host app — which forwards us every link it gets — routes the links ReachFive does
+        // not handle itself). When the delivery is deferred, `handled` is still false when we return:
+        // we cannot claim to have consumed an activity that no provider has seen yet.
         var handled = false
-        for provider in providers {
-            handled = provider.application(application, continue: userActivity, restorationHandler: restorationHandler) || handled
+        withProviders { providers in
+            for provider in providers {
+                handled = provider.application(application, continue: userActivity, restorationHandler: restorationHandler) || handled
+            }
         }
         return handled
+    }
+}
+
+private extension ReachFive {
+    /// Runs `body` over the providers, waiting for them if they do not exist yet.
+    ///
+    /// The app-lifecycle hooks fire while the app is launching, long before the two round trips of
+    /// `initialize()` have created the providers. On a cold start the initialization has not even
+    /// *started* when UIKit calls `applicationDidBecomeActive`: the hooks run on the main thread, and
+    /// the initialization only gets the main actor once UIKit is done launching the app. Iterating
+    /// `providers` right away would walk an empty array and lose the event for good — a missed
+    /// `AppEvents.shared.activateApp()` for the Facebook provider, or worse, a universal link or a
+    /// custom scheme silently dropped.
+    ///
+    /// So `body` runs right away when the providers are there, and otherwise as soon as the
+    /// initialization has created them — `initialize()` joins the one already in flight rather than
+    /// starting a second one. Either way the hook returns immediately: the main thread is never
+    /// blocked, and the hooks stay synchronous. Deferred events keep UIKit's order, so a provider is
+    /// never handed a link before its own `application(_:didFinishLaunchingWithOptions:)`.
+    ///
+    /// An event that arrives while the SDK cannot be initialized (offline, for instance) is dropped
+    /// rather than kept for later: replaying an activation or a link long after the fact would be
+    /// worse than missing it.
+    @MainActor
+    func withProviders(_ body: @escaping ([Provider]) -> Void) {
+        guard case .Initialized = state else {
+            let previousDelivery = lifecycleDelivery
+            lifecycleDelivery = Task { @MainActor in
+                // Deferred events are delivered in the order UIKit sent them: each one waits for the
+                // previous one. Left to their own tasks they would resume in any order.
+                await previousDelivery?.value
+                do {
+                    let providers = try await initialize()
+                    body(providers)
+                } catch {
+                    Logger.shared.log("The SDK could not be initialized, so an app lifecycle event was not forwarded to the providers: \(Logger.shared.message(for: error))")
+                }
+            }
+            return
+        }
+
+        body(providers)
     }
 }


### PR DESCRIPTION
Empilée sur `feature/initialize-once`, dont la déduplication de `initialize()` est nécessaire ici.

## Mesure

Lancement à froid du Sandbox, horodatage relatif au début de `didFinishLaunchingWithOptions` :

| | init. démarre | providers créés | `applicationDidBecomeActive` | providers notifiés ? |
|---|---|---|---|---|
| avant `initialize-once`, backend local | +2 ms (fil de fond) | +64 ms | +109 ms | oui, de justesse |
| avant `initialize-once`, backend distant | +2 ms (fil de fond) | +216 ms | +100 ms | **non** |
| avec `initialize-once` | +108 ms (acteur principal) | +193 ms | +107 ms | **non, systématiquement** |

L'isolation sur l'acteur principal transforme la course en ordre garanti : la tâche d'initialisation n'obtient l'acteur qu'une fois le lancement d'UIKit terminé, donc après `applicationDidBecomeActive`. Une URL remise pendant cette fenêtre (mesurée à +0, +50 et +150 ms) tombe elle aussi sur une boucle vide.

## Comment

Les quatre crochets passent par `withProviders` : exécution immédiate si les providers existent, sinon dès que l'initialisation en cours les a créés. Les crochets restent synchrones et rendent la main tout de suite, rien ne bloque le thread principal.

Les remises différées s'enchaînent (`ReachFive.lifecycleDelivery`) pour conserver l'ordre d'UIKit. Sans ce chaînage, les tâches reprennent dans le désordre — constaté à la mesure — et un provider peut recevoir un lien avant son propre `application(_:didFinishLaunchingWithOptions:)`.

## À regarder de près

- `ReachFiveApplication.swift` : `withProviders` et son commentaire de doc, qui porte le raisonnement.
- `application(_:continue:restorationHandler:)` : quand la remise est différée, `handled` vaut encore `false` au `return`. On ne peut pas affirmer avoir consommé une activité qu'aucun provider n'a vue ; l'app hôte garde donc la main, et les providers la reçoivent quand même ensuite.
- `applicationDidBecomeActive(_:)` et `application(_:didFinishLaunchingWithOptions:)` deviennent `@MainActor`, comme les deux autres crochets. Sans effet depuis un `UIApplicationDelegate`, déjà isolé sur l'acteur principal ; noté au CHANGELOG.
- Le `//TODO:` sur la cohérence `#if DEBUG` / `Logger` disparaît avec le code qu'il annotait : l'échec d'initialisation passe désormais par `Logger` comme le reste du SDK.
- Les 61 exemples de doc compilent toujours (`docs/verification/check.sh`), les 59 tests passent.