### PR TITLE
Le contrôle des exemples de doc ne tourne plus qu'à la release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,16 +108,6 @@ default_workflows_tags: &default_workflows_tags
     tags:
       only: /.*/
 
-# For the doc-examples check we want PR feedback only, not every push. CircleCI
-# filters can't test "is a PR" directly, so we run on all branches except the
-# base branch (and not on tags). Combined with the project setting
-# "Only build pull requests" (Project Settings › Advanced, set in the CircleCI
-# UI — not expressible here), this effectively limits the job to PR branches.
-pull_request_branches: &pull_request_branches
-  filters:
-    branches:
-      ignore: master
-
 workflows:
   version: 2
   build-and-deploy:
@@ -127,11 +117,12 @@ workflows:
       - test:
           <<: *default_workflows_tags
       - check-doc-examples:
-          <<: *pull_request_branches
+          <<: *default_workflows_filters
       - build-for-release:
           <<: *default_workflows_filters
       - publish:
           requires:
             - build-for-release
             - test
+            - check-doc-examples
           <<: *default_workflows_filters

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,6 +108,15 @@ default_workflows_tags: &default_workflows_tags
     tags:
       only: /.*/
 
+# check-doc-examples only needs to run when preparing a release (branch named
+# after the version, per RELEASE.md) — not on every PR (counter-productive,
+# see #146), and not on the tag: under SPM the tag itself is the publication,
+# resolved by consumers before any CircleCI pipeline on it even starts.
+release_branches: &release_branches
+  filters:
+    branches:
+      only: /^[0-9]+\.[0-9]+\.[0-9]+$/
+
 workflows:
   version: 2
   build-and-deploy:
@@ -117,12 +126,11 @@ workflows:
       - test:
           <<: *default_workflows_tags
       - check-doc-examples:
-          <<: *default_workflows_filters
+          <<: *release_branches
       - build-for-release:
           <<: *default_workflows_filters
       - publish:
           requires:
             - build-for-release
             - test
-            - check-doc-examples
           <<: *default_workflows_filters


### PR DESCRIPTION
`check-doc-examples` se déclenche sur les branches nommées comme la version (`x.x.x`, cf. `RELEASE.md`) plutôt que sur toutes les branches sauf `master`. Retiré des prérequis de `publish` : sous SPM le tag est déjà la publication, un job qui se déclenche après coup ne peut plus rien bloquer — et `publish` disparait de toute façon avec #126.

## Pourquoi

La doc publique pointe sur `master` et ne bouge plus tant que tout n'est pas prêt à être livré. Vérifier les exemples à chaque PR est alors contre-productif : le job rend rouge toute PR qui casse une API sans migrer du même geste une doc qu'on ne veut justement pas publier avant la release.

Cas concret : #146 casse `anchor: ASPresentationAnchor` en `presenting: Presentation`, invalidant 6 exemples — à migrer dans #147 (isolé, fusionné après la release), pas dans #146.
