### PR TITLE
[CA-6191] Doc : b.connect revient par le navigateur, pas par un lien universel

### DIFF
--- a/docs/modules/ROOT/examples/providerCreator.swift
+++ b/docs/modules/ROOT/examples/providerCreator.swift
@@ -5,6 +5,6 @@ static let reachfive: ReachFive = ReachFive(
         FacebookProvider(),
         AppleProvider(variant: "ios_native"),
         WeChat(),
-        WebProvider(name: .bconnect, variant: "natif", mode: .externalApp)
+        WebProvider(name: .bconnect, variant: "natif", mode: .customScheme)
     ]
 )

--- a/docs/modules/ROOT/pages/application/applicationContinueUserActivity.adoc
+++ b/docs/modules/ROOT/pages/application/applicationContinueUserActivity.adoc
@@ -10,7 +10,12 @@ AppDelegate.reachfive().application(<<application, application>>, continue: <<ap
 
 Allows {company} to handle user activity continuation such as handoffs, and more importantly, universal links.
 
-This method is required by xref:index.adoc#wechat-connect[WeChat] and by any *universal-link provider* (such as B.connect): when an external app reopens your app via a universal link to finish a login, the SDK completes the in-flight web authentication session out-of-band through this hook.
+This method is required by xref:index.adoc#wechat-connect[WeChat] and by providers whose login finishes on a universal link.
+
+[NOTE]
+====
+This is *not* how a login that leaves your app comes back. When a provider hands the user off to a third-party app (B.connect sending them to their bank app), that app reopens the *default browser*, not your app — so the callback arrives through xref:applicationOpenUrl.adoc[`application(_:open:)`] as a custom scheme. Forward that method for those providers.
+====
 
 Call this method in response to the equivalent UIKit method link:https://developer.apple.com/documentation/uikit/uiapplicationdelegate/[`application(_:continue:restorationHandler:)`^]. If your app uses scenes, forward link:https://developer.apple.com/documentation/uikit/uiscenedelegate/[`scene(_:continue:)`^] here as well.
 
@@ -18,9 +23,7 @@ Call this method in response to the equivalent UIKit method link:https://develop
 ====
 The method returns a `Bool` that tells you whether {company} actually consumed the activity. It returns `true` only when a {company} login was waiting for that universal link; otherwise it returns `false` so your app can route the link itself. Do not assume {company} handles every universal link you forward — honour the returned value.
 
-Universal-link delivery requires an `applinks:<host>` Associated Domain (see xref:index.adoc#configure-the-ios-sdk[Configure the SDK]).
-
-The in-flight login only lives in memory. If iOS terminates your app while the user is in the external app, the login is lost: when the universal link relaunches your app, this method returns `false` and the user must start the login again.
+Universal-link delivery requires an `applinks:<host>` Associated Domain (see xref:index.adoc#configure-the-ios-sdk[Configure the SDK]). A `.universalLink(_:)` web session additionally needs `webcredentials:<host>`, because the sheet intercepts the callback itself via `ASWebAuthenticationSession`'s `.https` callback (iOS 17.4+).
 ====
 
 == Examples

--- a/docs/modules/ROOT/pages/application/applicationOpenUrl.adoc
+++ b/docs/modules/ROOT/pages/application/applicationOpenUrl.adoc
@@ -12,7 +12,14 @@ Allows {company} to handle URLs in the following format:
 
 * `reachfive-clientId://`
 
-This includes the *custom-scheme out-of-band* login flow: when an external app finishes a login by reopening your app through the SDK's custom scheme, the SDK completes the in-flight web authentication session here. This is the custom-scheme counterpart of the universal-link flow handled by xref:application/applicationContinueUserActivity.adoc[`application(_:continue:)`].
+This is where a web login that *left your app* comes back. Some providers hand the user off to a third-party app mid-login — B.connect sends them to their bank app for strong authentication. That app does **not** reopen your app: it opens the user's *default browser*, and it is the browser that finally follows the redirect to `reachfive-clientId://callback` and hands it to this method (the user sees the system "Open in app" prompt). The SDK completes the in-flight web authentication session here and closes the `ASWebAuthenticationSession` sheet, which stayed open behind the detour.
+
+[NOTE]
+====
+Because the provider only decides mid-flight whether to make that detour, the SDK always arms both return paths for a `.customScheme` login: the sheet intercepts the callback when the flow never leaves it, and this method resolves it when the browser delivers it. You do not choose, and there is nothing to configure beyond forwarding this method.
+
+The in-flight login only lives in memory. If iOS terminates your app during the detour — which now spans an external app *and* the browser — the login is lost: the SDK finds nothing to complete, returns `false` so your app can route the URL itself, and the user must start over.
+====
 
 Additionally, the method allows configured providers to handle their own native links.
 

--- a/docs/modules/ROOT/pages/guides/custom-provider.adoc
+++ b/docs/modules/ROOT/pages/guides/custom-provider.adoc
@@ -10,7 +10,7 @@ Our built-in xref:providerCreator.adoc[provider creators] cover the most common 
 
 This custom provider guide instructs you how to implement a provider that none of the built-ins model such as a social/SSO provider with its own native SDK, or a login flow that none of the built-ins model.
 
-If your provider has no native SDK component and only needs to choose *how* its `ASWebAuthenticationSession` returns to the app (custom scheme, universal link, out-of-band), you don't need a custom provider, instead configure a xref:providerCreator.adoc[`WebProvider`].
+If your provider has no native SDK component and only needs to choose *how* its `ASWebAuthenticationSession` returns to the app (custom scheme or universal link), you don't need a custom provider, instead configure a xref:providerCreator.adoc[`WebProvider`]. That includes providers that detour through a third-party app mid-login, such as B.connect.
 
 == The two protocols
 
@@ -91,7 +91,7 @@ An example of this is resuming a paused native SDK session.
 |xref:application/applicationContinueUserActivity.adoc[application(_:continue:restorationHandler:)]
 |Your provider's callback arrives as a *universal link* (`NSUserActivityTypeBrowsingWeb`).
 
-An example of this is an out-of-band flow like `WebProvider` `.externalApp` mode. 
+An example of this is a flow whose `redirect_uri` is an https link your app is associated with, like `WebProvider` `.universalLink` mode.
 
 Return `true` only if you actually consumed the activity.
 {company} relies on that return value (see xref:application/applicationContinueUserActivity.adoc[] for details).

--- a/docs/modules/ROOT/pages/loadLoginWebview.adoc
+++ b/docs/modules/ROOT/pages/loadLoginWebview.adoc
@@ -22,7 +22,7 @@ include::docs:ROOT:partial$general/snippets/r_orchestrated-flows-min-version.ado
 
 CAUTION: We recommend using the standard native login or standard webview login for iOS. Proceed with caution while using this particular method for user authentication.
 
-CAUTION: *Universal-link* providers are not supported by this method: their out-of-band callback is delivered through `application(_:continue:)` and completes the session held by `ReachFive` itself, not this embedded webview. Use xref:webviewLogin.adoc[] (with a `WebProvider`, see xref:providerCreator.adoc[]) for them instead.
+CAUTION: `WebProvider` logins are not supported by this method. Their callback completes the `ASWebAuthenticationSession` held by `ReachFive` itself — whether it arrives in the sheet, through `application(_:open:)` after a detour via a third-party app, or through `application(_:continue:)` as a universal link — never in this embedded webview. Use xref:webviewLogin.adoc[] (with a `WebProvider`, see xref:providerCreator.adoc[]) for them instead.
 
 == Examples
 

--- a/docs/modules/ROOT/pages/providerCreator.adoc
+++ b/docs/modules/ROOT/pages/providerCreator.adoc
@@ -31,35 +31,38 @@ include::partial$config/params.adoc[tags="GoogleProvider,FacebookProvider,AppleP
 
 |===
 
-== Universal-link web providers
+== Web providers that leave the app
 
-Some web providers finish login on an *https* universal link instead of the custom scheme.
-Use the checklist for your <<WebProvider,`WebProvider`>> `mode`; you do *not* need xref:guides/custom-provider.adoc[a custom provider] unless none of the built-in options fit.
+Some providers hand the user off to a third-party app mid-login — B.connect sends them to their bank app for strong authentication.
 
-[tabs]
-====
-`.externalApp`::
-+
---
-Login may hand off to an external app (e.g. a banking app) that reopens yours via a universal link.
+**This needs no special mode.** The bank app does not reopen your app: it opens the user's *default browser*, which follows the rest of the OAuth flow and finally redirects to `reachfive-clientId://callback`, delivered to xref:application/applicationOpenUrl.adoc[`application(_:open:)`]. The default `.customScheme` already covers it, because the SDK arms both return paths for every login.
+
+It has to work that way: the provider decides whether to make the detour only *after* the authentication sheet is open. The very same `login()` call may finish without ever leaving the sheet (B.connect's `passive` case, when the user already has a valid session) or take the full detour (`active`). Neither you nor the SDK can know in advance.
 
 [%interactive]
 * [ ] Configure the provider and variant on your {cc}.
-* [ ] Whitelist the provider's `universalLink` URL in *Allowed Callback URLs* (see xref:docs:ROOT:clients.adoc[Clients]).
-* [ ] Register a <<WebProvider,`WebProvider`>> with `mode: .externalApp` in `ReachFive(providersCreators:)`.
+* [ ] Register a <<WebProvider,`WebProvider`>> with `mode: .customScheme` (or omit `mode`) in `ReachFive(providersCreators:)`.
 * [ ] Initialize the SDK so provider configurations are fetched and `getProvider` can resolve your provider (see xref:application/applicationDidFinishLaunchingWithOptions.adoc[`applicationDidFinishLaunchingWithOptions(_:)`]).
-* [ ] Add `applinks:$\{host\}` to Associated Domains and the matching `applinks` section in `apple-app-site-association` (see xref:index.adoc#associated-domains-universal-link-providers[`apple-app-site-association`]).
-* [ ] Forward `application(_:continue:restorationHandler:)` to {company} and honour the returned `Bool` (see xref:application/applicationContinueUserActivity.adoc[`application(_:continue:restorationHandler:)`]).
+* [ ] Whitelist `reachfive-$\{clientId\}://callback` in *Allowed Callback URLs* (see xref:docs:ROOT:clients.adoc[Clients]).
+* [ ] Forward `application(_:open:options:)` to {company} (see xref:application/applicationOpenUrl.adoc[]).
 * [ ] Call xref:getProvider.adoc[`getProvider(name:).login(...)`] with a `Presentation` built from a `UIViewController` attached to a window; see xref:getProvider.adoc[] for details.
 
-Do *not* use xref:loadLoginWebview.adoc[`loadLoginWebview`]: the callback is delivered through xref:application/applicationContinueUserActivity.adoc[`application(_:continue:)`], not an embedded webview.
+No Associated Domain is required — the return is a custom scheme, not a universal link.
 
-If iOS terminates your app while the user is in the external app, the in-flight login is lost and must be restarted (see xref:application/applicationContinueUserActivity.adoc[`application(_:continue:restorationHandler:)`]).
---
-`.universalLink` (iOS 17.4+)::
-+
---
-This is the same flow as the default custom-scheme login, but the OAuth `redirect_uri` is the provider's `https://` universal link and the authentication sheet intercepts it *in-band* meaning no external-app handoff.
+Do *not* use xref:loadLoginWebview.adoc[`loadLoginWebview`]: the callback comes back through the app delegate, not an embedded webview.
+
+If iOS terminates your app during the detour — which spans a third-party app *and* the browser — the in-flight login is lost and must be restarted.
+
+== Universal-link web providers
+
+A provider can instead finish login on an *https* universal link intercepted inside the authentication sheet.
+You do *not* need xref:guides/custom-provider.adoc[a custom provider] for this.
+
+=== `.universalLink` (iOS 17.4+)
+
+This is the same flow as the default custom-scheme login, but the OAuth `redirect_uri` is the provider's `https://` universal link, intercepted by the authentication sheet itself — the login never leaves the app.
+
+There is no fallback below iOS 17.4: the final redirect happens *inside* the sheet, and iOS does not follow a universal link on a navigation the user didn't initiate. Use `.customScheme` on older versions.
 
 [%interactive]
 * [ ] Configure the provider and variant on your {cc}.
@@ -72,7 +75,5 @@ This is the same flow as the default custom-scheme login, but the OAuth `redirec
 No `application(_:continue:)` wiring is required for login completion; the `ASWebAuthenticationSession` completes inside the sheet.
 
 Do *not* use xref:loadLoginWebview.adoc[`loadLoginWebview`]: use `WebProvider` or xref:webviewLogin.adoc[`webviewLogin`] with a secure session instead of an embedded webview.
---
-====
 
 TIP: None of these fit your case? See xref:guides/custom-provider.adoc[] to implement your own.

--- a/docs/modules/ROOT/pages/webviewLogin.adoc
+++ b/docs/modules/ROOT/pages/webviewLogin.adoc
@@ -18,7 +18,7 @@ AppDelegate.reachfive().{docname}(WebviewLoginRequest(
 <1> Scope isn't explicitly required.
 If not provided here, it defaults to the scopes set up in the client configuration which is picked up when you initialize the iOS SDK.
 <2> Available starting with version 7.1.3
-<3> Optional; defaults to `.sdkScheme`. Use `.externalApp`/`.universalLink` for providers that finish their login on a universal link — see xref:providerCreator.adoc[WebProvider].
+<3> Optional; defaults to `.customScheme`, which also covers providers that detour through a third-party app. Use `.universalLink` only when the login must come back on a universal link intercepted in the sheet — see xref:providerCreator.adoc[WebProvider].
 <4> Optional; requires xref:docs:ROOT:orchestration-token.adoc[request orchestration tokens] to be enabled for the client.
 
 == Description

--- a/docs/modules/ROOT/pages/webviewLogin.adoc
+++ b/docs/modules/ROOT/pages/webviewLogin.adoc
@@ -39,6 +39,14 @@ When logging in with secure webview, a dialog pops up where you must select *Con
 
 image::sdk-ios:ROOT:secure-login-dialog.png[width=500px,role=zoom]
 
+=== One web login at a time
+
+`{docname}`, a `login` on a xref:providerCreator.adoc[web provider] and xref:logout.adoc[`logout(webSessionLogout:)`] share a single web session. A call made while another one is still in progress ends with `AuthCanceled` and leaves the login under way untouched.
+
+There is nothing to add on your side: a double tap on a login control is absorbed by the SDK, and `AuthCanceled` means "nothing happened" (see <<ReachFiveError>>). Refusing the second call is deliberate — replacing the login in progress means dismissing its sheet and presenting another one behind it, which iOS fails asynchronously, losing *both* logins.
+
+To end a web login early, cancel the `Task` that started it: the sheet closes and the call returns `AuthCanceled`. A SwiftUI `.task` or any `Task` you cancel when tearing down your screen does this for you.
+
 == Usage
 
 Build the request with `presenting: Presentation(from: self)` from the initiating link:https://developer.apple.com/documentation/uikit/uiviewcontroller[UIViewController^]: the SDK derives the presentation context itself, as it does for xref:getProvider.adoc[`provider.login`].

--- a/docs/modules/ROOT/partials/config/params.adoc
+++ b/docs/modules/ROOT/partials/config/params.adoc
@@ -66,18 +66,17 @@ WeChat() <1>
 
 Takes a `name` (one of `.facebook`, `.google`, `.line`, `.bconnect`), an optional `variant`, and a `mode` controlling how the session's redirection reaches the app:
 
-* `.sdkScheme` (default): custom scheme, works on all supported iOS versions.
-* `.externalApp`: *out-of-band* — the flow ends in an external app (e.g. a banking app) that reopens yours via a universal link, forwarded to {company} through xref:application/applicationContinueUserActivity.adoc[]. Requires the `applinks:` Associated Domain.
-* `.universalLink` (iOS 17.4+): *in-band* — the universal-link redirect is intercepted directly inside the authentication sheet. Requires the `webcredentials:` Associated Domain.
+* `.customScheme` (default): the SDK's custom scheme, on all supported iOS versions. Covers a redirect intercepted inside the sheet *and* one delivered by the default browser to xref:application/applicationOpenUrl.adoc[] — including providers that detour through a third-party app, such as B.connect sending the user to their bank app.
+* `.universalLink` (iOS 17.4+): the universal-link redirect is intercepted directly inside the authentication sheet. Requires the `webcredentials:` Associated Domain and a `universalLink` on the provider's backend configuration.
 
 See the "Associated Domains" section of xref:index.adoc[] for the entitlement setup.
 
 [source,swift]
 ----
-WebProvider(name: .bconnect, variant: "natif", mode: .externalApp)
+WebProvider(name: .bconnect, variant: "natif", mode: .customScheme)
 ----
 
-NOTE: A provider configured on your client with no matching entry in `providersCreators` still logs in, falling back to `.sdkScheme` automatically. Add an explicit `WebProvider` only when you need `.externalApp`/`.universalLink`, or a specific `variant`.
+NOTE: A provider configured on your client with no matching entry in `providersCreators` still logs in, falling back to `.customScheme` automatically. Add an explicit `WebProvider` only when you need `.universalLink`, or a specific `variant`.
 
 TIP: Integrating a universal-link provider? See xref:providerCreator.adoc#universal-link-web-providers[the universal-link checklist].
 

--- a/docs/modules/ROOT/partials/models.adoc
+++ b/docs/modules/ROOT/partials/models.adoc
@@ -168,7 +168,7 @@ It authenticates the profile with the provider otherwise it returns a `ReachFive
 
 Based on the problem, the `ReachFiveError` will be:
 
-* `AuthCanceled`: The user cancelled the request or no credential was available in the keychain.
+* `AuthCanceled`: Nothing happened, and nothing is expected of you — ignoring it is a valid way to handle it. The user cancelled the request, no credential was available in the keychain, or a web login was dropped because another one was already in progress (see xref:webviewLogin.adoc[]).
 * `RequestError(apiError: ApiError)` for a Bad Request (status 400) error.
 * `AuthFailure(reason: String, apiError: ApiError?)` mainly for Unauthorized (status 401) error.
 * `TechnicalError(reason: String, apiError: ApiError?)` if it's an Internal Server Error (status 500) or other internal errors.

--- a/docs/modules/ROOT/partials/params.adoc
+++ b/docs/modules/ROOT/partials/params.adoc
@@ -402,18 +402,21 @@ TIP: For more, see link:https://developer.apple.com/documentation/authentication
 
 The value of this property is false by default.
 
+NOTE: An ephemeral session gets its own cookie store, isolated from the default browser's. That matters only for a provider whose flow carries state in a cookie *and* detours out of the sheet: if the login leaves for a third-party app and comes back through the default browser, the cookie set inside the ephemeral sheet is not there to be read. No {company} provider depends on this today — the SDK's own leg is stateless, carrying everything in the `state` — but it is the failure mode to look at first if an otherwise-working provider breaks only when this flag is on.
+
 TIP: For more, see link:https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession/prefersephemeralwebbrowsersession[here^].
 
 // end::prefersEphemeralWebBrowserSession[]
 
 // tag::webSessionMode[]
 |[[webSessionMode,webSessionMode]] webSessionMode `WebSessionMode`
-|Controls the return channel of the `ASWebAuthenticationSession` and its `redirect_uri`. Defaults to `.sdkScheme`.
+|Controls the shape of the `ASWebAuthenticationSession` callback and its `redirect_uri`. Defaults to `.customScheme`.
 
 .Values
-* `.sdkScheme`: custom scheme, intercepted inside the session. Works on all supported iOS versions.
-* `.universalLink(URL)`: universal link intercepted inside the session (iOS 17.4+). Requires the `webcredentials:` Associated Domain.
-* `.externalApp(URL)`: *out-of-band* — an external app reopens the host app via the universal link, forwarded to {company} through xref:application/applicationContinueUserActivity.adoc[]. Requires the `applinks:` Associated Domain.
+* `.customScheme`: the SDK's custom scheme, on all supported iOS versions. Both return paths are armed — the sheet intercepts the redirect when the login never leaves it, and xref:application/applicationOpenUrl.adoc[] resolves it when the default browser delivers it instead.
+* `.universalLink(URL)`: universal link intercepted inside the sheet (iOS 17.4+). Requires the `webcredentials:` Associated Domain.
+
+NOTE: There is no "in-band vs out-of-band" choice to make. A provider may decide *mid-flight*, sheet already open, whether to hand off to another app: B.connect only picks `passive` or `active` after the `/authorize` call. `.customScheme` covers both outcomes.
 
 TIP: See the "Associated Domains" section of xref:index.adoc[] for entitlement setup, and the xref:providerCreator.adoc[WebProvider] entry for a ready-made provider using this mechanism.
 // end::webSessionMode[]

--- a/docs/modules/ROOT/partials/r_configure.adoc
+++ b/docs/modules/ROOT/partials/r_configure.adoc
@@ -77,38 +77,36 @@ let ReachFive = ReachFive(
 
 === Associated Domains (universal-link providers)
 
-Some providers (such as B.connect) finish their login on an *https universal link* instead of the custom scheme.
-Which Associated Domains entry you declare depends on your xref:providerCreator.adoc[`WebProvider`] mode—add `applinks:$\{host\}` for `.externalApp`, or `webcredentials:$\{host\}` for `.universalLink` (iOS 17.4+).
-Declare both only if you support both modes on the same host, or also use xref:guides/passkeys.adoc[passkeys] on that host.
-Host a matching `apple-app-site-association` file on `$\{host\}` with the sections that match the entitlements you declared.
+A provider can finish its login on an *https universal link* instead of the custom scheme, using xref:providerCreator.adoc[`WebProvider`] with `mode: .universalLink` (iOS 17.4+).
+That mode needs `webcredentials:$\{host\}` in Associated Domains, and a matching `apple-app-site-association` file on `$\{host\}`.
 
 [cols="4m,6a"]
 |===
 |Entry |Role
 
-|applinks:$\{host\}
-|*Out-of-band* return (all iOS versions).
-When an external app (e.g. a bank) reopens your app via the universal link, iOS delivers it to `application(_:continue:)`, which you must forward to {company}.
-See xref:application/applicationContinueUserActivity.adoc[] for details.
-
 |webcredentials:$\{host\}
-|*In-band* completion on *iOS 17.4+*. 
-Lets `ASWebAuthenticationSession` intercept the redirect to the universal link directly inside its web view, without leaving the app. 
+|Completion inside the sheet, on *iOS 17.4+*.
+Lets `ASWebAuthenticationSession` intercept the redirect to the universal link directly inside its web view, without leaving the app.
 If this entry (or the association file) is missing, the session fails to start.
 
+|applinks:$\{host\}
+|Not needed for login completion. Declare it only if your app routes universal links on that host for its own purposes.
+
 |===
+
+NOTE: A provider that hands off to a third-party app mid-login (B.connect and its bank apps) needs *none* of this. That app reopens the default browser, not your app, and the login comes back on the custom scheme through xref:application/applicationOpenUrl.adoc[`application(_:open:)`]. Use the default `.customScheme`.
 
 `$\{host\}` is the host of the `universalLink` returned by {company} for that provider.
 An `apple-app-site-association` file on that host is always required; include the `applinks` and/or `webcredentials` sections that correspond to the Associated Domains entries you declared above.
 
 IMPORTANT: Whitelist the full `universalLink` URL (e.g. `\https://$\{host\}/path/to/callback`) in *Allowed Callback URLs* on your {cc} in addition to the custom-scheme entries above.
-The SDK sends this URL as the OAuth `redirect_uri` for both `/authorize` and the code exchange when using xref:providerCreator.adoc[`WebProvider`] with `.externalApp` or `.universalLink`, or xref:webviewLogin.adoc[`webviewLogin`] with a matching `webSessionMode`.
+The SDK sends this URL as the OAuth `redirect_uri` for both `/authorize` and the code exchange when using xref:providerCreator.adoc[`WebProvider`] with `.universalLink`, or xref:webviewLogin.adoc[`webviewLogin`] with a matching `webSessionMode`.
 Use the exact URL returned in your provider configuration for the chosen variant—the same value that supplies `$\{host\}` and the callback path below.
 See xref:docs:ROOT:clients.adoc[] for how to configure Allowed Callback URLs.
 
 The file must be served at `\https://$\{host\}/.well-known/apple-app-site-association` with a `200` response and a JSON `Content-Type`; a redirect or a non-JSON content type causes verification to fail.
 
-The sample below includes both sections for a host used in both modes; for `.externalApp` only, include `applinks` and omit `webcredentials`.
+The sample below includes both sections; for `.universalLink` alone, `webcredentials` is the one that matters.
 
 .apple-app-site-association example
 [source,json]
@@ -129,7 +127,7 @@ The sample below includes both sections for a host used in both modes; for `.ext
 ----
 <1> `<Application Identifier Prefix>.<Bundle Identifier>`.
 <2> Restrict to the callback path of the `universalLink` returned by {company} for this provider. Omit the whole `components` array to match every path on the host.
-<3> Only needed if you also declare `webcredentials:$\{host\}` (`.universalLink` in-band mode), or use xref:guides/passkeys.adoc[passkeys] on the same host.
+<3> Required for `.universalLink`, and for xref:guides/passkeys.adoc[passkeys] on the same host.
 
 [NOTE]
 ====


### PR DESCRIPTION
[Intégration de b.connect sur iOS](https://reach5.atlassian.net/browse/CA-6191)

Empilée sur #137.

La documentation décrivait un retour direct de l'app bancaire vers l'app hôte par lien universel. Le vrai flow passe par le navigateur par défaut, qui revient en custom scheme dans `application(_:open:)` — jamais par `application(_:continue:)`. Les pages concernées sont réécrites en conséquence :

- **`providerCreator.adoc`** — B.connect n'a besoin d'aucun mode particulier ; la checklist « universal-link » disparait au profit d'une explication de pourquoi `.customScheme` suffit.
- **`applicationOpenUrl.adoc`** — c'est ici que revient un login qui a quitté l'app ; explique le double armement des canaux et la perte du login si iOS tue l'app pendant le détour.
- **`applicationContinueUserActivity.adoc`** — précise ce que cette méthode ne fait plus.
- **`webviewLogin.adoc`** — section sur le contrat « un seul login web à la fois ».
- **`r_configure.adoc`, `params.adoc`, `models.adoc`, `custom-provider.adoc`** — terminologie `WebSessionMode` à jour (suppression de l'axe canal).

## À noter

Rebasée sur les corrections doc déjà mergées sur master (#129, #130) : le paragraphe d'`applicationOpenUrl.adoc` remplace entièrement celui qu'elles corrigeaient, et `r_configure.adoc` reprend leur échappement `\https` en plus de la nouvelle terminologie.